### PR TITLE
chore: .issues/ 運用ルールを CLAUDE.md に追記 + gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ backend/dbflute_wolf_mansiondb/log/*
 ### Claude ###
 .claude/settings.local.json
 .serena
+.reviews/
+.issues/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,21 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `feature/monorepo` には branch protection なし、ただしレビュー手順は遵守
 - 全 step 完了時の `feature/monorepo` → `main` 取り込みは **merge commit (`--no-ff`)** で行う（PR経由）
 
+### 引き継ぎ issue (`.issues/`) の扱い
+
+step の review で残った should-fix / nits や、後続にまわした改善は `.issues/<n>-<slug>.md`
+(ローカル管理、`.gitignore` 対象) に書き出して引き継ぐ。**次の step に着手する前に必ず `.issues/` を確認** し、
+以下のルールで処理する:
+
+- **次 step のスコープに含まれている issue** (例: step 2 で取り組む領域に対する step 1 の宿題)
+  → そのまま step 2 PR の中で同時に解消する。issue ファイルは PR merge 後に削除。
+- **次 step のスコープに含まれない issue**
+  → **先に `ship-issue` (`/ship-issue <n>`) で別 PR を切って消化** してから step に進む。
+    base は `feature/monorepo`、レビュー手順は通常の step PR と同じ。
+
+`.issues/README.md` に一覧テーブルを置き、各 issue の本文には `recommended-when` (どの step と一緒に
+潰すのが妥当か) を frontmatter で明示する。
+
 ## Project Overview
 
 人狼ゲーム（Werewolf/Mafia）のWebアプリケーション「wolf-mansion」。Spring Boot + Kotlin（バックエンド）、MySQL + DBFlute（ORM）で構成。フロントエンドはモダン化中（旧 Thymeleaf テンプレートから SPA + REST API 構成へ移行予定）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,15 +22,19 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### 引き継ぎ issue (`.issues/`) の扱い
 
-step の review で残った should-fix / nits や、後続にまわした改善は `.issues/<n>-<slug>.md`
-(ローカル管理、`.gitignore` 対象) に書き出して引き継ぐ。**次の step に着手する前に必ず `.issues/` を確認** し、
-以下のルールで処理する:
+step の review で残った should-fix / nits や、後続にまわした改善は、**step PR を merge した
+担当者 (Claude Code 自身) が `pr-reviewer` の出力 (`.reviews/PR-<番号>.md`) と未対応項目を読み返し、
+手動で `.issues/<n>-<slug>.md` (ローカル管理、`.gitignore` 対象) に書き出して引き継ぐ**。
+
+**次の step に着手する前に必ず `.issues/` を確認** し、以下のルールで処理する:
 
 - **次 step のスコープに含まれている issue** (例: step 2 で取り組む領域に対する step 1 の宿題)
   → そのまま step 2 PR の中で同時に解消する。issue ファイルは PR merge 後に削除。
 - **次 step のスコープに含まれない issue**
-  → **先に `ship-issue` (`/ship-issue <n>`) で別 PR を切って消化** してから step に進む。
+  → **原則として `ship-issue` (`/ship-issue <n>`) で別 PR を切り、step 着手前に解消する** 。
     base は `feature/monorepo`、レビュー手順は通常の step PR と同じ。
+  → ただし優先度が低い (緊急性なし + リファクタ的) と判断したものは `recommended-when` を
+    後続 step に明示した上で先送り可。`.issues/` に残し続けることで次回の着手前確認で再評価する。
 
 `.issues/README.md` に一覧テーブルを置き、各 issue の本文には `recommended-when` (どの step と一緒に
 潰すのが妥当か) を frontmatter で明示する。


### PR DESCRIPTION
## Summary

Step 1 完了後の振り返りで決めた「引き継ぎ issue の運用ルール」を CLAUDE.md に明文化し、ローカル運用のディレクトリを `.gitignore` 対象に追加する。Step 2 以降のすべての作業はこの新ルールに従って進める。

### 変更

- `.gitignore`:
  - `.issues/` を追加 (引き継ぎ issue のローカル管理ディレクトリ)
  - `.reviews/` を追加 (pr-reviewer のローカル出力。PR #6 で追加したが squash 取り込み漏れだったため再追加)
- `CLAUDE.md` 開発フローセクション末尾に「引き継ぎ issue (`.issues/`) の扱い」サブセクションを追加
  - 誰が書き出すか (step PR merge 担当が `.reviews/PR-<番号>.md` を読み返して手動作成)
  - 次 step 着手前に `.issues/` を確認
  - 次 step スコープ内 → step PR で同時解消
  - スコープ外 → 原則 `/ship-issue` で別 PR を先行マージ、優先度の低いものは `recommended-when` 明示で先送り可

### なぜ別 PR

これは Step 2 のスコープ外のプロセス整備であり、Step 2 着手の前提となる運用ルール定義なので、新ルール自体に従って先行マージする。

## Test plan

- [x] CLAUDE.md の追記内容が markdown として崩れないこと (目視確認)
- [x] `.gitignore` に `.issues/` と `.reviews/` が含まれること
- レビュー観点: 文言の意図、運用フローの抜け漏れ、文章のアクター明示性