### PR TITLE
chore: frontend/.vite を gitignore

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -6,5 +6,8 @@
 /.react-router/
 /build/
 
+# Vite cache (依存事前バンドル、ローカル生成物)
+/.vite/
+
 # OpenAPI 自動生成 (pnpm gen:api で再生成)
 /app/lib/api/generated.ts


### PR DESCRIPTION
## Summary

Vite の依存事前バンドルキャッシュ (`frontend/.vite/`) は dev server 起動時に生成されるローカル成果物。リポジトリには含めるべきでないので gitignore に追加する。

## なぜ別 PR

Step 4 (ログイン画面 + 認証ガード) のスコープ外の gitignore 整備なので、CLAUDE.md の運用ルールに従って先行マージする。

## Test plan

- [x] `frontend/.vite` がリポジトリにトラックされていないことを確認 (`git ls-files`)
- [x] `.gitignore` 追記後、`git status` で `frontend/.vite` が untracked にもならない (無視される)