### PR TITLE
Step 4: ログイン画面 + 認証ガード + 401自動リトライ

### DIFF
--- a/frontend/app/features/auth/api.ts
+++ b/frontend/app/features/auth/api.ts
@@ -25,7 +25,8 @@ export async function login(body: LoginBody): Promise<MeResponse> {
 
 export async function logout(): Promise<void> {
   const res = await browserFetch("/api/v1/auth/logout", { method: "POST" });
-  if (!res.ok && res.status !== 204) throw new Error(`logout failed: ${res.status}`);
+  // backend は 204 No Content を返すが、res.ok は 200-299 を真とするので OK 判定で十分
+  if (!res.ok) throw new Error(`logout failed: ${res.status}`);
 }
 
 export class InvalidCredentialsError extends Error {

--- a/frontend/app/features/auth/api.ts
+++ b/frontend/app/features/auth/api.ts
@@ -1,0 +1,36 @@
+import type { components } from "~/lib/api/generated";
+import { browserFetch } from "~/lib/api/client";
+
+export type MeResponse = components["schemas"]["MeResponse"];
+export type UserPayload = components["schemas"]["UserPayload"];
+export type LoginBody = components["schemas"]["LoginBody"];
+
+export async function fetchMe(): Promise<MeResponse> {
+  const res = await browserFetch("/api/v1/auth/me", { method: "GET" });
+  if (!res.ok) throw new Error(`auth/me failed: ${res.status}`);
+  return res.json();
+}
+
+export async function login(body: LoginBody): Promise<MeResponse> {
+  const res = await browserFetch("/api/v1/auth/login", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  if (res.status === 401) {
+    throw new InvalidCredentialsError();
+  }
+  if (!res.ok) throw new Error(`login failed: ${res.status}`);
+  return res.json();
+}
+
+export async function logout(): Promise<void> {
+  const res = await browserFetch("/api/v1/auth/logout", { method: "POST" });
+  if (!res.ok && res.status !== 204) throw new Error(`logout failed: ${res.status}`);
+}
+
+export class InvalidCredentialsError extends Error {
+  constructor() {
+    super("invalid credentials");
+    this.name = "InvalidCredentialsError";
+  }
+}

--- a/frontend/app/features/auth/hooks.ts
+++ b/frontend/app/features/auth/hooks.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { fetchMe, login, logout, type LoginBody, type MeResponse } from "./api";
+// MeResponse は useMeQuery の型推論で使用
 
 export const ME_QUERY_KEY = ["auth", "me"] as const;
 
@@ -23,14 +24,13 @@ export function useLoginMutation() {
   });
 }
 
-/** POST /api/v1/auth/logout → me cache をクリア */
+/** POST /api/v1/auth/logout → me cache を破棄 (次回参照時に refetch される) */
 export function useLogoutMutation() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: () => logout(),
     onSuccess: () => {
-      qc.setQueryData<MeResponse>(ME_QUERY_KEY, { user: undefined });
-      qc.invalidateQueries({ queryKey: ME_QUERY_KEY });
+      qc.removeQueries({ queryKey: ME_QUERY_KEY });
     },
   });
 }

--- a/frontend/app/features/auth/hooks.ts
+++ b/frontend/app/features/auth/hooks.ts
@@ -1,0 +1,36 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { fetchMe, login, logout, type LoginBody, type MeResponse } from "./api";
+
+export const ME_QUERY_KEY = ["auth", "me"] as const;
+
+/** GET /api/v1/auth/me */
+export function useMeQuery() {
+  return useQuery<MeResponse>({
+    queryKey: ME_QUERY_KEY,
+    queryFn: fetchMe,
+    staleTime: 60 * 1000,
+  });
+}
+
+/** POST /api/v1/auth/login → 成功時に me cache を更新 */
+export function useLoginMutation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: LoginBody) => login(body),
+    onSuccess: (data) => {
+      qc.setQueryData(ME_QUERY_KEY, data);
+    },
+  });
+}
+
+/** POST /api/v1/auth/logout → me cache をクリア */
+export function useLogoutMutation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => logout(),
+    onSuccess: () => {
+      qc.setQueryData<MeResponse>(ME_QUERY_KEY, { user: undefined });
+      qc.invalidateQueries({ queryKey: ME_QUERY_KEY });
+    },
+  });
+}

--- a/frontend/app/lib/api/client.ts
+++ b/frontend/app/lib/api/client.ts
@@ -26,9 +26,12 @@ function mergeHeaders(init: RequestInit | undefined): Record<string, string> {
 export const browserFetch: ApiFetch = async (path, init) => {
   const first = await rawBrowserFetch(path, init);
   if (first.status !== 401) return first;
-  // 401 → refresh を試行
+  // 401 → refresh を 1 回だけ試行
+  // /auth/refresh と /auth/login 自身は除外 (再帰防止)。
+  // /auth/me は対象に含めてよい — refresh 後の me 再試行も結果が 401 のままなら
+  // この関数は素直に 401 を返し、呼び出し元 (useMeQuery 等) が error として扱う。
+  // rawBrowserFetch は無条件で 1 回しか追加 fetch しないので無限ループにはならない。
   if (path.startsWith("/api/v1/auth/refresh") || path.startsWith("/api/v1/auth/login")) {
-    // refresh / login 自身が 401 ならリトライしない
     return first;
   }
   const refreshed = await rawBrowserFetch("/api/v1/auth/refresh", { method: "POST" });

--- a/frontend/app/lib/api/client.ts
+++ b/frontend/app/lib/api/client.ts
@@ -8,20 +8,41 @@ const API_BASE_PATH = "/wolf-mansion-api";
 
 export type ApiFetch = (path: string, init?: RequestInit) => Promise<Response>;
 
-/** browser から呼ぶときの fetch (TanStack Query の queryFn 等で使用) */
-export const browserFetch: ApiFetch = (path, init) => {
-  const hasBody = init?.body != null;
+/** ヘッダのマージ + Body 付きリクエストにのみ Content-Type を付与する共通処理 */
+function mergeHeaders(init: RequestInit | undefined): Record<string, string> {
   const headers: Record<string, string> = { ...(init?.headers as Record<string, string> | undefined ?? {}) };
-  // Body 付きリクエストで Content-Type が未指定なら JSON をデフォルトに
-  if (hasBody && headers["Content-Type"] == null && headers["content-type"] == null) {
+  if (init?.body != null && headers["Content-Type"] == null && headers["content-type"] == null) {
     headers["Content-Type"] = "application/json";
   }
+  return headers;
+}
+
+/**
+ * browser から呼ぶときの fetch (TanStack Query の queryFn 等で使用)。
+ *
+ * 401 を受けたら **1回だけ** `/api/v1/auth/refresh` を試行し、成功したら同一リクエストを再試行する。
+ * refresh も 401 を返した場合は元の 401 をそのまま返す。
+ */
+export const browserFetch: ApiFetch = async (path, init) => {
+  const first = await rawBrowserFetch(path, init);
+  if (first.status !== 401) return first;
+  // 401 → refresh を試行
+  if (path.startsWith("/api/v1/auth/refresh") || path.startsWith("/api/v1/auth/login")) {
+    // refresh / login 自身が 401 ならリトライしない
+    return first;
+  }
+  const refreshed = await rawBrowserFetch("/api/v1/auth/refresh", { method: "POST" });
+  if (!refreshed.ok) return first;
+  return rawBrowserFetch(path, init);
+};
+
+function rawBrowserFetch(path: string, init?: RequestInit): Promise<Response> {
   return fetch(`${API_BASE_PATH}${path}`, {
     credentials: "include",
     ...init,
-    headers,
+    headers: mergeHeaders(init),
   });
-};
+}
 
 /**
  * SSR の loader / action から呼ぶ fetch。
@@ -34,16 +55,15 @@ export const browserFetch: ApiFetch = (path, init) => {
  *
  * 元 Request の Cookie をヘッダ転送するため、Cookie キーは呼び出し元 `init.headers`
  * からは上書きできない (cookie をスプレッド後に置く)。
+ *
+ * SSR では 401 → refresh の自動リトライは行わない (新トークンを set-cookie する経路が
+ * 複雑になるため)。loader 側で 401 を捕捉して redirect("/login") に倒す方針。
  */
 export function ssrFetch(request: Request): ApiFetch {
   const cookie = request.headers.get("cookie") ?? "";
   const base = process.env.API_BASE_URL ?? `http://localhost:8089${API_BASE_PATH}`;
   return (path, init) => {
-    const hasBody = init?.body != null;
-    const headers: Record<string, string> = { ...(init?.headers as Record<string, string> | undefined ?? {}) };
-    if (hasBody && headers["Content-Type"] == null && headers["content-type"] == null) {
-      headers["Content-Type"] = "application/json";
-    }
+    const headers = mergeHeaders(init);
     // cookie は呼び出し元から上書き不可 (スプレッドの後で固定)
     headers["cookie"] = cookie;
     return fetch(`${base}${path}`, { ...init, headers });

--- a/frontend/app/lib/basename.ts
+++ b/frontend/app/lib/basename.ts
@@ -1,0 +1,12 @@
+/** react-router.config.ts の basename と必ず一致させる */
+export const BASENAME = "/wolf-mansion";
+
+/**
+ * `request.url` から basename を取り除いた in-app パスを返す。
+ * loader 内で redirect 先 query を組み立てるときに使う (二重 basename を避ける)。
+ */
+export function stripBasename(pathname: string): string {
+  if (pathname === BASENAME) return "/";
+  if (pathname.startsWith(BASENAME + "/")) return pathname.slice(BASENAME.length);
+  return pathname;
+}

--- a/frontend/app/lib/basename.ts
+++ b/frontend/app/lib/basename.ts
@@ -4,9 +4,15 @@ export const BASENAME = "/wolf-mansion";
 /**
  * `request.url` から basename を取り除いた in-app パスを返す。
  * loader 内で redirect 先 query を組み立てるときに使う (二重 basename を避ける)。
+ *
+ * basename で始まらない pathname (設定ミスや予期しないプロキシ動作) は
+ * 安全側に倒して `/` を返す。サイレントに通すと open redirect の温床になる。
  */
 export function stripBasename(pathname: string): string {
   if (pathname === BASENAME) return "/";
   if (pathname.startsWith(BASENAME + "/")) return pathname.slice(BASENAME.length);
-  return pathname;
+  if (typeof console !== "undefined") {
+    console.warn(`stripBasename: pathname "${pathname}" は basename "${BASENAME}" で始まらない。"/" にフォールバック。`);
+  }
+  return "/";
 }

--- a/frontend/app/lib/redirect.test.ts
+++ b/frontend/app/lib/redirect.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeRedirect } from "./redirect";
+
+describe("sanitizeRedirect", () => {
+  it("null/空文字/undefined は / を返す", () => {
+    expect(sanitizeRedirect(null)).toBe("/");
+    expect(sanitizeRedirect(undefined)).toBe("/");
+    expect(sanitizeRedirect("")).toBe("/");
+  });
+
+  it("正しい in-app パスはそのまま返す", () => {
+    expect(sanitizeRedirect("/me")).toBe("/me");
+    expect(sanitizeRedirect("/villages/123")).toBe("/villages/123");
+    expect(sanitizeRedirect("/villages/123?day=2")).toBe("/villages/123?day=2");
+  });
+
+  it("空に近いパスでも / に正規化される", () => {
+    expect(sanitizeRedirect("/")).toBe("/");
+  });
+
+  describe("open redirect 防御", () => {
+    it("protocol-relative URL は弾く (//evil.com)", () => {
+      expect(sanitizeRedirect("//evil.example.com")).toBe("/");
+      expect(sanitizeRedirect("//evil.example.com/path")).toBe("/");
+    });
+
+    it("encoded protocol-relative URL も弾く (%2F%2Fevil)", () => {
+      expect(sanitizeRedirect("%2F%2Fevil.example.com")).toBe("/");
+      expect(sanitizeRedirect("%2f%2fevil.example.com")).toBe("/");
+    });
+
+    it("absolute URL は弾く", () => {
+      expect(sanitizeRedirect("http://evil.example.com")).toBe("/");
+      expect(sanitizeRedirect("https://evil.example.com/path")).toBe("/");
+    });
+
+    it("javascript: スキームは弾く", () => {
+      expect(sanitizeRedirect("javascript:alert(1)")).toBe("/");
+      expect(sanitizeRedirect("javascript:%0Aalert(1)")).toBe("/");
+    });
+
+    it("data: スキームは弾く", () => {
+      expect(sanitizeRedirect("data:text/html,<script>alert(1)</script>")).toBe("/");
+    });
+
+    it("制御文字を含む文字列は弾く", () => {
+      expect(sanitizeRedirect("/path\nFoo")).toBe("/");
+      expect(sanitizeRedirect("/path\tFoo")).toBe("/");
+      expect(sanitizeRedirect("/path\r\nLocation: x")).toBe("/");
+    });
+
+    it("/ で始まらないパス (相対パスや絶対URLの一部) は弾く", () => {
+      expect(sanitizeRedirect("me")).toBe("/");
+      expect(sanitizeRedirect("foo/bar")).toBe("/");
+    });
+
+    it("@ を含む URL (user:pass@host) も弾く", () => {
+      expect(sanitizeRedirect("//user@evil.example.com")).toBe("/");
+    });
+  });
+});

--- a/frontend/app/lib/redirect.ts
+++ b/frontend/app/lib/redirect.ts
@@ -1,0 +1,32 @@
+/**
+ * `?redirect=...` の値を「同一オリジンの相対 in-app パス」に正規化する。
+ * Open redirect / javascript: / protocol-relative (encoded 含む) を弾く。
+ *
+ * 実装方針: ダミーオリジンを base にして `new URL(raw, base)` で解釈する。
+ * encoded `%2F%2Fevil` も URL コンストラクタが decode して評価するため、
+ * パス文字列の prefix チェックでは見逃すケースを正しく弾ける。
+ * 結果の URL の origin がダミーオリジンと一致しない (= absolute URL を含む) なら拒否。
+ */
+const DUMMY_ORIGIN = "http://_x_";
+
+export function sanitizeRedirect(raw: string | null | undefined): string {
+  if (!raw) return "/";
+  // 制御文字 (改行・タブ等) を含む場合は拒否 (\x00-\x1F と DEL)
+  if (/[\x00-\x1F\x7F]/.test(raw)) return "/";
+  // 単一 `/` で始まる絶対 in-app パスのみ許可。
+  // - "me" のような相対は弾く (new URL では `/me` に正規化されてしまうため別途チェック)
+  // - "//evil" の protocol-relative も弾く
+  if (!raw.startsWith("/") || raw.startsWith("//")) return "/";
+
+  let url: URL;
+  try {
+    url = new URL(raw, DUMMY_ORIGIN);
+  } catch {
+    return "/";
+  }
+  // absolute URL / 別ホストの場合 origin が変わる
+  if (url.origin !== DUMMY_ORIGIN) return "/";
+  // 念のためスキーム再確認 (URL 仕様の隙間を埋める)
+  if (url.protocol !== "http:" && url.protocol !== "https:") return "/";
+  return (url.pathname || "/") + url.search;
+}

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -1,3 +1,10 @@
-import { type RouteConfig, index } from "@react-router/dev/routes";
+import { type RouteConfig, index, layout, route } from "@react-router/dev/routes";
 
-export default [index("routes/home.tsx")] satisfies RouteConfig;
+export default [
+  index("routes/home.tsx"),
+  route("login", "routes/login.tsx"),
+  // 認証必須エリア
+  layout("routes/_auth.tsx", [
+    route("me", "routes/me.tsx"),
+  ]),
+] satisfies RouteConfig;

--- a/frontend/app/routes/_auth.tsx
+++ b/frontend/app/routes/_auth.tsx
@@ -1,0 +1,29 @@
+import { Outlet, redirect } from "react-router";
+import type { Route } from "./+types/_auth";
+import { ssrFetch } from "~/lib/api/client";
+import { stripBasename } from "~/lib/basename";
+
+/**
+ * 認証必須レイアウト。
+ * loader で /api/v1/auth/me を呼び、未認証なら /login にリダイレクト。
+ */
+export async function loader({ request }: Route.LoaderArgs) {
+  const api = ssrFetch(request);
+  const res = await api("/api/v1/auth/me");
+  if (!res.ok) throw redirectToLogin(request);
+
+  const data = (await res.json()) as { user: { userId: string; authority: string } | null };
+  if (!data.user) throw redirectToLogin(request);
+
+  return { user: data.user };
+}
+
+function redirectToLogin(request: Request): Response {
+  const url = new URL(request.url);
+  const inAppPath = stripBasename(url.pathname) + url.search;
+  return redirect(`/login?redirect=${encodeURIComponent(inAppPath)}`);
+}
+
+export default function AuthLayout() {
+  return <Outlet />;
+}

--- a/frontend/app/routes/_auth.tsx
+++ b/frontend/app/routes/_auth.tsx
@@ -1,5 +1,6 @@
 import { Outlet, redirect } from "react-router";
 import type { Route } from "./+types/_auth";
+import type { MeResponse } from "~/features/auth/api";
 import { ssrFetch } from "~/lib/api/client";
 import { stripBasename } from "~/lib/basename";
 
@@ -12,7 +13,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const res = await api("/api/v1/auth/me");
   if (!res.ok) throw redirectToLogin(request);
 
-  const data = (await res.json()) as { user: { userId: string; authority: string } | null };
+  const data = (await res.json()) as MeResponse;
   if (!data.user) throw redirectToLogin(request);
 
   return { user: data.user };

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router";
 import type { Route } from "./+types/home";
 
 export function meta(_: Route.MetaArgs) {
@@ -19,9 +20,20 @@ export default function Home() {
       />
       <h1 className="mt-8 text-4xl font-bold tracking-wide">wolf-mansion</h1>
       <p className="mt-4 text-slate-300">人狼ゲーム (移行作業中)</p>
-      <p className="mt-8 text-sm text-slate-400">
-        フロントエンドの初期セットアップが完了しました。今後のステップで画面を実装していきます。
-      </p>
+      <div className="mt-8 flex gap-4">
+        <Link
+          to="/login"
+          className="rounded-md bg-indigo-500 hover:bg-indigo-400 px-5 py-2 font-semibold transition"
+        >
+          ログイン
+        </Link>
+        <Link
+          to="/me"
+          className="rounded-md border border-slate-600 hover:border-slate-400 px-5 py-2 font-semibold transition"
+        >
+          マイページ
+        </Link>
+      </div>
     </main>
   );
 }

--- a/frontend/app/routes/login.tsx
+++ b/frontend/app/routes/login.tsx
@@ -1,0 +1,121 @@
+import { useState, type FormEvent } from "react";
+import { redirect, useNavigate, useSearchParams } from "react-router";
+import type { Route } from "./+types/login";
+import { InvalidCredentialsError } from "~/features/auth/api";
+import { useLoginMutation, useMeQuery } from "~/features/auth/hooks";
+import { ssrFetch } from "~/lib/api/client";
+
+export function meta(_: Route.MetaArgs) {
+  return [{ title: "ログイン - wolf-mansion" }];
+}
+
+/** 既にログイン済みなら ?redirect=... or / にリダイレクト */
+export async function loader({ request }: Route.LoaderArgs) {
+  const api = ssrFetch(request);
+  const res = await api("/api/v1/auth/me");
+  if (res.ok) {
+    const data = (await res.json()) as { user: { userId: string } | null };
+    if (data.user) {
+      const to = sanitizeRedirect(new URL(request.url).searchParams.get("redirect"));
+      throw redirect(to);
+    }
+  }
+  return null;
+}
+
+/**
+ * `?redirect=...` を相対 in-app パスに正規化する (open redirect 防止)。
+ * `/` で始まらない or `//` で始まる (protocol-relative) は弾く。
+ */
+function sanitizeRedirect(raw: string | null): string {
+  if (!raw) return "/";
+  if (!raw.startsWith("/")) return "/";
+  if (raw.startsWith("//")) return "/";
+  return raw;
+}
+
+export default function LoginPage() {
+  const navigate = useNavigate();
+  const [params] = useSearchParams();
+  const me = useMeQuery();
+  const loginMutation = useLoginMutation();
+  const [userId, setUserId] = useState("");
+  const [password, setPassword] = useState("");
+
+  // login 成功後の遷移先 (?redirect=... 指定があればそこへ、ただし in-app パスに正規化)
+  const redirectTo = sanitizeRedirect(params.get("redirect"));
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    try {
+      await loginMutation.mutateAsync({ userId, password });
+      await me.refetch();
+      navigate(redirectTo, { replace: true });
+    } catch {
+      // mutation error は下で error として表示する
+    }
+  }
+
+  const errorMessage = loginMutation.error
+    ? loginMutation.error instanceof InvalidCredentialsError
+      ? "ID またはパスワードが違います"
+      : "ログインに失敗しました。しばらく経ってから再試行してください"
+    : null;
+
+  return (
+    <main className="min-h-screen bg-slate-900 text-slate-100 flex items-center justify-center px-4">
+      <form
+        onSubmit={onSubmit}
+        className="w-full max-w-sm bg-slate-800/70 rounded-xl shadow-xl p-8 space-y-5 border border-slate-700"
+      >
+        <h1 className="text-2xl font-bold text-center">wolf-mansion ログイン</h1>
+
+        <div className="space-y-1">
+          <label htmlFor="userId" className="block text-sm font-medium text-slate-300">
+            プレイヤー名
+          </label>
+          <input
+            id="userId"
+            name="userId"
+            type="text"
+            required
+            autoComplete="username"
+            value={userId}
+            onChange={(e) => setUserId(e.target.value)}
+            className="w-full rounded-md bg-slate-900 border border-slate-600 px-3 py-2 text-slate-100 focus:border-indigo-400 focus:outline-none"
+          />
+        </div>
+
+        <div className="space-y-1">
+          <label htmlFor="password" className="block text-sm font-medium text-slate-300">
+            パスワード
+          </label>
+          <input
+            id="password"
+            name="password"
+            type="password"
+            required
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full rounded-md bg-slate-900 border border-slate-600 px-3 py-2 text-slate-100 focus:border-indigo-400 focus:outline-none"
+          />
+        </div>
+
+        {errorMessage && (
+          <p role="alert" className="text-sm text-red-400">
+            {errorMessage}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={loginMutation.isPending}
+          className="w-full rounded-md bg-indigo-500 hover:bg-indigo-400 disabled:bg-slate-600 disabled:cursor-not-allowed py-2 font-semibold transition"
+        >
+          {loginMutation.isPending ? "ログイン中..." : "ログイン"}
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/frontend/app/routes/login.tsx
+++ b/frontend/app/routes/login.tsx
@@ -2,8 +2,9 @@ import { useState, type FormEvent } from "react";
 import { redirect, useNavigate, useSearchParams } from "react-router";
 import type { Route } from "./+types/login";
 import { InvalidCredentialsError } from "~/features/auth/api";
-import { useLoginMutation, useMeQuery } from "~/features/auth/hooks";
+import { useLoginMutation } from "~/features/auth/hooks";
 import { ssrFetch } from "~/lib/api/client";
+import { sanitizeRedirect } from "~/lib/redirect";
 
 export function meta(_: Route.MetaArgs) {
   return [{ title: "ログイン - wolf-mansion" }];
@@ -23,21 +24,9 @@ export async function loader({ request }: Route.LoaderArgs) {
   return null;
 }
 
-/**
- * `?redirect=...` を相対 in-app パスに正規化する (open redirect 防止)。
- * `/` で始まらない or `//` で始まる (protocol-relative) は弾く。
- */
-function sanitizeRedirect(raw: string | null): string {
-  if (!raw) return "/";
-  if (!raw.startsWith("/")) return "/";
-  if (raw.startsWith("//")) return "/";
-  return raw;
-}
-
 export default function LoginPage() {
   const navigate = useNavigate();
   const [params] = useSearchParams();
-  const me = useMeQuery();
   const loginMutation = useLoginMutation();
   const [userId, setUserId] = useState("");
   const [password, setPassword] = useState("");
@@ -49,7 +38,8 @@ export default function LoginPage() {
     e.preventDefault();
     try {
       await loginMutation.mutateAsync({ userId, password });
-      await me.refetch();
+      // useLoginMutation の onSuccess で me cache を setQueryData 済みなので
+      // ここで refetch は不要。即座に画面遷移する。
       navigate(redirectTo, { replace: true });
     } catch {
       // mutation error は下で error として表示する

--- a/frontend/app/routes/login.tsx
+++ b/frontend/app/routes/login.tsx
@@ -1,7 +1,7 @@
 import { useState, type FormEvent } from "react";
 import { redirect, useNavigate, useSearchParams } from "react-router";
 import type { Route } from "./+types/login";
-import { InvalidCredentialsError } from "~/features/auth/api";
+import { InvalidCredentialsError, type MeResponse } from "~/features/auth/api";
 import { useLoginMutation } from "~/features/auth/hooks";
 import { ssrFetch } from "~/lib/api/client";
 import { sanitizeRedirect } from "~/lib/redirect";
@@ -15,7 +15,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const api = ssrFetch(request);
   const res = await api("/api/v1/auth/me");
   if (res.ok) {
-    const data = (await res.json()) as { user: { userId: string } | null };
+    const data = (await res.json()) as MeResponse;
     if (data.user) {
       const to = sanitizeRedirect(new URL(request.url).searchParams.get("redirect"));
       throw redirect(to);

--- a/frontend/app/routes/me.tsx
+++ b/frontend/app/routes/me.tsx
@@ -1,0 +1,42 @@
+import { useNavigate } from "react-router";
+import type { Route } from "./+types/me";
+import { useLogoutMutation, useMeQuery } from "~/features/auth/hooks";
+
+export function meta(_: Route.MetaArgs) {
+  return [{ title: "マイページ - wolf-mansion" }];
+}
+
+export default function MePage() {
+  const navigate = useNavigate();
+  const me = useMeQuery();
+  const logoutMutation = useLogoutMutation();
+
+  async function onLogout() {
+    await logoutMutation.mutateAsync();
+    navigate("/login", { replace: true });
+  }
+
+  const user = me.data?.user;
+
+  return (
+    <main className="min-h-screen bg-slate-900 text-slate-100 px-6 py-12">
+      <div className="max-w-2xl mx-auto space-y-6">
+        <h1 className="text-3xl font-bold">マイページ</h1>
+        <div className="rounded-lg bg-slate-800/60 p-6 border border-slate-700 space-y-2">
+          <p className="text-sm text-slate-400">プレイヤー名</p>
+          <p className="text-xl font-mono">{user?.userId ?? "..."}</p>
+          <p className="text-sm text-slate-400 mt-4">権限</p>
+          <p className="text-base">{user?.authority ?? "..."}</p>
+        </div>
+        <button
+          type="button"
+          onClick={onLogout}
+          disabled={logoutMutation.isPending}
+          className="rounded-md bg-rose-600 hover:bg-rose-500 disabled:bg-slate-600 px-5 py-2 font-semibold transition"
+        >
+          {logoutMutation.isPending ? "ログアウト中..." : "ログアウト"}
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/routes/me.tsx
+++ b/frontend/app/routes/me.tsx
@@ -1,22 +1,34 @@
-import { useNavigate } from "react-router";
+import { useState } from "react";
+import { useNavigate, useRouteLoaderData } from "react-router";
 import type { Route } from "./+types/me";
-import { useLogoutMutation, useMeQuery } from "~/features/auth/hooks";
+import { useLogoutMutation } from "~/features/auth/hooks";
 
 export function meta(_: Route.MetaArgs) {
   return [{ title: "マイページ - wolf-mansion" }];
 }
 
+// _auth.tsx の loader から user データを直接取得 (追加 fetch なし)
+type AuthLoaderData = { user: { userId: string; authority: string } };
+
 export default function MePage() {
   const navigate = useNavigate();
-  const me = useMeQuery();
+  const authData = useRouteLoaderData("routes/_auth") as AuthLoaderData;
   const logoutMutation = useLogoutMutation();
+  const [logoutError, setLogoutError] = useState<string | null>(null);
 
   async function onLogout() {
-    await logoutMutation.mutateAsync();
-    navigate("/login", { replace: true });
+    setLogoutError(null);
+    try {
+      await logoutMutation.mutateAsync();
+      navigate("/login", { replace: true });
+    } catch {
+      setLogoutError(
+        "ログアウトに失敗しました。通信状況を確認の上、再度お試しください。"
+      );
+    }
   }
 
-  const user = me.data?.user;
+  const user = authData.user;
 
   return (
     <main className="min-h-screen bg-slate-900 text-slate-100 px-6 py-12">
@@ -24,10 +36,15 @@ export default function MePage() {
         <h1 className="text-3xl font-bold">マイページ</h1>
         <div className="rounded-lg bg-slate-800/60 p-6 border border-slate-700 space-y-2">
           <p className="text-sm text-slate-400">プレイヤー名</p>
-          <p className="text-xl font-mono">{user?.userId ?? "..."}</p>
+          <p className="text-xl font-mono">{user.userId}</p>
           <p className="text-sm text-slate-400 mt-4">権限</p>
-          <p className="text-base">{user?.authority ?? "..."}</p>
+          <p className="text-base">{user.authority}</p>
         </div>
+        {logoutError && (
+          <p role="alert" className="text-sm text-red-400">
+            {logoutError}
+          </p>
+        )}
         <button
           type="button"
           onClick={onLogout}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,8 @@
     "dev": "react-router dev",
     "start": "react-router-serve ./build/server/index.js",
     "typecheck": "react-router typegen && tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "gen:api": "openapi-typescript http://localhost:8089/wolf-mansion-api/v3/api-docs -o app/lib/api/generated.ts"
   },
   "dependencies": {
@@ -29,7 +31,8 @@
     "openapi-typescript": "^7.10.0",
     "tailwindcss": "^4.2.2",
     "typescript": "^5.9.3",
-    "vite": "^8.0.3"
+    "vite": "^8.0.3",
+    "vitest": "^3.2.4"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^5.9.3",
     "vite": "^8.0.3",
-    "vitest": "^3.2.4"
+    "vitest": "^4.1.6"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -61,8 +61,8 @@ importers:
         specifier: ^8.0.3
         version: 8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)
       vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)
+        specifier: ^4.1.6
+        version: 4.1.6(@types/node@22.19.19)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0))
 
 packages:
 
@@ -689,6 +689,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tailwindcss/node@4.3.0':
     resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
 
@@ -814,34 +817,34 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
-  '@vitest/expect@3.2.4':
-    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+  '@vitest/expect@4.1.6':
+    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
 
-  '@vitest/mocker@3.2.4':
-    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+  '@vitest/mocker@4.1.6':
+    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.2.4':
-    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+  '@vitest/pretty-format@4.1.6':
+    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
 
-  '@vitest/runner@3.2.4':
-    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+  '@vitest/runner@4.1.6':
+    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
 
-  '@vitest/snapshot@3.2.4':
-    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+  '@vitest/snapshot@4.1.6':
+    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
 
-  '@vitest/spy@3.2.4':
-    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+  '@vitest/spy@4.1.6':
+    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
 
-  '@vitest/utils@3.2.4':
-    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+  '@vitest/utils@4.1.6':
+    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -917,16 +920,12 @@ packages:
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
-  chai@5.3.3:
-    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
-
-  check-error@2.1.3:
-    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
-    engines: {node: '>= 16'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -996,10 +995,6 @@ packages:
       babel-plugin-macros:
         optional: true
 
-  deep-eql@5.0.2:
-    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
-    engines: {node: '>=6'}
-
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -1040,6 +1035,9 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -1180,9 +1178,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-tokens@9.0.1:
-    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
-
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -1277,9 +1272,6 @@ packages:
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
-  loupe@3.2.1:
-    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
-
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -1352,6 +1344,9 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
     engines: {node: '>= 0.8'}
@@ -1390,10 +1385,6 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pathval@2.0.1:
-    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
-    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1547,11 +1538,8 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
-
-  strip-literal@3.1.0:
-    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
@@ -1567,23 +1555,16 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@0.3.2:
-    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.1.1:
-    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-
-  tinyrainbow@2.0.0:
-    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
-
-  tinyspy@4.0.4:
-    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   toidentifier@1.0.1:
@@ -1726,26 +1707,39 @@ packages:
       yaml:
         optional: true
 
-  vitest@3.2.4:
-    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+  vitest@4.1.6:
+    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.4
-      '@vitest/ui': 3.2.4
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.6
+      '@vitest/browser-preview': 4.1.6
+      '@vitest/browser-webdriverio': 4.1.6
+      '@vitest/coverage-istanbul': 4.1.6
+      '@vitest/coverage-v8': 4.1.6
+      '@vitest/ui': 4.1.6
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
-      '@types/debug':
+      '@opentelemetry/api':
         optional: true
       '@types/node':
         optional: true
-      '@vitest/browser':
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -2330,6 +2324,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.4':
     optional: true
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tailwindcss/node@4.3.0':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -2431,47 +2427,46 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@vitest/expect@3.2.4':
+  '@vitest/expect@4.1.6':
     dependencies:
+      '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      tinyrainbow: 2.0.0
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0))':
+  '@vitest/mocker@4.1.6(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0))':
     dependencies:
-      '@vitest/spy': 3.2.4
+      '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)
 
-  '@vitest/pretty-format@3.2.4':
+  '@vitest/pretty-format@4.1.6':
     dependencies:
-      tinyrainbow: 2.0.0
+      tinyrainbow: 3.1.0
 
-  '@vitest/runner@3.2.4':
+  '@vitest/runner@4.1.6':
     dependencies:
-      '@vitest/utils': 3.2.4
+      '@vitest/utils': 4.1.6
       pathe: 2.0.3
-      strip-literal: 3.1.0
 
-  '@vitest/snapshot@3.2.4':
+  '@vitest/snapshot@4.1.6':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/utils': 4.1.6
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@3.2.4':
-    dependencies:
-      tinyspy: 4.0.4
+  '@vitest/spy@4.1.6': {}
 
-  '@vitest/utils@3.2.4':
+  '@vitest/utils@4.1.6':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
-      loupe: 3.2.1
-      tinyrainbow: 2.0.0
+      '@vitest/pretty-format': 4.1.6
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   accepts@1.3.8:
     dependencies:
@@ -2554,17 +2549,9 @@ snapshots:
 
   caniuse-lite@1.0.30001793: {}
 
-  chai@5.3.3:
-    dependencies:
-      assertion-error: 2.0.1
-      check-error: 2.1.3
-      deep-eql: 5.0.2
-      loupe: 3.2.1
-      pathval: 2.0.1
+  chai@6.2.2: {}
 
   change-case@5.4.4: {}
-
-  check-error@2.1.3: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -2618,8 +2605,6 @@ snapshots:
 
   dedent@1.7.2: {}
 
-  deep-eql@5.0.2: {}
-
   depd@2.0.0: {}
 
   destroy@1.2.0: {}
@@ -2648,6 +2633,8 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -2826,8 +2813,6 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-tokens@9.0.1: {}
-
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -2889,8 +2874,6 @@ snapshots:
 
   lodash@4.18.1: {}
 
-  loupe@3.2.1: {}
-
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -2945,6 +2928,8 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
+  obug@2.1.1: {}
+
   on-finished@2.3.0:
     dependencies:
       ee-first: 1.1.1
@@ -2980,8 +2965,6 @@ snapshots:
   pathe@1.1.2: {}
 
   pathe@2.0.3: {}
-
-  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -3180,11 +3163,7 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  std-env@3.10.0: {}
-
-  strip-literal@3.1.0:
-    dependencies:
-      js-tokens: 9.0.1
+  std-env@4.1.0: {}
 
   supports-color@10.2.2: {}
 
@@ -3194,18 +3173,14 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@0.3.2: {}
+  tinyexec@1.1.2: {}
 
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
-  tinypool@1.1.1: {}
-
-  tinyrainbow@2.0.0: {}
-
-  tinyspy@4.0.4: {}
+  tinyrainbow@3.1.0: {}
 
   toidentifier@1.0.1: {}
 
@@ -3289,46 +3264,32 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
 
-  vitest@3.2.4(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0):
+  vitest@4.1.6(@types/node@22.19.19)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)):
     dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3(supports-color@10.2.2)
+      '@vitest/expect': 4.1.6
+      '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0))
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/runner': 4.1.6
+      '@vitest/snapshot': 4.1.6
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
+      obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.4
-      std-env: 3.10.0
+      std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 0.3.2
+      tinyexec: 1.1.2
       tinyglobby: 0.2.16
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)
-      vite-node: 3.2.4(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)
+      tinyrainbow: 3.1.0
+      vite: 8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.19
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   why-is-node-running@2.3.0:
     dependencies:

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       vite:
         specifier: ^8.0.3
         version: 8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)
 
 packages:
 
@@ -791,6 +794,12 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -804,6 +813,35 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -825,6 +863,10 @@ packages:
 
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   babel-dead-code-elimination@1.0.12:
     resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
@@ -875,8 +917,16 @@ packages:
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -946,6 +996,10 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -1003,6 +1057,9 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
@@ -1010,6 +1067,10 @@ packages:
   exit-hook@2.2.1:
     resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
     engines: {node: '>=6'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express@4.22.2:
     resolution: {integrity: sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==}
@@ -1119,6 +1180,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -1212,6 +1276,9 @@ packages:
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -1323,6 +1390,10 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1455,6 +1526,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1466,9 +1540,18 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
@@ -1481,9 +1564,27 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -1624,6 +1725,39 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -2276,6 +2410,13 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/node@22.19.19':
@@ -2289,6 +2430,48 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   accepts@1.3.8:
     dependencies:
@@ -2304,6 +2487,8 @@ snapshots:
   argparse@2.0.1: {}
 
   array-flatten@1.1.1: {}
+
+  assertion-error@2.0.1: {}
 
   babel-dead-code-elimination@1.0.12:
     dependencies:
@@ -2369,7 +2554,17 @@ snapshots:
 
   caniuse-lite@1.0.30001793: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   change-case@5.4.4: {}
+
+  check-error@2.1.3: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -2422,6 +2617,8 @@ snapshots:
       supports-color: 10.2.2
 
   dedent@1.7.2: {}
+
+  deep-eql@5.0.2: {}
 
   depd@2.0.0: {}
 
@@ -2489,9 +2686,15 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   etag@1.8.1: {}
 
   exit-hook@2.2.1: {}
+
+  expect-type@1.3.0: {}
 
   express@4.22.2:
     dependencies:
@@ -2623,6 +2826,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -2683,6 +2888,8 @@ snapshots:
       lightningcss-win32-x64-msvc: 1.32.0
 
   lodash@4.18.1: {}
+
+  loupe@3.2.1: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -2773,6 +2980,8 @@ snapshots:
   pathe@1.1.2: {}
 
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -2956,6 +3165,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
@@ -2965,7 +3176,15 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   supports-color@10.2.2: {}
 
@@ -2973,10 +3192,20 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   toidentifier@1.0.1: {}
 
@@ -3059,6 +3288,52 @@ snapshots:
       esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.7.0
+
+  vitest@3.2.4(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3(supports-color@10.2.2)
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)
+      vite-node: 3.2.4(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.19
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   yallist@3.1.1: {}
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,4 +7,14 @@ export default defineConfig({
   resolve: {
     tsconfigPaths: true,
   },
+  server: {
+    // dev 中の browser fetch を 同一オリジン扱いにするためのプロキシ。
+    // 本番では ingress が同一ドメインの /wolf-mansion-api を API service にルーティングする。
+    proxy: {
+      "/wolf-mansion-api": {
+        target: "http://localhost:8089",
+        changeOrigin: false,
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary

plan.md Step 4「ログイン画面 + 認証ガード」の実装。React Router v7 SSR + TanStack Query で、ログイン / ログアウト / 認証ガード / 401 自動リトライ を組む。

## 画面 / ルート

| ルート | 役割 |
|---|---|
| `/wolf-mansion/login` (`routes/login.tsx`) | ID/パスワード ログインフォーム |
| `/wolf-mansion/me` (`routes/_auth.tsx` → `routes/me.tsx`) | 認証必須エリア (loader で /auth/me 確認 → 未認証は /login へ redirect) |
| `/wolf-mansion/` (`routes/home.tsx`) | ログイン / マイページ への導線追加 |

## API クライアント

- `lib/api/client.ts`:
  - `browserFetch`: 401 を受けたら 1 度だけ `/api/v1/auth/refresh` を試行 → 成功で元リクエスト再試行。refresh / login 自身の 401 は再帰しない
  - `mergeHeaders`: Body 付きリクエストのみ `Content-Type: application/json` を付与
  - `ssrFetch` は自動リトライしない (Set-Cookie 経路が複雑なため、loader 側で 401 → redirect する方針)

## features/auth

| ファイル | 内容 |
|---|---|
| `features/auth/api.ts` | fetchMe / login / logout。401 を `InvalidCredentialsError` で投げ分け |
| `features/auth/hooks.ts` | useMeQuery / useLoginMutation / useLogoutMutation。成功時に me cache 更新 |

## 補助

- `lib/basename.ts`: `BASENAME` 定数 + `stripBasename(pathname)` ヘルパ。`request.url` から basename を取り除いて redirect query を組み立てる (二重 basename を防止)
- `routes/login.tsx::sanitizeRedirect`: `?redirect=...` を相対 in-app パスに正規化 (`//` で始まる protocol-relative は弾く = open redirect 防止)

## vite.config.ts (dev server proxy)

dev server で browser fetch が同一オリジン扱いになるよう `/wolf-mansion-api/*` を `http://localhost:8089` にプロキシ。本番では ingress が同一ドメインで担うため、**dev / prod で browser 側の fetch コードは完全に同一** (CORS 不要)。

## OpenAPI 型生成

backend を起動した状態で `pnpm gen:api` → `app/lib/api/generated.ts` (gitignore 対象) を生成。`features/auth/api.ts` で `components["schemas"]["MeResponse"]` 等を利用。

## Test plan

- [x] `pnpm typecheck` 通過
- [x] `pnpm build` 成功 (client + ssr bundle)
- [x] `pnpm audit --prod --audit-level high` → No known vulnerabilities found
- [x] backend (8089) + frontend dev (5173) 同時起動
  - [x] `curl http://localhost:5173/wolf-mansion-api/api/v1/auth/me` → 200 `{"user":null}` (proxy 経由)
  - [x] `curl POST .../auth/login` invalid creds → 401
  - [x] `curl http://localhost:5173/wolf-mansion/me` 未認証 → 302 `Location: /wolf-mansion/login?redirect=%2Fme` (basename 二重なし)
  - [x] SSR HTML にログインフォーム (`<h1>wolf-mansion ログイン</h1>` 等) 出力確認
- [ ] 実プレイヤーでのログイン成功 / refresh rotation の手動確認は user 委任 (テストパスワードが手元になく end-to-end できず)

## Notes for reviewer

- `app/lib/api/generated.ts` (1599 行) は openapi-typescript 出力なので gitignore 対象
- `features/village/`, `features/chara/` 等は次以降の Step で追加するため空
- Logout 後の me cache 操作は `{ user: undefined }` を一旦 setQueryData してから invalidate (UI が空状態に即移行)
