### PR TITLE
Step 5: 村一覧 REST + フロントエンド一覧/トップ画面

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/response/village/SimpleVillageView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/village/SimpleVillageView.kt
@@ -1,0 +1,39 @@
+package com.ort.app.api.response.village
+
+import com.ort.app.domain.model.village.Village
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "村一覧用の軽量ビュー")
+data class SimpleVillageView(
+    @field:Schema(description = "村ID")
+    val id: Int,
+    @field:Schema(description = "村番号 (4桁ゼロ埋め)")
+    val number: String,
+    @field:Schema(description = "村名")
+    val name: String,
+    @field:Schema(description = "ステータスコード (例: 募集中, 進行中, エピローグ, 終了, 廃村)")
+    val statusCode: String,
+    @field:Schema(description = "ステータス表示名")
+    val statusName: String,
+    @field:Schema(description = "参加者数 (見学含まない)")
+    val participantCount: Int,
+    @field:Schema(description = "見学者数")
+    val spectatorCount: Int,
+    @field:Schema(description = "募集開始日時")
+    val createDatetime: LocalDateTime,
+    @field:Schema(description = "村作成者プレイヤー名")
+    val createPlayerName: String,
+) {
+    constructor(village: Village) : this(
+        id = village.id,
+        number = village.id.toString().padStart(4, '0'),
+        name = village.name,
+        statusCode = village.status.code,
+        statusName = village.status.name,
+        participantCount = village.participants.count,
+        spectatorCount = village.spectators.count,
+        createDatetime = village.createDatetime,
+        createPlayerName = village.createPlayerName,
+    )
+}

--- a/backend/src/main/kotlin/com/ort/app/api/response/village/VillagesView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/village/VillagesView.kt
@@ -8,7 +8,10 @@ data class VillagesView(
     @field:Schema(description = "村のリスト (新着順)")
     val list: List<SimpleVillageView>,
 ) {
+    // DB の取得順 (現状 ASC) に依存せず、view 層で明示的に新着順に並べる。
+    // 件数が増えた際は DataSource にページネーション + ORDER BY DESC を導入し、
+    // ここの再ソートは取り除くこと (Step 6 以降の課題)。
     constructor(villages: Villages) : this(
-        list = villages.list.reversed().map { SimpleVillageView(it) },
+        list = villages.list.sortedByDescending { it.id }.map { SimpleVillageView(it) },
     )
 }

--- a/backend/src/main/kotlin/com/ort/app/api/response/village/VillagesView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/village/VillagesView.kt
@@ -1,0 +1,14 @@
+package com.ort.app.api.response.village
+
+import com.ort.app.domain.model.village.Villages
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "村一覧")
+data class VillagesView(
+    @field:Schema(description = "村のリスト (新着順)")
+    val list: List<SimpleVillageView>,
+) {
+    constructor(villages: Villages) : this(
+        list = villages.list.reversed().map { SimpleVillageView(it) },
+    )
+}

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageRestController.kt
@@ -1,0 +1,52 @@
+package com.ort.app.api.v1.villages
+
+import com.ort.app.api.response.village.VillagesView
+import com.ort.app.application.service.VillageService
+import com.ort.app.domain.model.village.VillageQuery
+import com.ort.app.domain.model.village.VillageStatus
+import com.ort.app.domain.model.village.toModel
+import com.ort.dbflute.allcommon.CDef
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/villages")
+@Tag(name = "villages", description = "村")
+class VillageRestController(
+    private val villageService: VillageService,
+) {
+
+    @GetMapping
+    @Operation(
+        summary = "村一覧取得",
+        description = "ステータスでフィルタ可能。指定なしなら全村を返す。新着順 (id 降順)。",
+    )
+    fun list(
+        @Parameter(
+            description = "ステータスコードのカンマ区切り (例: 募集中,進行中)。未指定なら全件。",
+        )
+        @RequestParam(required = false) status: String?,
+    ): VillagesView {
+        val statuses = parseStatuses(status)
+        val villages = villageService.findVillages(VillageQuery(statuses = statuses))
+        return VillagesView(villages)
+    }
+
+    private fun parseStatuses(raw: String?): List<VillageStatus> {
+        if (raw.isNullOrBlank()) return emptyList()
+        val all = CDef.VillageStatus.listAll()
+        return raw.split(",")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .mapNotNull { token ->
+                CDef.VillageStatus.codeOf(token)
+                    ?: all.firstOrNull { it.alias() == token }
+            }
+            .map { it.toModel() }
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageRestController.kt
@@ -37,6 +37,9 @@ class VillageRestController(
         return VillagesView(villages)
     }
 
+    // NOTE: frontend (routes/villages._index.tsx の `parseStatuses`) と意味的に対応する。
+    // CDef.VillageStatus の値 (募集中/進行中/エピローグ/終了/廃村) が増減したら
+    // frontend 側 ALL_STATUSES と VillageStatusCode 型も同期更新が必要。
     private fun parseStatuses(raw: String?): List<VillageStatus> {
         if (raw.isNullOrBlank()) return emptyList()
         val all = CDef.VillageStatus.listAll()

--- a/backend/src/test/kotlin/com/ort/app/api/v1/villages/VillageRestControllerTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/api/v1/villages/VillageRestControllerTest.kt
@@ -1,0 +1,126 @@
+package com.ort.app.api.v1.villages
+
+import com.ort.app.application.service.VillageService
+import com.ort.app.domain.model.village.Villages
+import com.ort.app.domain.model.village.createPrologueVillage
+import com.ort.app.domain.model.village.toModel
+import com.ort.dbflute.allcommon.CDef
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.check
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+
+@SpringBootTest
+class VillageRestControllerTest {
+
+    @Autowired
+    private lateinit var context: WebApplicationContext
+
+    @MockitoBean
+    private lateinit var villageService: VillageService
+
+    private lateinit var mockMvc: MockMvc
+
+    @BeforeEach
+    fun setup() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+            .apply<org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder>(springSecurity())
+            .build()
+    }
+
+    @Test
+    fun `GET _api_v1_villages 認証不要で 200 と list を返す`() {
+        val v1 = createPrologueVillage().copy(id = 1, name = "村1")
+        val v2 = createPrologueVillage().copy(id = 2, name = "村2")
+        whenever(villageService.findVillages(any())).thenReturn(Villages(list = listOf(v1, v2)))
+
+        mockMvc.perform(get("/api/v1/villages"))
+            .andExpect(status().isOk)
+            // reversed: id=2 が先頭
+            .andExpect(jsonPath("$.list[0].id").value(2))
+            .andExpect(jsonPath("$.list[0].name").value("村2"))
+            .andExpect(jsonPath("$.list[0].number").value("0002"))
+            .andExpect(jsonPath("$.list[0].statusCode").exists())
+            .andExpect(jsonPath("$.list[0].statusName").exists())
+            .andExpect(jsonPath("$.list[1].id").value(1))
+    }
+
+    @Test
+    fun `status クエリでフィルタ条件が渡る (code 形式)`() {
+        whenever(villageService.findVillages(any())).thenReturn(Villages(list = emptyList()))
+
+        mockMvc.perform(get("/api/v1/villages").param("status", "募集中,進行中"))
+            .andExpect(status().isOk)
+
+        verify(villageService).findVillages(check { query ->
+            val codes = query.statuses.map { it.code }
+            require(codes.containsAll(listOf(CDef.VillageStatus.募集中.code(), CDef.VillageStatus.進行中.code()))) {
+                "expected 募集中,進行中 statuses but got $codes"
+            }
+        })
+    }
+
+    @Test
+    fun `status 未指定なら statuses は空リスト (全件取得)`() {
+        whenever(villageService.findVillages(any())).thenReturn(Villages(list = emptyList()))
+
+        mockMvc.perform(get("/api/v1/villages"))
+            .andExpect(status().isOk)
+
+        verify(villageService).findVillages(check { query ->
+            require(query.statuses.isEmpty()) { "expected empty statuses but got ${query.statuses}" }
+        })
+    }
+
+    @Test
+    fun `status に未知の値が混ざっても 200 で無視される`() {
+        whenever(villageService.findVillages(any())).thenReturn(Villages(list = emptyList()))
+
+        mockMvc.perform(get("/api/v1/villages").param("status", "ghost,募集中"))
+            .andExpect(status().isOk)
+
+        verify(villageService).findVillages(check { query ->
+            val codes = query.statuses.map { it.code }
+            require(codes == listOf(CDef.VillageStatus.募集中.code())) {
+                "expected only 募集中 but got $codes"
+            }
+        })
+    }
+
+    @Test
+    fun `id 4桁ゼロ埋め number が出る`() {
+        val v = createPrologueVillage().copy(id = 42)
+        whenever(villageService.findVillages(any())).thenReturn(Villages(list = listOf(v)))
+
+        mockMvc.perform(get("/api/v1/villages"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.list[0].number").value("0042"))
+    }
+
+    @Test
+    fun `id 1万を超える村も number はそのまま表示`() {
+        val v = createPrologueVillage().copy(id = 12345)
+        whenever(villageService.findVillages(any())).thenReturn(Villages(list = listOf(v)))
+
+        mockMvc.perform(get("/api/v1/villages"))
+            .andExpect(jsonPath("$.list[0].number").value("12345"))
+    }
+
+    @Suppress("unused")
+    private fun referenceTypes() {
+        // unused import 抑止用
+        @Suppress("UNUSED_VARIABLE") val ignored = CDef.VillageStatus.募集中.toModel()
+    }
+}

--- a/backend/src/test/kotlin/com/ort/app/api/v1/villages/VillageRestControllerTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/api/v1/villages/VillageRestControllerTest.kt
@@ -3,7 +3,6 @@ package com.ort.app.api.v1.villages
 import com.ort.app.application.service.VillageService
 import com.ort.app.domain.model.village.Villages
 import com.ort.app.domain.model.village.createPrologueVillage
-import com.ort.app.domain.model.village.toModel
 import com.ort.dbflute.allcommon.CDef
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -118,9 +117,28 @@ class VillageRestControllerTest {
             .andExpect(jsonPath("$.list[0].number").value("12345"))
     }
 
-    @Suppress("unused")
-    private fun referenceTypes() {
-        // unused import 抑止用
-        @Suppress("UNUSED_VARIABLE") val ignored = CDef.VillageStatus.募集中.toModel()
+    @Test
+    fun `募集中の村は statusCode に CDef code (英字) + statusName に alias (日本語) が出る`() {
+        val v = createPrologueVillage().copy(id = 1)
+        whenever(villageService.findVillages(any())).thenReturn(Villages(list = listOf(v)))
+
+        mockMvc.perform(get("/api/v1/villages"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.list[0].statusCode").value(CDef.VillageStatus.募集中.code()))
+            .andExpect(jsonPath("$.list[0].statusName").value(CDef.VillageStatus.募集中.alias()))
+    }
+
+    @Test
+    fun `複数村は id 降順 (新着順) で返る`() {
+        val v1 = createPrologueVillage().copy(id = 1)
+        val v3 = createPrologueVillage().copy(id = 3)
+        val v2 = createPrologueVillage().copy(id = 2)
+        // DataSource は ASC で返すが view 層で降順整列される想定
+        whenever(villageService.findVillages(any())).thenReturn(Villages(list = listOf(v1, v2, v3)))
+
+        mockMvc.perform(get("/api/v1/villages"))
+            .andExpect(jsonPath("$.list[0].id").value(3))
+            .andExpect(jsonPath("$.list[1].id").value(2))
+            .andExpect(jsonPath("$.list[2].id").value(1))
     }
 }

--- a/frontend/app/features/village/VillageList.tsx
+++ b/frontend/app/features/village/VillageList.tsx
@@ -1,0 +1,54 @@
+import { Link } from "react-router";
+import type { SimpleVillageView } from "./api";
+
+const STATUS_BADGE: Record<string, string> = {
+  募集中: "bg-emerald-600/30 text-emerald-200 border-emerald-500/40",
+  進行中: "bg-amber-600/30 text-amber-200 border-amber-500/40",
+  エピローグ: "bg-sky-600/30 text-sky-200 border-sky-500/40",
+  終了: "bg-slate-600/30 text-slate-300 border-slate-500/40",
+  廃村: "bg-rose-600/30 text-rose-200 border-rose-500/40",
+};
+
+function StatusBadge({ code }: { code: string }) {
+  const cls = STATUS_BADGE[code] ?? "bg-slate-700/40 text-slate-300 border-slate-500/40";
+  return (
+    <span className={`text-xs px-2 py-0.5 rounded border ${cls}`}>{code}</span>
+  );
+}
+
+/** 村のリスト表示 (一覧 / トップ共通) */
+export function VillageList({ villages, emptyMessage }: {
+  villages: SimpleVillageView[];
+  emptyMessage?: string;
+}) {
+  if (villages.length === 0) {
+    return (
+      <p className="text-slate-400 text-sm py-8 text-center">
+        {emptyMessage ?? "村がありません"}
+      </p>
+    );
+  }
+  return (
+    <ul className="divide-y divide-slate-700/60">
+      {villages.map((v) => (
+        <li key={v.id}>
+          <Link
+            to={`/villages/${v.id}`}
+            className="flex items-center gap-3 py-3 px-2 hover:bg-slate-800/40 transition rounded"
+          >
+            <span className="font-mono text-slate-400 text-sm w-14 shrink-0">
+              #{v.number}
+            </span>
+            <span className="flex-1 min-w-0 truncate">{v.name}</span>
+            <span className="text-sm text-slate-400 shrink-0">
+              {v.spectatorCount > 0
+                ? `${v.participantCount} (${v.spectatorCount})人`
+                : `${v.participantCount}人`}
+            </span>
+            <StatusBadge code={v.statusCode} />
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/app/features/village/VillageList.tsx
+++ b/frontend/app/features/village/VillageList.tsx
@@ -1,18 +1,26 @@
 import { Link } from "react-router";
 import type { SimpleVillageView } from "./api";
 
+// 表示用キーは日本語 alias (statusName)。
+// SimpleVillageView.statusCode は backend 側 CDef のコード値 (英字: IN_PREPARATION 等) なので、
+// 視覚的なバッジ色は localized な statusName で引く。
 const STATUS_BADGE: Record<string, string> = {
-  募集中: "bg-emerald-600/30 text-emerald-200 border-emerald-500/40",
-  進行中: "bg-amber-600/30 text-amber-200 border-amber-500/40",
-  エピローグ: "bg-sky-600/30 text-sky-200 border-sky-500/40",
-  終了: "bg-slate-600/30 text-slate-300 border-slate-500/40",
-  廃村: "bg-rose-600/30 text-rose-200 border-rose-500/40",
+  募集中: "bg-emerald-600/30 text-emerald-100 border-emerald-500/40",
+  進行中: "bg-amber-600/30 text-amber-100 border-amber-500/40",
+  エピローグ: "bg-sky-600/30 text-sky-100 border-sky-500/40",
+  終了: "bg-slate-600/30 text-slate-200 border-slate-500/40",
+  廃村: "bg-rose-600/30 text-rose-100 border-rose-500/40",
 };
 
-function StatusBadge({ code }: { code: string }) {
-  const cls = STATUS_BADGE[code] ?? "bg-slate-700/40 text-slate-300 border-slate-500/40";
+function StatusBadge({ name }: { name: string }) {
+  const cls = STATUS_BADGE[name] ?? "bg-slate-700/40 text-slate-200 border-slate-500/40";
   return (
-    <span className={`text-xs px-2 py-0.5 rounded border ${cls}`}>{code}</span>
+    <span
+      className={`text-xs px-2 py-0.5 rounded border ${cls}`}
+      aria-label={`ステータス: ${name}`}
+    >
+      {name}
+    </span>
   );
 }
 
@@ -45,7 +53,7 @@ export function VillageList({ villages, emptyMessage }: {
                 ? `${v.participantCount} (${v.spectatorCount})人`
                 : `${v.participantCount}人`}
             </span>
-            <StatusBadge code={v.statusCode} />
+            <StatusBadge name={v.statusName} />
           </Link>
         </li>
       ))}

--- a/frontend/app/features/village/api.ts
+++ b/frontend/app/features/village/api.ts
@@ -1,0 +1,30 @@
+import type { components } from "~/lib/api/generated";
+import { browserFetch, type ApiFetch } from "~/lib/api/client";
+
+export type VillagesView = components["schemas"]["VillagesView"];
+export type SimpleVillageView = components["schemas"]["SimpleVillageView"];
+
+export type VillageStatusCode =
+  | "募集中"
+  | "進行中"
+  | "エピローグ"
+  | "終了"
+  | "廃村";
+
+/**
+ * GET /api/v1/villages
+ *
+ * SSR loader / browser どちらでも使えるよう、`fetcher` 引数で fetch 関数を差し替え可能。
+ * 省略時は browserFetch (CSR 用)。
+ */
+export async function fetchVillages(
+  params: { statuses?: VillageStatusCode[] } = {},
+  fetcher: ApiFetch = browserFetch,
+): Promise<VillagesView> {
+  const qs = params.statuses && params.statuses.length > 0
+    ? `?status=${encodeURIComponent(params.statuses.join(","))}`
+    : "";
+  const res = await fetcher(`/api/v1/villages${qs}`);
+  if (!res.ok) throw new Error(`villages fetch failed: ${res.status}`);
+  return res.json();
+}

--- a/frontend/app/features/village/hooks.ts
+++ b/frontend/app/features/village/hooks.ts
@@ -1,0 +1,23 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { fetchVillages, type VillagesView, type VillageStatusCode } from "./api";
+
+/** TanStack Query 用のキー。statuses 配列はソート済み文字列にしてキー安定化 */
+function villagesQueryKey(statuses: VillageStatusCode[] | undefined) {
+  return ["villages", { statuses: (statuses ?? []).slice().sort() }] as const;
+}
+
+/**
+ * GET /api/v1/villages を TanStack Query で取得。
+ * - SSR で取得したデータを `initialData` として渡すと、初回マウント時の追加 fetch を避けられる。
+ */
+export function useVillagesQuery(
+  params: { statuses?: VillageStatusCode[] } = {},
+  initialData?: VillagesView,
+): UseQueryResult<VillagesView> {
+  return useQuery<VillagesView>({
+    queryKey: villagesQueryKey(params.statuses),
+    queryFn: () => fetchVillages(params),
+    initialData,
+    staleTime: 30 * 1000,
+  });
+}

--- a/frontend/app/features/village/hooks.ts
+++ b/frontend/app/features/village/hooks.ts
@@ -9,6 +9,8 @@ function villagesQueryKey(statuses: VillageStatusCode[] | undefined) {
 /**
  * GET /api/v1/villages を TanStack Query で取得。
  * - SSR で取得したデータを `initialData` として渡すと、初回マウント時の追加 fetch を避けられる。
+ *   `initialDataUpdatedAt` を指定しないと v5 では epoch (1970) 起点で stale 判定されて
+ *   必ず refetch が走り、hydration mismatch のリスクがあるので Date.now() を渡す。
  */
 export function useVillagesQuery(
   params: { statuses?: VillageStatusCode[] } = {},
@@ -18,6 +20,7 @@ export function useVillagesQuery(
     queryKey: villagesQueryKey(params.statuses),
     queryFn: () => fetchVillages(params),
     initialData,
+    initialDataUpdatedAt: initialData ? Date.now() : undefined,
     staleTime: 30 * 1000,
   });
 }

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -3,6 +3,7 @@ import { type RouteConfig, index, layout, route } from "@react-router/dev/routes
 export default [
   index("routes/home.tsx"),
   route("login", "routes/login.tsx"),
+  route("villages", "routes/villages._index.tsx"),
   // 認証必須エリア
   layout("routes/_auth.tsx", [
     route("me", "routes/me.tsx"),

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -1,5 +1,11 @@
 import { Link } from "react-router";
 import type { Route } from "./+types/home";
+import { fetchVillages, type VillagesView } from "~/features/village/api";
+import { useVillagesQuery } from "~/features/village/hooks";
+import { VillageList } from "~/features/village/VillageList";
+import { ssrFetch } from "~/lib/api/client";
+
+const TOP_STATUSES = ["募集中", "進行中", "エピローグ"] as const;
 
 export function meta(_: Route.MetaArgs) {
   return [
@@ -10,30 +16,60 @@ export function meta(_: Route.MetaArgs) {
   ];
 }
 
-export default function Home() {
+export async function loader({ request }: Route.LoaderArgs) {
+  const api = ssrFetch(request);
+  try {
+    const villages = await fetchVillages({ statuses: [...TOP_STATUSES] }, api);
+    return { villages };
+  } catch {
+    // backend 不可用時は空一覧で続行 (404 にせず UI を出す)
+    return { villages: { list: [] } satisfies VillagesView };
+  }
+}
+
+export default function Home({ loaderData }: Route.ComponentProps) {
+  const villagesQuery = useVillagesQuery(
+    { statuses: [...TOP_STATUSES] },
+    loaderData.villages,
+  );
+  const villages = villagesQuery.data?.list ?? [];
+
   return (
-    <main className="min-h-screen bg-slate-900 text-slate-100 flex flex-col items-center justify-center px-6 py-16">
-      <img
-        src="/wolf-mansion/img/top.jpg"
-        alt="wolf-mansion"
-        className="w-full max-w-2xl rounded-lg shadow-xl"
-      />
-      <h1 className="mt-8 text-4xl font-bold tracking-wide">wolf-mansion</h1>
-      <p className="mt-4 text-slate-300">人狼ゲーム (移行作業中)</p>
-      <div className="mt-8 flex gap-4">
-        <Link
-          to="/login"
-          className="rounded-md bg-indigo-500 hover:bg-indigo-400 px-5 py-2 font-semibold transition"
-        >
-          ログイン
-        </Link>
-        <Link
-          to="/me"
-          className="rounded-md border border-slate-600 hover:border-slate-400 px-5 py-2 font-semibold transition"
-        >
-          マイページ
-        </Link>
-      </div>
+    <main className="min-h-screen bg-slate-900 text-slate-100">
+      <section className="max-w-3xl mx-auto px-6 py-12 space-y-8">
+        <header className="text-center space-y-2">
+          <img
+            src="/wolf-mansion/img/top.jpg"
+            alt="wolf-mansion"
+            className="w-full max-w-xl mx-auto rounded-lg shadow-xl"
+          />
+          <h1 className="mt-6 text-4xl font-bold tracking-wide">wolf-mansion</h1>
+          <p className="text-slate-300">人狼ゲーム</p>
+        </header>
+
+        <div className="flex gap-3 justify-center">
+          <Link
+            to="/villages"
+            className="rounded-md bg-indigo-500 hover:bg-indigo-400 px-5 py-2 font-semibold transition"
+          >
+            全村一覧
+          </Link>
+          <Link
+            to="/login"
+            className="rounded-md border border-slate-600 hover:border-slate-400 px-5 py-2 font-semibold transition"
+          >
+            ログイン
+          </Link>
+        </div>
+
+        <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
+          <h2 className="text-lg font-semibold mb-2">進行中の村</h2>
+          <VillageList
+            villages={villages}
+            emptyMessage="現在、進行中の村はありません"
+          />
+        </section>
+      </section>
     </main>
   );
 }

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -63,10 +63,11 @@ export default function Home({ loaderData }: Route.ComponentProps) {
         </div>
 
         <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
-          <h2 className="text-lg font-semibold mb-2">進行中の村</h2>
+          <h2 className="text-lg font-semibold mb-2">開催中の村</h2>
+          <p className="text-xs text-slate-400 mb-2">募集中 / 進行中 / エピローグ</p>
           <VillageList
             villages={villages}
-            emptyMessage="現在、進行中の村はありません"
+            emptyMessage="現在、開催中の村はありません"
           />
         </section>
       </section>

--- a/frontend/app/routes/villages._index.tsx
+++ b/frontend/app/routes/villages._index.tsx
@@ -5,6 +5,8 @@ import { useVillagesQuery } from "~/features/village/hooks";
 import { VillageList } from "~/features/village/VillageList";
 import { ssrFetch } from "~/lib/api/client";
 
+// NOTE: backend (VillageRestController#parseStatuses) と意味的に対応する。
+// CDef.VillageStatus の値が増減したら backend 側も同期更新が必要。
 const ALL_STATUSES: VillageStatusCode[] = ["募集中", "進行中", "エピローグ", "終了", "廃村"];
 
 export function meta(_: Route.MetaArgs) {

--- a/frontend/app/routes/villages._index.tsx
+++ b/frontend/app/routes/villages._index.tsx
@@ -1,0 +1,105 @@
+import { Link, useSearchParams } from "react-router";
+import type { Route } from "./+types/villages._index";
+import { fetchVillages, type VillagesView, type VillageStatusCode } from "~/features/village/api";
+import { useVillagesQuery } from "~/features/village/hooks";
+import { VillageList } from "~/features/village/VillageList";
+import { ssrFetch } from "~/lib/api/client";
+
+const ALL_STATUSES: VillageStatusCode[] = ["募集中", "進行中", "エピローグ", "終了", "廃村"];
+
+export function meta(_: Route.MetaArgs) {
+  return [{ title: "村一覧 - wolf-mansion" }];
+}
+
+function parseStatuses(raw: string | null): VillageStatusCode[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s): s is VillageStatusCode => ALL_STATUSES.includes(s as VillageStatusCode));
+}
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const url = new URL(request.url);
+  const statuses = parseStatuses(url.searchParams.get("status"));
+  const api = ssrFetch(request);
+  try {
+    const villages = await fetchVillages({ statuses }, api);
+    return { villages, statuses };
+  } catch {
+    return { villages: { list: [] } satisfies VillagesView, statuses };
+  }
+}
+
+export default function VillagesIndex({ loaderData }: Route.ComponentProps) {
+  const [params, setParams] = useSearchParams();
+  const selected = parseStatuses(params.get("status"));
+
+  const villagesQuery = useVillagesQuery(
+    { statuses: selected.length > 0 ? selected : undefined },
+    loaderData.villages,
+  );
+
+  function toggleStatus(s: VillageStatusCode) {
+    const next = selected.includes(s)
+      ? selected.filter((x) => x !== s)
+      : [...selected, s];
+    const newParams = new URLSearchParams(params);
+    if (next.length === 0) newParams.delete("status");
+    else newParams.set("status", next.join(","));
+    setParams(newParams, { replace: true });
+  }
+
+  const list = villagesQuery.data?.list ?? [];
+
+  return (
+    <main className="min-h-screen bg-slate-900 text-slate-100">
+      <section className="max-w-3xl mx-auto px-6 py-10 space-y-6">
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold">村一覧</h1>
+          <Link to="/" className="text-sm text-slate-400 hover:text-slate-200">
+            ← トップへ
+          </Link>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {ALL_STATUSES.map((s) => {
+            const active = selected.includes(s);
+            return (
+              <button
+                key={s}
+                type="button"
+                onClick={() => toggleStatus(s)}
+                aria-pressed={active}
+                className={
+                  "rounded-full px-3 py-1 text-xs border transition " +
+                  (active
+                    ? "bg-indigo-500/30 border-indigo-400 text-indigo-100"
+                    : "border-slate-600 text-slate-300 hover:border-slate-400")
+                }
+              >
+                {s}
+              </button>
+            );
+          })}
+          {selected.length > 0 && (
+            <button
+              type="button"
+              onClick={() => setParams(new URLSearchParams(), { replace: true })}
+              className="text-xs text-slate-400 hover:text-slate-200 ml-2 underline"
+            >
+              クリア
+            </button>
+          )}
+        </div>
+
+        <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
+          <p className="text-xs text-slate-400 mb-2">
+            {selected.length === 0 ? "全村" : `${selected.join(" / ")}`} ({list.length}件)
+          </p>
+          <VillageList villages={list} emptyMessage="該当する村がありません" />
+        </section>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

plan.md Step 5「村一覧 + トップ」の実装。Backend に新 REST endpoint と response DTO、Frontend にトップと一覧ページを追加する。

### backend

#### 新規 `api/response/village/` (plan.md の DTO 設計に準拠)

- **`SimpleVillageView`**: `id`, `number` (4 桁ゼロ埋め), `name`, `statusCode/Name`, `participantCount`, `spectatorCount`, `createDatetime`, `createPlayerName`
- **`VillagesView`**: `list` (新着順 = `id` 降順)

#### 新規 `api/v1/villages/VillageRestController`

- `GET /api/v1/villages?status=募集中,進行中` (カンマ区切り)
  - `status` 未指定なら全村
  - 未知ステータスは無視 (200 を返す)
  - 認証不要 (`anyRequest().permitAll()` 配下)
- OpenAPI `@Tag` / `@Operation` / `@Parameter` を付与

#### テスト (`@SpringBootTest` + MockMvc + MockitoBean) 6 ケース

- 認証不要で 200 と list 返却 + JSON 形状検証
- `status` フィルタが `VillageQuery.statuses` に渡る
- `status` 未指定で空フィルタ
- 未知ステータスは無視されつつ 200
- `id=42` → `number="0042"`、`id=12345` → `number="12345"`

### frontend

#### 新規 `features/village/`

- **`api.ts`**: `VillagesView` / `SimpleVillageView` 型 (`generated.ts` 由来)、`fetchVillages(params, fetcher)` で SSR / CSR どちらの fetch も差し替え可能
- **`hooks.ts`**: `useVillagesQuery(params, initialData?)` — TanStack Query で取得、`initialData` で SSR loader 結果を継承して初回マウントの追加 fetch を回避
- **`VillageList.tsx`**: 一覧表示コンポーネント (ステータスバッジ色分け、`<Link to={/villages/{id}}>`)

#### 新規 `routes/villages._index.tsx` (`/villages`)

- 全 5 ステータスのトグルフィルタ (`?status=` クエリと同期、`replace` 遷移)
- SSR loader が `?status` を読んで取得 → `useVillagesQuery` が `initialData` として継承
- backend 落ち時は空一覧で表示継続 (loader 内 try/catch)

#### `routes/home.tsx` を刷新

- 募集中 / 進行中 / エピローグ の進行中村を SSR で取得して表示
- 全村一覧 / ログインへの導線

`routes.ts` に `route("villages", "routes/villages._index.tsx")` 追加。

## Test plan

- [x] backend `./gradlew test` (新規 6 + 既存 → 全 47 ケース緑)
- [x] backend `./gradlew bootRun` 起動成功
  - `GET /api/v1/villages` → 200 `{"list":[]}` (DB に村なし)
  - `?status=募集中,進行中` で statuses が VillageQuery に伝搬
- [x] frontend `pnpm typecheck` 通過
- [x] frontend `pnpm test` (redirect 11 ケース) 緑
- [x] frontend `pnpm build` (client + ssr) 成功
- [x] frontend `pnpm audit --prod --audit-level high` → No known vulnerabilities
- [x] dev 起動 (5173) で:
  - `/wolf-mansion` 200 → SSR HTML に "進行中の村" "現在、進行中の村はありません" を含む
  - `/wolf-mansion/villages` 200 → SSR HTML に "村一覧" / "該当する村がありません"
  - `/wolf-mansion/villages?status=募集中` 200 → フィルタ反映

## Notes for reviewer

- `firewolf` 流の DTO 命名 (`~View`) と secondary constructor (`Village` から直接構築) を採用
- 既存 Thymeleaf 用の `VillageListContent` / `VillageApiController#villageList` は Step 9 削除予定のため未変更
- Step 6 (村詳細 + メッセージ + 足音隠蔽) のために `<Link to={/villages/{id}}>` のリンクだけ先に張ってあるが、当該ルートは未実装 (404 になる)
