### PR TITLE
fix(issue #3): 足音 reveal の team-share を撤回し既存挙動 (全員匿名) に合わせる

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
@@ -93,7 +93,7 @@ class VillageDetailRestController(
     @GetMapping("/{villageId}/footsteps")
     @Operation(
         summary = "足音一覧取得",
-        description = "進行中は他人の足音について registerChara / chara を隠す。エピローグ / 終了では全公開、募集中 / 廃村は空リスト。",
+        description = "進行中は registerChara / chara を隠し roomNumbers のみ公開 (墓下開示村で dead / 見学の viewer には例外的に全公開)。エピローグ / 終了では全公開、募集中 / 廃村は空リスト。",
     )
     fun footsteps(
         @PathVariable villageId: Int,

--- a/backend/src/main/kotlin/com/ort/app/domain/service/footstep/FootstepRevealDomainService.kt
+++ b/backend/src/main/kotlin/com/ort/app/domain/service/footstep/FootstepRevealDomainService.kt
@@ -6,21 +6,18 @@ import com.ort.app.domain.model.village.participant.VillageParticipant
 import org.springframework.stereotype.Service
 
 /**
- * 足音 DTO 構築時の "出した人" 開示判定。
+ * 村状況欄の足音 DTO 構築時の "出した人" 開示判定。
  *
- * - 終了 / エピローグ: 全員に対し全公開
- * - 募集中 / 廃村: そもそも未登録 (呼び出し側で空リストを返す前提なので念のため false)
- * - 進行中: 自分の足音は常に開示、同じ "say チャンネル" を共有する陣営なら開示、それ以外は隠す
+ * 既存の `FootstepDomainService.convertToSituation` の挙動と一致させる:
+ *  - エピローグ / 終了: 全員に対し全公開
+ *  - 進行中、墓下開示村 (`isOpenSkillInGrave`) で自分が dead / 見学: その閲覧者にだけ全公開
+ *  - それ以外 (進行中の alive 参加者、人狼を含む / 未参加閲覧者 / 募集中 / 廃村):
+ *    匿名表示 (registerChara / chara を null、`roomNumbers` のみ公開)
  *
- * "team共有" のルールは既存 Say の `isViewable*` セマンティクスに合わせる:
- *  - 人狼の囁き: `isViewableWerewolfSay()` 同士
- *  - 共鳴: `isViewableSympathizeSay()` 同士
- *  - 念話 (狐): `isViewableTelepathy()` 同士 — fox-possessioned も同じチャンネルに含むのは Say と同じ
- *  - 恋人: **per-pair** で判定する (`loverIdList` overlap)。Say では複数恋人グループが全部見える既存挙動だが、
- *         足音は推理ゲーム上ペア境界を尊重した方が公平なので per-pair に絞っている。
- *
- * NOTE: `playerId == 1` の admin 参加者は `isViewableWerewolfSay` 等が常に true になるため、
- *       admin がプレイヤー参加した村では全チームの足音が見えてしまう。これは既存 Say と同じ挙動。
+ * NOTE: 「自分が登録した足音を自分には見せる」「team共有」は **行わない**。
+ * 既存挙動が全員匿名扱いであり、夢遊病者など本人にもどこを通ったか不明な役職がある
+ * ため、村状況欄では一律で隠す。能力フォーム / 行使履歴で自分の登録足音を見たい場合は
+ * 別 endpoint (Step 7 の ability 系) で扱う想定。
  */
 @Service
 class FootstepRevealDomainService {
@@ -28,33 +25,15 @@ class FootstepRevealDomainService {
     fun shouldRevealOwner(
         village: Village,
         myself: VillageParticipant?,
-        footstep: Footstep,
+        @Suppress("UNUSED_PARAMETER") footstep: Footstep,
     ): Boolean {
+        // 1) settled (エピローグ / 終了) なら全員に対し全公開
         if (village.status.isSettled()) return true
-        if (!village.status.isProgress()) return false
-        // 進行中
-        myself ?: return false
-        if (myself.charaId == footstep.registerCharaId) return true
-        val owner = village.allParticipants().list
-            .firstOrNull { it.charaId == footstep.registerCharaId }
-            ?: return false
-        return isSameTeam(myself, owner)
-    }
-
-    private fun isSameTeam(viewer: VillageParticipant, owner: VillageParticipant): Boolean {
-        if (viewer.isViewableWerewolfSay() && owner.isViewableWerewolfSay()) return true
-        if (viewer.isViewableSympathizeSay() && owner.isViewableSympathizeSay()) return true
-        if (viewer.isViewableTelepathy() && owner.isViewableTelepathy()) return true
-        if (isSameLoverPair(viewer, owner)) return true
+        // 2) 進行中でも、墓下開示村で自分が dead / 見学なら全公開
+        //    (既存 SpoilerDomainService.isViewableSpoilerContent の "myself 側" と整合)
+        val isOpenSkillInGrave = village.setting.rule.isOpenSkillInGrave
+        if (myself?.isViewableSpoilerContent(isOpenSkillInGrave) == true) return true
+        // 3) それ以外は匿名 (自分の足音であっても、人狼であっても同じ)
         return false
-    }
-
-    /**
-     * 恋絆 (loverIdList) で直接結ばれているか。耳年増 (`isViewableLoversSay` skill check) は
-     * 恋人ではないため per-pair の対象外で、足音は隠したままにする。
-     */
-    private fun isSameLoverPair(viewer: VillageParticipant, owner: VillageParticipant): Boolean {
-        return viewer.status.loverIdList.contains(owner.id) ||
-                owner.status.loverIdList.contains(viewer.id)
     }
 }

--- a/backend/src/main/kotlin/com/ort/app/domain/service/footstep/FootstepRevealDomainService.kt
+++ b/backend/src/main/kotlin/com/ort/app/domain/service/footstep/FootstepRevealDomainService.kt
@@ -25,6 +25,8 @@ class FootstepRevealDomainService {
     fun shouldRevealOwner(
         village: Village,
         myself: VillageParticipant?,
+        // 現状は per-footstep の判定要素は無いが、将来「特定の役職が他人の足音を見られる」等の
+        // 拡張時に footstep 単位の情報 (登録者など) を参照できるようにシグネチャを保持する。
         @Suppress("UNUSED_PARAMETER") footstep: Footstep,
     ): Boolean {
         // 1) settled (エピローグ / 終了) なら全員に対し全公開

--- a/backend/src/test/kotlin/com/ort/app/domain/service/footstep/FootstepRevealDomainServiceTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/domain/service/footstep/FootstepRevealDomainServiceTest.kt
@@ -94,6 +94,19 @@ class FootstepRevealDomainServiceTest {
     }
 
     @Test
+    fun `進行中、墓下開示村で見学者の viewer にも全公開`() {
+        val baseVillage = createDay1Village()
+        val openVillage = baseVillage.copy(
+            setting = baseVillage.setting.copy(rule = baseVillage.setting.rule.copy(isOpenSkillInGrave = true))
+        )
+        val villager = openVillage.participants.list.first { it.skill?.toCdef() == CDef.Skill.村人 }
+        val spectatorViewer = villager.copy(isSpectator = true)
+        val wolf = openVillage.participants.list.first { it.skill?.toCdef() == CDef.Skill.人狼 }
+        val footstep = Footstep(day = 1, charaId = wolf.charaId, roomNumbers = "10,11")
+        assertTrue(service.shouldRevealOwner(openVillage, myself = spectatorViewer, footstep = footstep))
+    }
+
+    @Test
     fun `進行中、isOpenSkillInGrave=false の村では dead viewer でも匿名 (既存挙動)`() {
         // createDay1Village の rule は isOpenSkillInGrave=false がデフォルト
         val village = createDay1Village()

--- a/backend/src/test/kotlin/com/ort/app/domain/service/footstep/FootstepRevealDomainServiceTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/domain/service/footstep/FootstepRevealDomainServiceTest.kt
@@ -13,107 +13,94 @@ class FootstepRevealDomainServiceTest {
 
     private val service = FootstepRevealDomainService()
 
-    // ---------- 募集中 ----------
-
+    // 募集中はそもそも足音が存在しないので controller 側で空リスト返却するが、
+    // 念のため "進行中でないなら必ず false" な挙動を検証する。
     @Test
-    fun `募集中はそもそも未登録なので呼ばれても false を返す`() {
+    fun `募集中は誰に対しても false`() {
         val village = createPrologueVillage()
         val footstep = Footstep(day = 0, charaId = 1, roomNumbers = "なし")
-        // 参加者がいないので myself = null
         assertFalse(service.shouldRevealOwner(village, myself = null, footstep = footstep))
     }
 
-    // ---------- エピローグ / 終了 ----------
+    // ---------- settled (エピローグ / 終了) は全公開 ----------
 
     @Test
     fun `エピローグでは未参加者でも全公開される`() {
-        val village = createDay1Village().let { it.copy(status = CDef.VillageStatus.エピローグ.toModel()) }
+        val village = createDay1Village().copy(status = CDef.VillageStatus.エピローグ.toModel())
         val footstep = Footstep(day = 1, charaId = 3, roomNumbers = "01,02")
         assertTrue(service.shouldRevealOwner(village, myself = null, footstep = footstep))
     }
 
     @Test
     fun `終了では未参加者でも全公開される`() {
-        val village = createDay1Village().let { it.copy(status = CDef.VillageStatus.終了.toModel()) }
+        val village = createDay1Village().copy(status = CDef.VillageStatus.終了.toModel())
         val footstep = Footstep(day = 1, charaId = 3, roomNumbers = "01,02")
         assertTrue(service.shouldRevealOwner(village, myself = null, footstep = footstep))
     }
 
-    // ---------- 進行中 ----------
+    // ---------- 進行中は alive viewer に対しては常に匿名 ----------
 
     @Test
-    fun `進行中、自分の足音は開示される`() {
+    fun `進行中、自分の足音であっても匿名扱い (既存挙動と一致)`() {
         val village = createDay1Village()
-        // organize "村狼狼狼魔狐賢導狩共共霊霊霊霊霊霊" の先頭 = 村 (id=2)
         val myself = village.participants.list.first { it.skill?.toCdef() == CDef.Skill.村人 }
         val footstep = Footstep(day = 1, charaId = myself.charaId, roomNumbers = "01,02")
-        assertTrue(service.shouldRevealOwner(village, myself = myself, footstep = footstep))
+        assertFalse(service.shouldRevealOwner(village, myself = myself, footstep = footstep))
     }
 
     @Test
-    fun `進行中、他人 (異陣営) の足音は隠蔽される`() {
-        val village = createDay1Village()
-        val villager = village.participants.list.first { it.skill?.toCdef() == CDef.Skill.村人 }
-        val wolf = village.participants.list.first { it.skill?.toCdef() == CDef.Skill.人狼 }
-        val footstep = Footstep(day = 1, charaId = wolf.charaId, roomNumbers = "03,04")
-        assertFalse(service.shouldRevealOwner(village, myself = villager, footstep = footstep))
-    }
-
-    @Test
-    fun `進行中、同じ人狼陣営の足音は開示される (チーム共有)`() {
+    fun `進行中、人狼から見ても他人の足音は匿名 (team共有しない)`() {
         val village = createDay1Village()
         val wolves = village.participants.list.filter { it.skill?.toCdef() == CDef.Skill.人狼 }
-        // 2 匹以上の人狼がいる前提 (createDay1Village の organize に "狼狼狼" を含む)
         val viewer = wolves[0]
-        val other = wolves[1]
-        val footstep = Footstep(day = 1, charaId = other.charaId, roomNumbers = "05,06")
-        assertTrue(service.shouldRevealOwner(village, myself = viewer, footstep = footstep))
+        val otherWolf = wolves[1]
+        val footstep = Footstep(day = 1, charaId = otherWolf.charaId, roomNumbers = "05,06")
+        assertFalse(service.shouldRevealOwner(village, myself = viewer, footstep = footstep))
     }
 
     @Test
-    fun `進行中、未ログイン (myself null) の閲覧者には他人の足音は隠蔽される`() {
+    fun `進行中、未ログイン (myself null) でも匿名`() {
         val village = createDay1Village()
         val any = village.participants.list.first()
         val footstep = Footstep(day = 1, charaId = any.charaId, roomNumbers = "07")
         assertFalse(service.shouldRevealOwner(village, myself = null, footstep = footstep))
     }
 
-    @Test
-    fun `進行中、共鳴者は他の共鳴者の足音を見られる`() {
-        val village = createDay1Village()
-        val sympathizers = village.participants.list.filter { it.skill?.toCdef() == CDef.Skill.共鳴者 }
-        val viewer = sympathizers[0]
-        val other = sympathizers[1]
-        val footstep = Footstep(day = 1, charaId = other.charaId, roomNumbers = "08,09")
-        assertTrue(service.shouldRevealOwner(village, myself = viewer, footstep = footstep))
-    }
+    // ---------- 進行中、墓下開示村 + 自分が dead / 見学なら全公開 ----------
 
     @Test
-    fun `進行中、恋絆で結ばれていない参加者の足音は隠蔽される (耳年増は per-pair 対象外)`() {
-        // どの参加者にも loverIdList を仕込んでいないので、恋人扱いの組は無い。
-        val village = createDay1Village()
-        val viewer = village.participants.list.first { it.skill?.toCdef() == CDef.Skill.村人 }
-        val other = village.participants.list.first { it.skill?.toCdef() == CDef.Skill.妖狐 }
-        val footstep = Footstep(day = 1, charaId = other.charaId, roomNumbers = "10,11")
-        assertFalse(service.shouldRevealOwner(village, myself = viewer, footstep = footstep))
-    }
-
-    @Test
-    fun `進行中、registerCharaId と charaId が異なる偽装足音でも、登録者基準で開示判定される`() {
-        val village = createDay1Village()
-        val wolves = village.participants.list.filter { it.skill?.toCdef() == CDef.Skill.人狼 }
-        val registerWolf = wolves[0]
-        val villager = village.participants.list.first { it.skill?.toCdef() == CDef.Skill.村人 }
-        // 人狼が村人として偽装した足音
-        val disguised = Footstep(
-            day = 1,
-            registerCharaId = registerWolf.charaId,
-            charaId = villager.charaId,
-            roomNumbers = "12,13",
+    fun `進行中、墓下開示村で自分が死亡している viewer には全公開`() {
+        val baseVillage = createDay1Village()
+        val openVillage = baseVillage.copy(
+            setting = baseVillage.setting.copy(rule = baseVillage.setting.rule.copy(isOpenSkillInGrave = true))
         )
-        // 別の人狼 viewer は登録者 (人狼陣営) を見られる
-        assertTrue(service.shouldRevealOwner(village, myself = wolves[1], footstep = disguised))
-        // 村人 viewer は隠蔽 (登録者基準で別陣営)
-        assertFalse(service.shouldRevealOwner(village, myself = villager, footstep = disguised))
+        val villager = openVillage.participants.list.first { it.skill?.toCdef() == CDef.Skill.村人 }
+        val deadViewer = villager.execute(day = 1)
+        val wolf = openVillage.participants.list.first { it.skill?.toCdef() == CDef.Skill.人狼 }
+        val footstep = Footstep(day = 1, charaId = wolf.charaId, roomNumbers = "03,04")
+        assertTrue(service.shouldRevealOwner(openVillage, myself = deadViewer, footstep = footstep))
+    }
+
+    @Test
+    fun `進行中、墓下開示村でも alive viewer は匿名のまま`() {
+        val baseVillage = createDay1Village()
+        val openVillage = baseVillage.copy(
+            setting = baseVillage.setting.copy(rule = baseVillage.setting.rule.copy(isOpenSkillInGrave = true))
+        )
+        val aliveViewer = openVillage.participants.list.first { it.skill?.toCdef() == CDef.Skill.村人 }
+        val wolf = openVillage.participants.list.first { it.skill?.toCdef() == CDef.Skill.人狼 }
+        val footstep = Footstep(day = 1, charaId = wolf.charaId, roomNumbers = "03,04")
+        assertFalse(service.shouldRevealOwner(openVillage, myself = aliveViewer, footstep = footstep))
+    }
+
+    @Test
+    fun `進行中、isOpenSkillInGrave=false の村では dead viewer でも匿名 (既存挙動)`() {
+        // createDay1Village の rule は isOpenSkillInGrave=false がデフォルト
+        val village = createDay1Village()
+        val villager = village.participants.list.first { it.skill?.toCdef() == CDef.Skill.村人 }
+        val deadViewer = villager.execute(day = 1)
+        val wolf = village.participants.list.first { it.skill?.toCdef() == CDef.Skill.人狼 }
+        val footstep = Footstep(day = 1, charaId = wolf.charaId, roomNumbers = "08,09")
+        assertFalse(service.shouldRevealOwner(village, myself = deadViewer, footstep = footstep))
     }
 }


### PR DESCRIPTION
## Summary

Step 6 (PR #13) で導入した \`FootstepRevealDomainService.isSameTeam\` は plan.md の「同陣営の足音はチーム共有」記述に引きずられた誤実装でした。既存の \`FootstepDomainService.convertToSituation\` を再確認したところ team-share は行っておらず、進行中は **全員 (人狼を含む alive 参加者・未参加者・自分自身を含めて) 匿名表示** が正しい挙動です。

### 既存挙動の根拠

\`FootstepDomainService.convertToSituation\` (backend/src/main/kotlin/com/ort/app/domain/service/FootstepDomainService.kt:17-31) の分岐は \`spoilerDomainService.isViewableSpoilerContent(village, myself)\` のみで判定:

- true (= \`village.status.isSettled()\` または \`isOpenSkillInGrave + dead/見学\`): \`getDisplayFootstepStringOpenSkill\` で全公開
- false: \`getDisplayFootstepStringWithoutHeader\` で「部屋XXで足音が聞こえた…」のみ、匿名

つまり人狼 viewer であれ自分の足音であれ進行中は全部匿名。

### 修正

- \`FootstepRevealDomainService.shouldRevealOwner\` を simplify
  - \`settled\` (エピローグ / 終了) なら true
  - 進行中・墓下開示村で自分が dead / 見学なら true
  - それ以外は false
- \`isSameTeam\` / \`isSameLoverPair\` の private fn を削除
- service テストを「自分の足音も匿名」「人狼から人狼も匿名」「dead viewer + 墓下開示なら全公開」「dead viewer + 墓下非開示なら匿名」等のケースに再構成 (9 件)
- VillageDetailRestController と DTO の shape は変更なし、frontend 影響なし

能力フォーム / 行使履歴で自分の登録足音を見たい用途 (探偵の調査結果や、夢遊病者が自分の通った場所を見られない、など) は別レイヤとして Step 7 の ability endpoint で扱う想定 (\`.issues/3\` に明記)。

## Test plan

- [x] \`cd backend && ./gradlew test\` (全 PASS、FootstepRevealDomainServiceTest 9 件 / VillageDetailRestControllerTest 5 件)
- [x] \`cd frontend && pnpm typecheck\` (DTO shape 不変なので影響なし)
- [ ] pr-reviewer サブエージェントでレビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)