### PR TITLE
Step 8a: 村画面 参加系 UI (入村/退村/見学切替/希望役職変更)

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/response/village/VillageSettingsView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/village/VillageSettingsView.kt
@@ -18,6 +18,12 @@ data class VillageSettingsView(
     val joinPasswordRequired: Boolean,
     @field:Schema(description = "オリジナルキャラチップの村か")
     val isOriginalCharachip: Boolean,
+    @field:Schema(description = "村が参照しているキャラチップ ID 一覧 (selectableCharas エンドポイント呼出に使用)")
+    val charachipIds: List<Int>,
+    @field:Schema(description = "希望役職指定が可能な村か")
+    val isSkillRequestAvailable: Boolean,
+    @field:Schema(description = "見学参加が可能な村か")
+    val isSpectateAvailable: Boolean,
 ) {
     constructor(village: Village) : this(
         personMin = village.setting.personMin,
@@ -26,5 +32,8 @@ data class VillageSettingsView(
         dayChangeIntervalSeconds = village.setting.dayChangeIntervalSeconds,
         joinPasswordRequired = !village.setting.joinPassword.isNullOrEmpty(),
         isOriginalCharachip = village.setting.chara.isOriginalCharachip,
+        charachipIds = village.setting.chara.charachipIds,
+        isSkillRequestAvailable = village.setting.rule.isPossibleSkillRequest,
+        isSpectateAvailable = village.setting.rule.isAvailableSpectate,
     )
 }

--- a/backend/src/main/kotlin/com/ort/app/api/response/village/VillageView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/village/VillageView.kt
@@ -1,5 +1,6 @@
 package com.ort.app.api.response.village
 
+import com.ort.app.api.response.skill.SkillView
 import com.ort.app.domain.model.village.Village
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
@@ -38,6 +39,11 @@ data class VillageView(
     val isCreator: Boolean,
     @field:Schema(description = "閲覧者が参加 (見学含む) しているか")
     val isParticipating: Boolean,
+    @field:Schema(
+        description = "プロローグで希望役職に指定できる役職一覧。" +
+                "isSkillRequestAvailable=false の村では空リスト。"
+    )
+    val requestableSkills: List<SkillView>,
 ) {
     constructor(
         village: Village,
@@ -61,5 +67,8 @@ data class VillageView(
         participants = participants,
         isCreator = isCreator,
         isParticipating = isParticipating,
+        requestableSkills = if (village.setting.rule.isPossibleSkillRequest) {
+            village.allRequestableSkillList().map { SkillView(it) }
+        } else emptyList(),
     )
 }

--- a/backend/src/main/kotlin/com/ort/app/api/response/village/VillageView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/village/VillageView.kt
@@ -40,8 +40,10 @@ data class VillageView(
     @field:Schema(description = "閲覧者が参加 (見学含む) しているか")
     val isParticipating: Boolean,
     @field:Schema(
-        description = "プロローグで希望役職に指定できる役職一覧。" +
-                "isSkillRequestAvailable=false の村では空リスト。"
+        description = "希望役職に指定できる役職一覧。" +
+                "isSkillRequestAvailable=false (希望役職指定不可) の村では空リスト、" +
+                "それ以外なら村ステータスによらず常に同じ非空のリストを返す。" +
+                "実際の希望変更操作はプロローグ中のみ受け付けられる点に注意。"
     )
     val requestableSkills: List<SkillView>,
 ) {

--- a/backend/src/test/kotlin/com/ort/app/api/v1/villages/VillageDetailRestControllerTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/api/v1/villages/VillageDetailRestControllerTest.kt
@@ -32,6 +32,7 @@ import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfig
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.hamcrest.Matchers.greaterThan
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
@@ -87,10 +88,10 @@ class VillageDetailRestControllerTest {
             .andExpect(jsonPath("$.isCreator").value(false))
             // 入村系 UI が必要とする補助情報
             .andExpect(jsonPath("$.settings.charachipIds").isArray)
-            .andExpect(jsonPath("$.settings.isSkillRequestAvailable").isBoolean)
+            .andExpect(jsonPath("$.settings.isSkillRequestAvailable").value(true))
             .andExpect(jsonPath("$.settings.isSpectateAvailable").isBoolean)
-            // 希望役職指定可な村は requestableSkills が空でない
-            .andExpect(jsonPath("$.requestableSkills").isArray)
+            // 希望役職指定可 (isPossibleSkillRequest=true) なテスト fixture では非空
+            .andExpect(jsonPath("$.requestableSkills.length()").value(greaterThan(0)))
     }
 
     @Test

--- a/backend/src/test/kotlin/com/ort/app/api/v1/villages/VillageDetailRestControllerTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/api/v1/villages/VillageDetailRestControllerTest.kt
@@ -85,6 +85,12 @@ class VillageDetailRestControllerTest {
             .andExpect(jsonPath("$.statusCode").value(CDef.VillageStatus.募集中.code()))
             .andExpect(jsonPath("$.isParticipating").value(false))
             .andExpect(jsonPath("$.isCreator").value(false))
+            // 入村系 UI が必要とする補助情報
+            .andExpect(jsonPath("$.settings.charachipIds").isArray)
+            .andExpect(jsonPath("$.settings.isSkillRequestAvailable").isBoolean)
+            .andExpect(jsonPath("$.settings.isSpectateAvailable").isBoolean)
+            // 希望役職指定可な村は requestableSkills が空でない
+            .andExpect(jsonPath("$.requestableSkills").isArray)
     }
 
     @Test

--- a/frontend/app/features/village/detail/ParticipateActions.tsx
+++ b/frontend/app/features/village/detail/ParticipateActions.tsx
@@ -1,0 +1,439 @@
+import { useState } from "react";
+import {
+  useChangeRequestSkillMutation,
+  useLeaveMutation,
+  useParticipateMutation,
+  useSelectableCharasQuery,
+  useSwitchParticipateMutation,
+} from "./hooks";
+import type {
+  CharaView,
+  MyselfView,
+  VillageView,
+} from "./api";
+
+/**
+ * プロローグ中の参加系操作 UI。
+ *
+ * - 未参加 (myself=null): 入村フォーム (キャラ選択 / 希望役職 / メッセージ / 入村パスワード / 見学トグル)
+ * - 参加中: 「参加/見学切替」「希望役職変更」「退村」アクション
+ *
+ * オリジナルキャラチップ村 (`isOriginalCharachip=true`) は multipart 入村 endpoint 未実装のため、
+ * 入村 UI は出さず案内テキストのみ表示する。
+ */
+export function ParticipateActions({
+  village,
+  myself,
+}: {
+  village: VillageView;
+  myself: MyselfView | null;
+}) {
+  // プロローグでないなら参加系操作はそもそも出さない (能力 / 投票等は別 UI 担当)
+  // CDef.VillageStatus.募集中 のコードは "IN_PREPARATION"。
+  if (village.statusCode !== "IN_PREPARATION") return null;
+
+  if (myself == null) {
+    return <ParticipateForm village={village} />;
+  }
+  return <ParticipatingActions village={village} myself={myself} />;
+}
+
+// ---------- 未参加 → 入村フォーム ----------
+
+function ParticipateForm({ village }: { village: VillageView }) {
+  const { settings, requestableSkills } = village;
+
+  // hooks のルール上、early return より前にすべての hook を呼び出す必要がある。
+  // オリジナルキャラチップ村では下で fetch 結果を使わないため、enabled=false 相当として
+  // charachipId に null を渡す (useSelectableCharasQuery 側で disabled になる)。
+  const charachipId = settings.isOriginalCharachip ? null : settings.charachipIds[0] ?? null;
+  const charasQuery = useSelectableCharasQuery(village.id, charachipId);
+
+  const mutation = useParticipateMutation(village.id);
+
+  const [charaId, setCharaId] = useState<number | null>(null);
+  const [charaName, setCharaName] = useState("");
+  const [charaShortName, setCharaShortName] = useState("");
+  const [joinMessage, setJoinMessage] = useState("");
+  const [joinPassword, setJoinPassword] = useState("");
+  const [spectator, setSpectator] = useState(false);
+  const [requestedSkill, setRequestedSkill] = useState<string>("");
+  const [secondRequestedSkill, setSecondRequestedSkill] = useState<string>("");
+
+  if (settings.isOriginalCharachip) {
+    return (
+      <Panel title="入村">
+        <p className="text-slate-400 text-sm">
+          オリジナルキャラチップ村への入村は現在この画面では未対応です (旧画面 / API 拡張 予定)。
+        </p>
+      </Panel>
+    );
+  }
+
+  function onSelectChara(id: number) {
+    setCharaId(id);
+    const c = charasQuery.data?.find((x) => x.id === id);
+    if (c) {
+      setCharaName((prev) => prev || c.name);
+      setCharaShortName((prev) => prev || c.shortName);
+    }
+  }
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (charaId == null) return;
+    if (!charaName.trim() || !charaShortName.trim() || !joinMessage.trim()) return;
+    mutation.mutate({
+      charaId,
+      charaName: charaName.trim(),
+      charaShortName: charaShortName.trim(),
+      joinMessage: joinMessage.trim(),
+      // 希望役職指定不可な村では送らない (backend 側で空文字 / おまかせは許容するが、送らないのが明確)
+      requestedSkill: settings.isSkillRequestAvailable && requestedSkill ? requestedSkill : undefined,
+      secondRequestedSkill:
+        settings.isSkillRequestAvailable && secondRequestedSkill ? secondRequestedSkill : undefined,
+      joinPassword: settings.joinPasswordRequired ? joinPassword : undefined,
+      spectator,
+    });
+  }
+
+  const charas = charasQuery.data ?? [];
+  const isLoadingCharas = charasQuery.isLoading;
+  const submittable =
+    charaId != null &&
+    charaName.trim().length > 0 &&
+    charaShortName.trim().length === 1 &&
+    joinMessage.trim().length > 0 &&
+    !mutation.isPending;
+
+  return (
+    <Panel title="入村">
+      <form onSubmit={submit} className="space-y-3">
+        <Field label="キャラ">
+          {isLoadingCharas ? (
+            <p className="text-slate-400 text-sm">読み込み中...</p>
+          ) : charas.length === 0 ? (
+            <p className="text-slate-400 text-sm">選択可能なキャラがいません</p>
+          ) : (
+            <CharaGrid charas={charas} selectedId={charaId} onSelect={onSelectChara} />
+          )}
+        </Field>
+
+        <Field label="表示名">
+          <input
+            type="text"
+            value={charaName}
+            onChange={(e) => setCharaName(e.target.value)}
+            maxLength={40}
+            className={inputClass}
+            placeholder="キャラ名 (40 文字以内)"
+            disabled={mutation.isPending}
+          />
+        </Field>
+
+        <Field label="略称 (1 文字)">
+          <input
+            type="text"
+            value={charaShortName}
+            onChange={(e) => setCharaShortName(e.target.value)}
+            maxLength={1}
+            className={`${inputClass} w-24`}
+            disabled={mutation.isPending}
+          />
+        </Field>
+
+        {settings.isSkillRequestAvailable && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <Field label="希望役職 (第一)">
+              <SkillSelect
+                value={requestedSkill}
+                onChange={setRequestedSkill}
+                options={requestableSkills}
+                disabled={mutation.isPending}
+              />
+            </Field>
+            <Field label="希望役職 (第二)">
+              <SkillSelect
+                value={secondRequestedSkill}
+                onChange={setSecondRequestedSkill}
+                options={requestableSkills}
+                disabled={mutation.isPending}
+              />
+            </Field>
+          </div>
+        )}
+
+        <Field label="入村メッセージ">
+          <textarea
+            value={joinMessage}
+            onChange={(e) => setJoinMessage(e.target.value)}
+            rows={3}
+            className={inputClass}
+            placeholder="挨拶など (発言扱い)"
+            disabled={mutation.isPending}
+          />
+        </Field>
+
+        {settings.joinPasswordRequired && (
+          <Field label="入村パスワード">
+            <input
+              type="password"
+              value={joinPassword}
+              onChange={(e) => setJoinPassword(e.target.value)}
+              className={inputClass}
+              disabled={mutation.isPending}
+              autoComplete="off"
+            />
+          </Field>
+        )}
+
+        {settings.isSpectateAvailable && (
+          <label className="flex items-center gap-2 text-sm text-slate-200">
+            <input
+              type="checkbox"
+              checked={spectator}
+              onChange={(e) => setSpectator(e.target.checked)}
+              disabled={mutation.isPending}
+            />
+            見学として参加する
+          </label>
+        )}
+
+        <div className="flex items-center gap-3">
+          <button
+            type="submit"
+            disabled={!submittable}
+            className={primaryButtonClass}
+          >
+            {mutation.isPending ? "送信中..." : spectator ? "見学する" : "入村する"}
+          </button>
+          {mutation.isError && (
+            <span className="text-xs text-rose-300">{mutation.error.message}</span>
+          )}
+        </div>
+      </form>
+    </Panel>
+  );
+}
+
+function CharaGrid({
+  charas,
+  selectedId,
+  onSelect,
+}: {
+  charas: CharaView[];
+  selectedId: number | null;
+  onSelect: (id: number) => void;
+}) {
+  return (
+    <ul className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+      {charas.map((c) => {
+        const isSelected = c.id === selectedId;
+        return (
+          <li key={c.id}>
+            <button
+              type="button"
+              onClick={() => onSelect(c.id)}
+              className={`w-full text-left p-2 rounded border text-sm transition ${
+                isSelected
+                  ? "border-indigo-400 bg-indigo-500/20"
+                  : "border-slate-700 hover:border-slate-500 bg-slate-900/40"
+              }`}
+            >
+              <span className="font-medium">{c.name}</span>
+              <span className="ml-2 text-xs text-slate-400">[{c.shortName}]</span>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+// ---------- 参加中 → 切替 / 希望変更 / 退村 ----------
+
+function ParticipatingActions({
+  village,
+  myself,
+}: {
+  village: VillageView;
+  myself: MyselfView;
+}) {
+  return (
+    <Panel title="参加状態の操作">
+      <div className="space-y-3">
+        {village.settings.isSpectateAvailable && <SwitchParticipateButton villageId={village.id} isSpectator={myself.isSpectator} />}
+        {village.settings.isSkillRequestAvailable && !myself.isSpectator && (
+          <ChangeRequestSkillForm village={village} myself={myself} />
+        )}
+        {!village.isCreator && <LeaveButton villageId={village.id} />}
+        {village.isCreator && (
+          <p className="text-xs text-slate-500">
+            村建ては退村できません (廃村は別途 admin 画面で操作)。
+          </p>
+        )}
+      </div>
+    </Panel>
+  );
+}
+
+function SwitchParticipateButton({
+  villageId,
+  isSpectator,
+}: {
+  villageId: number;
+  isSpectator: boolean;
+}) {
+  const mutation = useSwitchParticipateMutation(villageId);
+  return (
+    <div className="flex items-center gap-3">
+      <button
+        type="button"
+        onClick={() => mutation.mutate()}
+        disabled={mutation.isPending}
+        className={secondaryButtonClass}
+      >
+        {isSpectator ? "参加者になる" : "見学者になる"}
+      </button>
+      {mutation.isError && (
+        <span className="text-xs text-rose-300">{mutation.error.message}</span>
+      )}
+    </div>
+  );
+}
+
+function ChangeRequestSkillForm({
+  village,
+  myself,
+}: {
+  village: VillageView;
+  myself: MyselfView;
+}) {
+  const mutation = useChangeRequestSkillMutation(village.id);
+  // 既存希望は myself に乗っていない (skill は確定後のもの) ので空からスタート
+  const [requestedSkill, setRequestedSkill] = useState<string>("");
+  const [secondRequestedSkill, setSecondRequestedSkill] = useState<string>("");
+
+  // 参加直後の myself.skill は未確定 (null)。役職確定後は変更させない。
+  if (myself.skill != null) return null;
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!requestedSkill || !secondRequestedSkill) return;
+    mutation.mutate({ requestedSkill, secondRequestedSkill });
+  }
+
+  const submittable = requestedSkill && secondRequestedSkill && !mutation.isPending;
+
+  return (
+    <form onSubmit={submit} className="space-y-2 border-t border-slate-700/60 pt-3">
+      <p className="text-xs text-slate-400">希望役職変更</p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        <SkillSelect
+          value={requestedSkill}
+          onChange={setRequestedSkill}
+          options={village.requestableSkills}
+          disabled={mutation.isPending}
+        />
+        <SkillSelect
+          value={secondRequestedSkill}
+          onChange={setSecondRequestedSkill}
+          options={village.requestableSkills}
+          disabled={mutation.isPending}
+        />
+      </div>
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={!submittable}
+          className={secondaryButtonClass}
+        >
+          {mutation.isPending ? "送信中..." : "希望を反映"}
+        </button>
+        {mutation.isError && (
+          <span className="text-xs text-rose-300">{mutation.error.message}</span>
+        )}
+      </div>
+    </form>
+  );
+}
+
+function LeaveButton({ villageId }: { villageId: number }) {
+  const mutation = useLeaveMutation(villageId);
+  function onClick() {
+    if (!confirm("退村しますか？")) return;
+    mutation.mutate();
+  }
+  return (
+    <div className="flex items-center gap-3 border-t border-slate-700/60 pt-3">
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={mutation.isPending}
+        className="rounded bg-rose-600 hover:bg-rose-500 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium"
+      >
+        {mutation.isPending ? "送信中..." : "退村する"}
+      </button>
+      {mutation.isError && (
+        <span className="text-xs text-rose-300">{mutation.error.message}</span>
+      )}
+    </div>
+  );
+}
+
+// ---------- 部品 ----------
+
+function Panel({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
+      <h2 className="text-sm text-slate-400 mb-3">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1">
+      <label className="text-xs text-slate-400">{label}</label>
+      {children}
+    </div>
+  );
+}
+
+function SkillSelect({
+  value,
+  onChange,
+  options,
+  disabled,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  options: Array<{ code: string; name: string }>;
+  disabled?: boolean;
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className={inputClass}
+      disabled={disabled}
+    >
+      <option value="">(おまかせ)</option>
+      {options.map((s) => (
+        <option key={s.code} value={s.code}>
+          {s.name}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+const inputClass =
+  "w-full bg-slate-900 border border-slate-700 rounded px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:outline-none focus:border-indigo-500 disabled:opacity-50";
+
+const primaryButtonClass =
+  "rounded bg-indigo-500 hover:bg-indigo-400 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium";
+
+const secondaryButtonClass =
+  "rounded bg-slate-700 hover:bg-slate-600 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium";

--- a/frontend/app/features/village/detail/ParticipateActions.tsx
+++ b/frontend/app/features/village/detail/ParticipateActions.tsx
@@ -44,10 +44,10 @@ function ParticipateForm({ village }: { village: VillageView }) {
   const { settings, requestableSkills } = village;
 
   // hooks のルール上、early return より前にすべての hook を呼び出す必要がある。
-  // オリジナルキャラチップ村では下で fetch 結果を使わないため、enabled=false 相当として
-  // charachipId に null を渡す (useSelectableCharasQuery 側で disabled になる)。
-  const charachipId = settings.isOriginalCharachip ? null : settings.charachipIds[0] ?? null;
-  const charasQuery = useSelectableCharasQuery(village.id, charachipId);
+  // オリジナルキャラチップ村ではキャラ一覧 fetch を発行しない (空配列)。
+  // 通常村は複数キャラチップを持つことがあるので、全 ID に対して並列クエリして結合する。
+  const charachipIds = settings.isOriginalCharachip ? [] : settings.charachipIds;
+  const charasQuery = useSelectableCharasQuery(village.id, charachipIds);
 
   const mutation = useParticipateMutation(village.id);
 
@@ -97,13 +97,16 @@ function ParticipateForm({ village }: { village: VillageView }) {
     });
   }
 
-  const charas = charasQuery.data ?? [];
+  const charas = charasQuery.data;
   const isLoadingCharas = charasQuery.isLoading;
+  // backend の MessageContent.assertMessageRestrict はプロローグでは early return するため、
+  // 入村メッセージの長さ上限を frontend で吸収する (旧 Thymeleaf も同様に 400 文字制限)。
   const submittable =
     charaId != null &&
     charaName.trim().length > 0 &&
     charaShortName.trim().length === 1 &&
     joinMessage.trim().length > 0 &&
+    joinMessage.length <= MESSAGE_MAX_LENGTH &&
     !mutation.isPending;
 
   return (
@@ -164,14 +167,20 @@ function ParticipateForm({ village }: { village: VillageView }) {
         )}
 
         <Field label="入村メッセージ">
-          <textarea
-            value={joinMessage}
-            onChange={(e) => setJoinMessage(e.target.value)}
-            rows={3}
-            className={inputClass}
-            placeholder="挨拶など (発言扱い)"
-            disabled={mutation.isPending}
-          />
+          <div className="space-y-1">
+            <textarea
+              value={joinMessage}
+              onChange={(e) => setJoinMessage(e.target.value)}
+              rows={3}
+              maxLength={MESSAGE_MAX_LENGTH}
+              className={inputClass}
+              placeholder={`挨拶など (発言扱い、${MESSAGE_MAX_LENGTH} 文字以内)`}
+              disabled={mutation.isPending}
+            />
+            <p className="text-xs text-slate-500 text-right">
+              {joinMessage.length} / {MESSAGE_MAX_LENGTH}
+            </p>
+          </div>
         </Field>
 
         {settings.joinPasswordRequired && (
@@ -259,10 +268,14 @@ function ParticipatingActions({
   village: VillageView;
   myself: MyselfView;
 }) {
+  // isSpectateAvailable=false でも、既に見学者になっているプレイヤーには「参加者に戻る」
+  // の動線を残す (将来の設定変更パスで「見学不可だが見学者が存在する」状態が生まれた
+  // 場合の保険)。
+  const showSwitch = village.settings.isSpectateAvailable || myself.isSpectator;
   return (
     <Panel title="参加状態の操作">
       <div className="space-y-3">
-        {village.settings.isSpectateAvailable && <SwitchParticipateButton villageId={village.id} isSpectator={myself.isSpectator} />}
+        {showSwitch && <SwitchParticipateButton villageId={village.id} isSpectator={myself.isSpectator} />}
         {village.settings.isSkillRequestAvailable && !myself.isSpectator && (
           <ChangeRequestSkillForm village={village} myself={myself} />
         )}
@@ -310,7 +323,8 @@ function ChangeRequestSkillForm({
   myself: MyselfView;
 }) {
   const mutation = useChangeRequestSkillMutation(village.id);
-  // 既存希望は myself に乗っていない (skill は確定後のもの) ので空からスタート
+  // 既存希望は myself に乗っていない (skill は確定後のもの) ので空からスタート。
+  // 空文字 ("(おまかせ)") は送信時に OMAKASE_CODE にマップする (backend は NotBlank)。
   const [requestedSkill, setRequestedSkill] = useState<string>("");
   const [secondRequestedSkill, setSecondRequestedSkill] = useState<string>("");
 
@@ -319,11 +333,13 @@ function ChangeRequestSkillForm({
 
   function submit(e: React.FormEvent) {
     e.preventDefault();
-    if (!requestedSkill || !secondRequestedSkill) return;
-    mutation.mutate({ requestedSkill, secondRequestedSkill });
+    mutation.mutate({
+      requestedSkill: requestedSkill || OMAKASE_CODE,
+      secondRequestedSkill: secondRequestedSkill || OMAKASE_CODE,
+    });
   }
 
-  const submittable = requestedSkill && secondRequestedSkill && !mutation.isPending;
+  const submittable = !mutation.isPending;
 
   return (
     <form onSubmit={submit} className="space-y-2 border-t border-slate-700/60 pt-3">
@@ -428,6 +444,18 @@ function SkillSelect({
     </select>
   );
 }
+
+/** 発言系の上限 (旧 Thymeleaf 通常発言フォームと同じ 400 文字)。 */
+const MESSAGE_MAX_LENGTH = 400;
+
+/**
+ * 「おまかせ」役職 (CDef.Skill.おまかせ) のコード。
+ * 入村フォームでは未指定 (undefined) を送れば backend 側で `Skill(おまかせ)` に解決される
+ * (`VillageParticipateRestController.resolveSkill`) が、希望役職変更 endpoint の
+ * `VillageChangeRequestSkillBody` は `@NotBlank` のため、UI で「おまかせ」を選んだ場合は
+ * 明示的にこのコードに変換して送る。
+ */
+const OMAKASE_CODE = "LEFTOVER";
 
 const inputClass =
   "w-full bg-slate-900 border border-slate-700 rounded px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:outline-none focus:border-indigo-500 disabled:opacity-50";

--- a/frontend/app/features/village/detail/api.ts
+++ b/frontend/app/features/village/detail/api.ts
@@ -8,6 +8,8 @@ import { browserFetch, type ApiFetch } from "~/lib/api/client";
 
 export type CharaView = components["schemas"]["CharaView"];
 export type SkillView = components["schemas"]["SkillView"];
+export type VillageParticipateBody = components["schemas"]["VillageParticipateBody"];
+export type VillageChangeRequestSkillBody = components["schemas"]["VillageChangeRequestSkillBody"];
 export type VillageView = components["schemas"]["VillageView"];
 export type VillageSettingsView = components["schemas"]["VillageSettingsView"];
 export type VillageDayView = components["schemas"]["VillageDayView"];
@@ -105,4 +107,95 @@ export async function fetchMyself(
   const text = await res.text();
   if (!text || text === "null") return null;
   return JSON.parse(text) as MyselfView;
+}
+
+/**
+ * GET /api/v1/villages/{id}/participate/selectable-charas?charachipId=...
+ *
+ * 当該村で参加に選べるキャラを返す。複数キャラチップ村の場合は呼び出し側でキャラチップごとに
+ * 並列呼出して結合する想定。失敗時は例外を投げる。
+ */
+export async function fetchSelectableCharas(
+  villageId: number,
+  charachipId: number,
+  fetcher: ApiFetch = browserFetch,
+): Promise<CharaView[]> {
+  const res = await fetcher(
+    `/api/v1/villages/${villageId}/participate/selectable-charas?charachipId=${charachipId}`,
+  );
+  if (!res.ok) throw new Error(`selectable charas fetch failed: ${res.status}`);
+  return res.json();
+}
+
+// ---------- participate mutations ----------
+
+async function readErrorMessage(res: Response): Promise<string> {
+  const errBody = await res.text();
+  try {
+    const parsed = JSON.parse(errBody) as { message?: string };
+    if (parsed.message) return parsed.message;
+  } catch {
+    // not JSON
+  }
+  return errBody;
+}
+
+/** POST /api/v1/villages/{id}/participate */
+export async function postParticipate(
+  villageId: number,
+  body: VillageParticipateBody,
+  fetcher: ApiFetch = browserFetch,
+): Promise<void> {
+  const res = await fetcher(`/api/v1/villages/${villageId}/participate`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`participate failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+}
+
+/**
+ * POST /api/v1/villages/{id}/participate/switch
+ *
+ * プロローグ中の参加 ↔ 見学切替。body 不要。
+ */
+export async function postSwitchParticipate(
+  villageId: number,
+  fetcher: ApiFetch = browserFetch,
+): Promise<void> {
+  const res = await fetcher(`/api/v1/villages/${villageId}/participate/switch`, {
+    method: "POST",
+  });
+  if (!res.ok) {
+    throw new Error(`switch participate failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+}
+
+/** PUT /api/v1/villages/{id}/participate/skill */
+export async function putChangeRequestSkill(
+  villageId: number,
+  body: VillageChangeRequestSkillBody,
+  fetcher: ApiFetch = browserFetch,
+): Promise<void> {
+  const res = await fetcher(`/api/v1/villages/${villageId}/participate/skill`, {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`change request skill failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+}
+
+/** DELETE /api/v1/villages/{id}/participate */
+export async function deleteLeave(
+  villageId: number,
+  fetcher: ApiFetch = browserFetch,
+): Promise<void> {
+  const res = await fetcher(`/api/v1/villages/${villageId}/participate`, {
+    method: "DELETE",
+  });
+  if (!res.ok) {
+    throw new Error(`leave failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
 }

--- a/frontend/app/features/village/detail/hooks.ts
+++ b/frontend/app/features/village/detail/hooks.ts
@@ -1,4 +1,11 @@
-import { useMutation, useQuery, useQueryClient, type UseMutationResult, type UseQueryResult } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
 import {
   deleteLeave,
   fetchMyself,
@@ -101,20 +108,33 @@ function invalidateVillage(queryClient: ReturnType<typeof useQueryClient>, villa
 }
 
 /**
- * GET /api/v1/villages/{id}/participate/selectable-charas
+ * GET /api/v1/villages/{id}/participate/selectable-charas を charachipId ごとに並列発行し、
+ * 全チップのキャラを結合した一覧を返す。複数キャラチップ村に対応するため。
  *
- * 村のキャラチップ ID ごとに 1 クエリ。プロローグ + 未参加時のみ有効化する想定。
+ * - 空配列 → クエリ自体を発行せず `{ data: [], isLoading: false, isError: false }`
+ * - すべてのクエリが完了したら `isLoading=false`、いずれか失敗していれば `isError=true`
+ *
+ * Hooks のルールに従い、useQueries は常に同じ引数構造で呼び出す (charachipIds が
+ * 空のときは queries=[] のまま useQueries を呼ぶ)。
  */
 export function useSelectableCharasQuery(
   villageId: number,
-  charachipId: number | null,
-): UseQueryResult<CharaView[]> {
-  return useQuery<CharaView[]>({
-    queryKey: ["village", villageId, "selectable-charas", charachipId],
-    queryFn: () => fetchSelectableCharas(villageId, charachipId!),
-    enabled: charachipId != null,
-    staleTime: 60_000,
+  charachipIds: number[],
+): { data: CharaView[]; isLoading: boolean; isError: boolean; error?: Error } {
+  const results = useQueries({
+    queries: charachipIds.map((charachipId) => ({
+      queryKey: ["village", villageId, "selectable-charas", charachipId] as const,
+      queryFn: () => fetchSelectableCharas(villageId, charachipId),
+      staleTime: 60_000,
+    })),
   });
+  const isLoading = results.some((r) => r.isLoading);
+  const errorResult = results.find((r) => r.isError);
+  const isError = errorResult != null;
+  const data: CharaView[] = isLoading || isError
+    ? []
+    : results.flatMap((r) => r.data ?? []);
+  return { data, isLoading, isError, error: errorResult?.error ?? undefined };
 }
 
 export function useParticipateMutation(

--- a/frontend/app/features/village/detail/hooks.ts
+++ b/frontend/app/features/village/detail/hooks.ts
@@ -1,14 +1,22 @@
 import { useMutation, useQuery, useQueryClient, type UseMutationResult, type UseQueryResult } from "@tanstack/react-query";
 import {
+  deleteLeave,
   fetchMyself,
+  fetchSelectableCharas,
   fetchVillage,
   fetchVillageFootsteps,
   fetchVillageMessages,
+  postParticipate,
   postSay,
+  postSwitchParticipate,
+  putChangeRequestSkill,
+  type CharaView,
   type MessagesView,
   type MyselfView,
   type SayInput,
+  type VillageChangeRequestSkillBody,
   type VillageFootstepsView,
+  type VillageParticipateBody,
   type VillageView,
 } from "./api";
 
@@ -84,5 +92,65 @@ export function useSayMutation(villageId: number): UseMutationResult<void, Error
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["village", villageId, "messages"] });
     },
+  });
+}
+
+/** 参加系操作後に村ヘッダ / myself / messages を refetch させる共通 invalidator */
+function invalidateVillage(queryClient: ReturnType<typeof useQueryClient>, villageId: number) {
+  queryClient.invalidateQueries({ queryKey: ["village", villageId] });
+}
+
+/**
+ * GET /api/v1/villages/{id}/participate/selectable-charas
+ *
+ * 村のキャラチップ ID ごとに 1 クエリ。プロローグ + 未参加時のみ有効化する想定。
+ */
+export function useSelectableCharasQuery(
+  villageId: number,
+  charachipId: number | null,
+): UseQueryResult<CharaView[]> {
+  return useQuery<CharaView[]>({
+    queryKey: ["village", villageId, "selectable-charas", charachipId],
+    queryFn: () => fetchSelectableCharas(villageId, charachipId!),
+    enabled: charachipId != null,
+    staleTime: 60_000,
+  });
+}
+
+export function useParticipateMutation(
+  villageId: number,
+): UseMutationResult<void, Error, VillageParticipateBody> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, VillageParticipateBody>({
+    mutationFn: (body) => postParticipate(villageId, body),
+    onSuccess: () => invalidateVillage(queryClient, villageId),
+  });
+}
+
+export function useSwitchParticipateMutation(
+  villageId: number,
+): UseMutationResult<void, Error, void> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, void>({
+    mutationFn: () => postSwitchParticipate(villageId),
+    onSuccess: () => invalidateVillage(queryClient, villageId),
+  });
+}
+
+export function useChangeRequestSkillMutation(
+  villageId: number,
+): UseMutationResult<void, Error, VillageChangeRequestSkillBody> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, VillageChangeRequestSkillBody>({
+    mutationFn: (body) => putChangeRequestSkill(villageId, body),
+    onSuccess: () => invalidateVillage(queryClient, villageId),
+  });
+}
+
+export function useLeaveMutation(villageId: number): UseMutationResult<void, Error, void> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, void>({
+    mutationFn: () => deleteLeave(villageId),
+    onSuccess: () => invalidateVillage(queryClient, villageId),
   });
 }

--- a/frontend/app/routes/villages.$id.tsx
+++ b/frontend/app/routes/villages.$id.tsx
@@ -19,6 +19,7 @@ import {
   useVillageMessagesQuery,
   useVillageQuery,
 } from "~/features/village/detail/hooks";
+import { ParticipateActions } from "~/features/village/detail/ParticipateActions";
 import { ssrFetch } from "~/lib/api/client";
 
 export function meta({ data }: Route.MetaArgs) {
@@ -63,6 +64,8 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
         <VillageHeader village={village} />
 
         {myself && <MyselfPanel myself={myself} />}
+
+        <ParticipateActions village={village} myself={myself} />
 
         <ParticipantsPanel participants={village.participants.list} />
 


### PR DESCRIPTION
## Summary

Step 7 で backend を整備した参加系操作 (`POST participate` / `DELETE leave` / `POST participate/switch` / `PUT participate/skill`) に対応する frontend UI を村画面に追加する。Step 8 を複数 PR に分割するうちの最初の一つ。

### backend
- `VillageSettingsView` に `charachipIds` / `isSkillRequestAvailable` / `isSpectateAvailable` を露出 (入村フォームの分岐用)
- `VillageView` に `requestableSkills` を追加。`isSkillRequestAvailable=false` の村では空配列

### frontend
- `api.ts`: `fetchSelectableCharas` と 4 つの mutation (`postParticipate` / `postSwitchParticipate` / `putChangeRequestSkill` / `deleteLeave`)
- `hooks.ts`: 対応 React Query hook。成功時に村 query を invalidate
- `ParticipateActions.tsx` (新規): プロローグ中のみ表示
  - 未参加 → 入村フォーム (キャラ選択 / 表示名 / 略称 / 希望役職 / 入村メッセージ / 入村 PW / 見学トグル)
  - 参加中 → 「見学/参加切替」 + 「希望役職変更」 + 「退村」
- `villages.$id.tsx`: `MyselfPanel` の直下に `ParticipateActions` を挿入

### 既知の制約 (後続 PR で対応予定)
- オリジナルキャラチップ村への入村 multipart endpoint は引き続き未実装 (案内テキストのみ)
- 村建ては退村できないため、`isCreator=true` の場合は退村ボタンを出さず案内のみ
- 希望役職変更フォームは役職確定後 (`myself.skill != null`) は非表示
- `.issues/4-face-types-authz.md` の認可整備は本 PR ではスコープ外 (face-types UI 未実装)

## Test plan
- [x] `./gradlew test` (`VillageDetailRestControllerTest` 含む) で BUILD SUCCESSFUL
- [x] `./gradlew build -x test` で BUILD SUCCESSFUL
- [x] `pnpm gen:api` で新 schema (`VillageParticipateBody`, `requestableSkills`, `charachipIds` 等) が生成されることを確認
- [x] `pnpm typecheck` / `pnpm test` / `pnpm build` パス
- [ ] (ローカル E2E) testuser でログイン → プロローグ村に入村 → 見学切替 → 退村 までの動線
- [ ] 進行中の村 / 終了村で `ParticipateActions` が描画されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)