### PR TITLE
Step 8b: 村画面 能力 / 投票 / コミット UI

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/response/myself/MyselfAbilityView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/myself/MyselfAbilityView.kt
@@ -1,0 +1,56 @@
+package com.ort.app.api.response.myself
+
+import com.ort.app.domain.model.situation.participant.ParticipantAbilitySituation
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "自分の能力状態 (役職別の入力仕様 + 当日の選択状態 + 履歴)")
+data class MyselfAbilityView(
+    @field:Schema(description = "能力を行使できる状態か (進行中 + 生存中 + 行使可能な日)")
+    val canUseAbility: Boolean,
+    @field:Schema(description = "能力種別コード (役職に能力なしなら null)")
+    val typeCode: String?,
+    @field:Schema(description = "能力種別名 (役職に能力なしなら null)")
+    val typeName: String?,
+    @field:Schema(description = "対象候補のキャラ ID 一覧 (襲撃希望の場合は空、襲撃可能対象は別 GET で取る)")
+    val targetCharaIds: List<Int>,
+    @field:Schema(description = "捜査対象の足音候補")
+    val targetFootsteps: List<String>,
+    @field:Schema(description = "選択中の襲撃者キャラ ID (襲撃希望のみ)")
+    val attackerCharaId: Int?,
+    @field:Schema(description = "選択中の対象キャラ ID")
+    val targetCharaId: Int?,
+    @field:Schema(description = "選択中の捜査対象足音 (捜査のみ)")
+    val targetFootstep: String?,
+    @field:Schema(description = "選択中の足音 (徘徊・襲撃希望など)")
+    val footstep: String?,
+    @field:Schema(description = "対象なし (no-target) を許容するか")
+    val isAvailableNoTarget: Boolean,
+    @field:Schema(description = "襲撃者候補のキャラ ID 一覧 (襲撃希望のみ)")
+    val attackerCharaIds: List<Int>,
+    @field:Schema(description = "能力行使履歴")
+    val skillHistoryList: List<String>,
+    @field:Schema(description = "対象指定の前置きメッセージ")
+    val targetPrefixMessage: String?,
+    @field:Schema(description = "対象指定の後置きメッセージ")
+    val targetSuffixMessage: String?,
+    @field:Schema(description = "対象指定と同時に足音を選ぶ能力か (狩人・人狼の襲撃希望など)")
+    val isTargetingAndFootstep: Boolean,
+) {
+    constructor(situation: ParticipantAbilitySituation) : this(
+        canUseAbility = situation.canUseAbility,
+        typeCode = situation.type?.code,
+        typeName = situation.type?.name,
+        targetCharaIds = situation.targetList.map { it.charaId },
+        targetFootsteps = situation.targetFootstepList,
+        attackerCharaId = situation.attacker?.charaId,
+        targetCharaId = situation.target?.charaId,
+        targetFootstep = situation.targetFootstep,
+        footstep = situation.footstep,
+        isAvailableNoTarget = situation.isAvailableNoTarget,
+        attackerCharaIds = situation.attackerList.map { it.charaId },
+        skillHistoryList = situation.skillHistoryList,
+        targetPrefixMessage = situation.targetPrefix,
+        targetSuffixMessage = situation.targetSuffix,
+        isTargetingAndFootstep = situation.isTargetingAndFootstep,
+    )
+}

--- a/backend/src/main/kotlin/com/ort/app/api/response/myself/MyselfCommitView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/myself/MyselfCommitView.kt
@@ -1,0 +1,17 @@
+package com.ort.app.api.response.myself
+
+import com.ort.app.domain.model.situation.participant.ParticipantCommitSituation
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "自分のコミット状態")
+data class MyselfCommitView(
+    @field:Schema(description = "コミット可能か (村設定で有効 + 進行中 + 生存中 + 非ダミー)")
+    val isAvailable: Boolean,
+    @field:Schema(description = "現時点でコミット中か")
+    val isCommitting: Boolean,
+) {
+    constructor(situation: ParticipantCommitSituation) : this(
+        isAvailable = situation.isAvailableCommit,
+        isCommitting = situation.isCommitting,
+    )
+}

--- a/backend/src/main/kotlin/com/ort/app/api/response/myself/MyselfView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/myself/MyselfView.kt
@@ -1,6 +1,7 @@
 package com.ort.app.api.response.myself
 
 import com.ort.app.api.response.skill.SkillView
+import com.ort.app.domain.model.situation.ParticipantSituation
 import com.ort.app.domain.model.village.participant.VillageParticipant
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -30,8 +31,14 @@ data class MyselfView(
     val skill: SkillView?,
     @field:Schema(description = "陣営コード")
     val campCode: String?,
+    @field:Schema(description = "コミット状態")
+    val commit: MyselfCommitView,
+    @field:Schema(description = "投票状態")
+    val vote: MyselfVoteView,
+    @field:Schema(description = "能力状態")
+    val ability: MyselfAbilityView,
 ) {
-    constructor(myself: VillageParticipant) : this(
+    constructor(myself: VillageParticipant, situation: ParticipantSituation) : this(
         id = myself.id,
         charaId = myself.charaId,
         name = myself.name(),
@@ -41,5 +48,8 @@ data class MyselfView(
         isWin = myself.isWin,
         skill = myself.skill?.let { SkillView(it) },
         campCode = myself.camp?.code,
+        commit = MyselfCommitView(situation.commit),
+        vote = MyselfVoteView(situation.vote),
+        ability = MyselfAbilityView(situation.ability),
     )
 }

--- a/backend/src/main/kotlin/com/ort/app/api/response/myself/MyselfVoteView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/myself/MyselfVoteView.kt
@@ -1,0 +1,20 @@
+package com.ort.app.api.response.myself
+
+import com.ort.app.domain.model.situation.participant.ParticipantVoteSituation
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "自分の投票状態")
+data class MyselfVoteView(
+    @field:Schema(description = "投票可能か (進行中 + 2 日目以降 + 生存中)")
+    val canVote: Boolean,
+    @field:Schema(description = "投票対象候補のキャラ ID 一覧 (生存者)")
+    val targetCharaIds: List<Int>,
+    @field:Schema(description = "現在の投票対象キャラ ID (未投票なら null)")
+    val targetCharaId: Int?,
+) {
+    constructor(situation: ParticipantVoteSituation) : this(
+        canVote = situation.canVote,
+        targetCharaIds = situation.targetList.map { it.charaId },
+        targetCharaId = situation.target?.charaId,
+    )
+}

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
@@ -16,6 +16,7 @@ import com.ort.app.application.service.PlayerService
 import com.ort.app.application.service.VillageService
 import com.ort.app.application.service.VoteApplicationService
 import com.ort.app.domain.model.chara.Chara
+import com.ort.app.domain.model.chara.Charachips
 import com.ort.app.domain.model.message.MessageQuery
 import com.ort.app.domain.model.player.Player
 import com.ort.app.domain.model.village.Village
@@ -111,7 +112,7 @@ class VillageDetailRestController(
             return VillageFootstepsView(list = emptyList())
         }
         val footsteps = footstepService.findFootsteps(villageId)
-        val charaById: Map<Int, Chara> = ctx.charas.associateBy { it.id }
+        val charaById: Map<Int, Chara> = ctx.charachips.charas().list.associateBy { it.id }
         val views = footsteps.list
             .sortedWith(compareBy({ it.day }, { it.roomNumbers }))
             .mapNotNull { footstep ->
@@ -142,9 +143,6 @@ class VillageDetailRestController(
     ): ResponseEntity<MyselfView?> {
         val ctx = loadContext(villageId)
         val myself = ctx.myself ?: return ResponseEntity.ok(null)
-        val charachips = ctx.village.setting.chara.let {
-            charaService.findCharachips(it.charachipIds, it.isOriginalCharachip)
-        }
         val situation = villageCoordinator.findParticipantSituation(
             village = ctx.village,
             username = ctx.user?.username,
@@ -152,7 +150,7 @@ class VillageDetailRestController(
             votes = voteService.findVotes(ctx.village.id),
             abilities = abilityService.findAbilities(ctx.village.id),
             footsteps = footstepService.findFootsteps(ctx.village.id),
-            charachips = charachips,
+            charachips = ctx.charachips,
             day = ctx.village.latestDay(),
         )
         return ResponseEntity.ok(MyselfView(myself, situation))
@@ -164,15 +162,15 @@ class VillageDetailRestController(
         val user = WolfMansionUserInfoUtil.getUserInfo()
         val player = user?.let { playerService.findPlayer(it.username) }
         val myself = user?.let { villageService.findVillageParticipant(village.id, it.username) }
-        val charas = village.setting.chara.let {
-            charaService.findCharachips(it.charachipIds, it.isOriginalCharachip).charas().list
+        val charachips = village.setting.chara.let {
+            charaService.findCharachips(it.charachipIds, it.isOriginalCharachip)
         }
         val players = playerService.findPlayers(village.id)
-        return VillageDetailContext(village, user, player, myself, charas, players)
+        return VillageDetailContext(village, user, player, myself, charachips, players)
     }
 
     private fun buildParticipants(ctx: VillageDetailContext): VillageParticipantsView {
-        val charaById = ctx.charas.associateBy { it.id }
+        val charaById = ctx.charachips.charas().list.associateBy { it.id }
         val playerById = ctx.players.list.associateBy { it.id }
         val isSpoilerOpen = spoilerDomainService.isViewableSpoilerContent(ctx.village, ctx.myself)
         val sorted = ctx.village.allParticipants().sortedByRoomNumber().list
@@ -233,7 +231,7 @@ class VillageDetailRestController(
         val user: com.ort.app.fw.security.UserInfo?,
         val player: Player?,
         val myself: VillageParticipant?,
-        val charas: List<Chara>,
+        val charachips: Charachips,
         val players: com.ort.app.domain.model.player.Players,
     )
 }

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
@@ -7,11 +7,14 @@ import com.ort.app.api.response.village.VillageFootstepsView
 import com.ort.app.api.response.village.VillageParticipantView
 import com.ort.app.api.response.village.VillageParticipantsView
 import com.ort.app.api.response.village.VillageView
+import com.ort.app.application.coordinator.VillageCoordinator
+import com.ort.app.application.service.AbilityService
 import com.ort.app.application.service.CharaService
 import com.ort.app.application.service.FootstepApplicationService
 import com.ort.app.application.service.MessageService
 import com.ort.app.application.service.PlayerService
 import com.ort.app.application.service.VillageService
+import com.ort.app.application.service.VoteApplicationService
 import com.ort.app.domain.model.chara.Chara
 import com.ort.app.domain.model.message.MessageQuery
 import com.ort.app.domain.model.player.Player
@@ -40,6 +43,9 @@ class VillageDetailRestController(
     private val playerService: PlayerService,
     private val messageService: MessageService,
     private val footstepService: FootstepApplicationService,
+    private val abilityService: AbilityService,
+    private val voteService: VoteApplicationService,
+    private val villageCoordinator: VillageCoordinator,
     private val spoilerDomainService: SpoilerDomainService,
     private val footstepRevealDomainService: FootstepRevealDomainService,
 ) {
@@ -128,14 +134,28 @@ class VillageDetailRestController(
     @GetMapping("/{villageId}/myself")
     @Operation(
         summary = "自分視点の参加者情報",
-        description = "ログイン中ユーザがこの村に参加していれば 200 + body、未参加なら 200 + null。",
+        description = "ログイン中ユーザがこの村に参加していれば 200 + body、未参加なら 200 + null。" +
+                "当日の能力 / 投票 / コミット状態と役職別の入力仕様を含む。",
     )
     fun myself(
         @PathVariable villageId: Int,
     ): ResponseEntity<MyselfView?> {
         val ctx = loadContext(villageId)
         val myself = ctx.myself ?: return ResponseEntity.ok(null)
-        return ResponseEntity.ok(MyselfView(myself))
+        val charachips = ctx.village.setting.chara.let {
+            charaService.findCharachips(it.charachipIds, it.isOriginalCharachip)
+        }
+        val situation = villageCoordinator.findParticipantSituation(
+            village = ctx.village,
+            username = ctx.user?.username,
+            myself = myself,
+            votes = voteService.findVotes(ctx.village.id),
+            abilities = abilityService.findAbilities(ctx.village.id),
+            footsteps = footstepService.findFootsteps(ctx.village.id),
+            charachips = charachips,
+            day = ctx.village.latestDay(),
+        )
+        return ResponseEntity.ok(MyselfView(myself, situation))
     }
 
     private fun loadContext(villageId: Int): VillageDetailContext {

--- a/frontend/app/features/village/detail/ActionPanel.tsx
+++ b/frontend/app/features/village/detail/ActionPanel.tsx
@@ -223,10 +223,15 @@ function AbilityForm({
     mutation.mutate({});
   }
 
-  // 対象選択が必須 (徘徊系・捜査系を除く) の能力で未選択なら submit させない
+  // 対象選択が必須 (徘徊系・捜査系を除く) の能力で未選択なら submit させない。
+  // 襲撃希望は attacker 連動で attack-targets を fetch するため、ロード中も無効化する
+  // (空配列で targetRequired=false になり submittable が活性化してしまうのを防ぐ)。
   const targetRequired = !isInvestigate && targetCharaIds.length > 0;
+  const attackTargetsLoading = isAttacker && attackTargetsQuery.isLoading;
   const submittable =
-    !mutation.isPending && (!targetRequired || targetCharaId != null);
+    !mutation.isPending &&
+    !attackTargetsLoading &&
+    (!targetRequired || targetCharaId != null);
   const hasCurrent =
     ability.attackerCharaId != null ||
     ability.targetCharaId != null ||
@@ -500,6 +505,11 @@ function CommitSection({
 
 // ---------- 部品 / utils ----------
 
+/**
+ * 子要素を `<label>` で包んでフォームコントロールと関連付ける。
+ * 単一の input/select を渡す前提なので、`<label>` の中に置けば htmlFor は不要
+ * (スクリーンリーダーは内包要素を自動で関連付ける)。
+ */
 function Row({
   label,
   suffix,
@@ -510,11 +520,11 @@ function Row({
   children: React.ReactNode;
 }) {
   return (
-    <div className="space-y-1">
-      <label className="text-xs text-slate-400">{label}</label>
+    <label className="block space-y-1">
+      <span className="text-xs text-slate-400">{label}</span>
       {children}
-      {suffix && <p className="text-xs text-slate-500">{suffix}</p>}
-    </div>
+      {suffix && <span className="block text-xs text-slate-500">{suffix}</span>}
+    </label>
   );
 }
 

--- a/frontend/app/features/village/detail/ActionPanel.tsx
+++ b/frontend/app/features/village/detail/ActionPanel.tsx
@@ -1,0 +1,537 @@
+import { useEffect, useMemo, useState } from "react";
+import type {
+  MyselfAbilityView,
+  MyselfCommitView,
+  MyselfView,
+  MyselfVoteView,
+  VillageParticipantView,
+  VillageView,
+} from "./api";
+import {
+  useAbilityMutation,
+  useAttackTargetsQuery,
+  useCommitMutation,
+  useFootstepCandidatesQuery,
+  useVoteMutation,
+} from "./hooks";
+
+/**
+ * 進行中の村で「能力 / 投票 / コミット」をまとめて行う操作パネル。
+ *
+ * 表示条件:
+ * - 村が進行中 (statusCode = "PROGRESS")
+ * - myself が参加中で見学者でない
+ * いずれか満たさなければ何も描画しない。
+ *
+ * 役職に能力が無い (canUseAbility=false かつ ability.typeCode=null) ケースでも、
+ * 投票 / コミットだけは出せるよう独立パネルにしている。
+ */
+export function ActionPanel({
+  village,
+  myself,
+}: {
+  village: VillageView;
+  myself: MyselfView;
+}) {
+  // CDef.VillageStatus.進行中 = "IN_PROGRESS"
+  if (village.statusCode !== "IN_PROGRESS") return null;
+  if (myself.isSpectator) return null;
+
+  return (
+    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4 space-y-4">
+      <h2 className="text-sm text-slate-400">行動</h2>
+      <AbilitySection
+        village={village}
+        myself={myself}
+        ability={myself.ability}
+        isDead={myself.isDead}
+      />
+      <VoteSection
+        village={village}
+        myselfCharaId={myself.charaId}
+        vote={myself.vote}
+      />
+      <CommitSection villageId={village.id} commit={myself.commit} />
+    </section>
+  );
+}
+
+// ---------- 能力 ----------
+
+/**
+ * 能力フォーム。役職に応じて以下を出し分ける:
+ *
+ * - 単純対象指定 (占い / 護衛 / 同棲 等): target select 1 つ + 能力セット
+ * - 襲撃希望 (人狼): attacker select + target select (attacker 連動で fetch) + 足音 (任意)
+ * - 捜査 (探偵): targetFootstep を一覧から選択
+ * - 徘徊 (狂人 / 妖狐): target なしで footstep のみ
+ * - 護衛など足音同時セット: target select + footstep 候補 (target 連動で fetch)
+ *
+ * 死亡時 / 行使不可日は履歴のみ表示。
+ */
+function AbilitySection({
+  village,
+  myself,
+  ability,
+  isDead,
+}: {
+  village: VillageView;
+  myself: MyselfView;
+  ability: MyselfAbilityView;
+  isDead: boolean;
+}) {
+  // 役職そのものが能力を持たないなら能力セクションごと出さない
+  if (!myself.skill) return null;
+  if (ability.typeCode == null && !ability.isTargetingAndFootstep && !ability.targetFootsteps.length) {
+    // 念のため: type=null は能力なし役職を意味する。履歴があれば履歴だけ出す。
+    if (ability.skillHistoryList.length === 0) return null;
+  }
+
+  const showForm = ability.canUseAbility && !isDead;
+
+  return (
+    <div className="space-y-3 border-t border-slate-700/60 pt-3 first:border-t-0 first:pt-0">
+      <div className="text-xs text-slate-400">
+        能力 {ability.typeName ? `(${ability.typeName})` : ""}
+      </div>
+
+      {showForm && <AbilityForm village={village} ability={ability} />}
+
+      {ability.skillHistoryList.length > 0 && (
+        <div className="space-y-1">
+          <p className="text-xs text-slate-400">能力セット履歴</p>
+          <ul className="text-xs text-slate-300 space-y-0.5">
+            {ability.skillHistoryList.map((h, i) => (
+              <li key={`${i}-${h}`}>{h}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AbilityForm({
+  village,
+  ability,
+}: {
+  village: VillageView;
+  ability: MyselfAbilityView;
+}) {
+  const mutation = useAbilityMutation(village.id);
+
+  // 制御 state — backend が返している現在の選択状態を初期値に。
+  const [attackerCharaId, setAttackerCharaId] = useState<number | null>(
+    ability.attackerCharaId ?? (ability.attackerCharaIds[0] ?? null),
+  );
+  const [targetCharaId, setTargetCharaId] = useState<number | null>(
+    ability.targetCharaId ?? null,
+  );
+  // 捜査の足音 (targetFootstep)
+  const [targetFootstep, setTargetFootstep] = useState<string>(
+    ability.targetFootstep ?? "",
+  );
+  // 徘徊 / 護衛 / 襲撃希望の足音
+  const [footstep, setFootstep] = useState<string>(ability.footstep ?? "");
+
+  // backend からの最新状態が変わったら state を同期 (refetch でリセットされる)
+  useEffect(() => {
+    setAttackerCharaId(ability.attackerCharaId ?? (ability.attackerCharaIds[0] ?? null));
+    setTargetCharaId(ability.targetCharaId ?? null);
+    setTargetFootstep(ability.targetFootstep ?? "");
+    setFootstep(ability.footstep ?? "");
+  }, [
+    ability.attackerCharaId,
+    ability.targetCharaId,
+    ability.targetFootstep,
+    ability.footstep,
+    ability.attackerCharaIds.join(","),
+  ]);
+
+  const isAttacker = ability.attackerCharaIds.length > 0;
+  const isInvestigate = ability.targetFootsteps.length > 0;
+  const targetingAndFootstep = ability.isTargetingAndFootstep;
+
+  // 襲撃希望: attacker 選択時に backend から襲撃可能対象を取得
+  const attackTargetsQuery = useAttackTargetsQuery(
+    village.id,
+    isAttacker ? attackerCharaId : null,
+  );
+  const attackTargetIds = attackTargetsQuery.data ?? [];
+
+  // 足音同時セット (護衛 / 単独襲撃 / 襲撃希望など): target 連動で候補を fetch
+  const footstepCandidatesQuery = useFootstepCandidatesQuery(
+    village.id,
+    {
+      charaId: isAttacker ? attackerCharaId : null,
+      targetCharaId,
+    },
+    targetingAndFootstep,
+  );
+  const footstepCandidates = footstepCandidatesQuery.data ?? [];
+
+  // backend から取得した候補が変わったら、未選択時は先頭を選択
+  useEffect(() => {
+    if (targetingAndFootstep && footstepCandidates.length > 0 && !footstep) {
+      setFootstep(footstepCandidates[0]);
+    }
+  }, [footstepCandidates.join(","), targetingAndFootstep]);
+
+  // 襲撃希望の対象は別 GET から得た候補に絞る
+  const aliveCharaIds = useMemo(
+    () =>
+      village.participants.list
+        .filter((p) => !p.isSpectator && !p.isDead && !p.isGone)
+        .map((p) => p.chara.id),
+    [village.participants.list],
+  );
+  const targetCharaIds = isAttacker ? attackTargetIds : ability.targetCharaIds;
+
+  function nameOf(charaId: number | null): string {
+    if (charaId == null) return "";
+    return charaNameMap(village.participants.list)[charaId] ?? `#${charaId}`;
+  }
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    const body: {
+      attackerCharaId?: number;
+      targetCharaId?: number;
+      footstep?: string;
+    } = {};
+    if (isAttacker && attackerCharaId != null) body.attackerCharaId = attackerCharaId;
+    if (isInvestigate) {
+      body.footstep = targetFootstep || undefined;
+    } else if (targetCharaId != null) {
+      body.targetCharaId = targetCharaId;
+    }
+    if (targetingAndFootstep && footstep) body.footstep = footstep;
+    // 徘徊系: target なしで footstep のみ
+    if (
+      !isAttacker &&
+      !isInvestigate &&
+      !targetingAndFootstep &&
+      ability.targetCharaIds.length === 0 &&
+      footstep
+    ) {
+      body.footstep = footstep;
+    }
+    mutation.mutate(body);
+  }
+
+  function cancel() {
+    if (!confirm("当日の能力行使を取り消しますか？")) return;
+    mutation.mutate({});
+  }
+
+  const submittable = !mutation.isPending;
+  const hasCurrent =
+    ability.attackerCharaId != null ||
+    ability.targetCharaId != null ||
+    ability.targetFootstep != null ||
+    (ability.footstep != null && ability.footstep.length > 0);
+
+  return (
+    <form onSubmit={submit} className="space-y-2">
+      {isAttacker && (
+        <Row label="襲撃者">
+          <select
+            value={attackerCharaId ?? ""}
+            onChange={(e) =>
+              setAttackerCharaId(e.target.value ? Number(e.target.value) : null)
+            }
+            className={inputClass}
+            disabled={mutation.isPending}
+          >
+            {ability.attackerCharaIds.map((id) => (
+              <option key={id} value={id}>
+                {nameOf(id)}
+              </option>
+            ))}
+          </select>
+        </Row>
+      )}
+
+      {isInvestigate ? (
+        <Row label="調査対象">
+          <select
+            value={targetFootstep}
+            onChange={(e) => setTargetFootstep(e.target.value)}
+            className={inputClass}
+            disabled={mutation.isPending}
+          >
+            <option value="">(選択してください)</option>
+            {ability.targetFootsteps.map((fs) => (
+              <option key={fs} value={fs}>
+                {fs}
+              </option>
+            ))}
+          </select>
+        </Row>
+      ) : (
+        targetCharaIds.length > 0 && (
+          <Row
+            label={
+              ability.targetPrefixMessage
+                ? ability.targetPrefixMessage
+                : "対象"
+            }
+            suffix={ability.targetSuffixMessage ?? undefined}
+          >
+            <select
+              value={targetCharaId ?? ""}
+              onChange={(e) =>
+                setTargetCharaId(e.target.value ? Number(e.target.value) : null)
+              }
+              className={inputClass}
+              disabled={mutation.isPending}
+            >
+              <option value="">(選択してください)</option>
+              {targetCharaIds.map((id) => (
+                <option key={id} value={id}>
+                  {nameOf(id)}
+                </option>
+              ))}
+            </select>
+          </Row>
+        )
+      )}
+
+      {targetingAndFootstep && (
+        <Row label="足音">
+          <select
+            value={footstep}
+            onChange={(e) => setFootstep(e.target.value)}
+            className={inputClass}
+            disabled={mutation.isPending || footstepCandidatesQuery.isLoading}
+          >
+            {footstepCandidates.length === 0 ? (
+              <option value="">{footstepCandidatesQuery.isLoading ? "読み込み中..." : "(候補なし)"}</option>
+            ) : (
+              footstepCandidates.map((fs) => (
+                <option key={fs} value={fs}>
+                  {fs}
+                </option>
+              ))
+            )}
+          </select>
+        </Row>
+      )}
+
+      {/* 徘徊系 (target 不要、footstep のみ): targetCharaIds と attackerCharaIds が両方空のときに出す */}
+      {!isAttacker &&
+        !isInvestigate &&
+        !targetingAndFootstep &&
+        ability.targetCharaIds.length === 0 && (
+          <Row label="足音 (徘徊)">
+            <input
+              type="text"
+              value={footstep}
+              onChange={(e) => setFootstep(e.target.value)}
+              placeholder="例: 101,102,103 / なし"
+              className={inputClass}
+              disabled={mutation.isPending}
+            />
+          </Row>
+        )}
+
+      <div className="flex items-center gap-3 pt-1">
+        <button
+          type="submit"
+          disabled={!submittable}
+          className={primaryButtonClass}
+        >
+          {mutation.isPending ? "送信中..." : "能力セット"}
+        </button>
+        {hasCurrent && (
+          <button
+            type="button"
+            onClick={cancel}
+            disabled={!submittable}
+            className={secondaryButtonClass}
+          >
+            取消
+          </button>
+        )}
+        {mutation.isError && (
+          <span className="text-xs text-rose-300">{mutation.error.message}</span>
+        )}
+      </div>
+
+      {/* useMemo の警告抑制のために aliveCharaIds を参照しておく (将来のフィルタ用にメモ化を残す) */}
+      <span hidden aria-hidden="true">{aliveCharaIds.length}</span>
+    </form>
+  );
+}
+
+// ---------- 投票 ----------
+
+function VoteSection({
+  village,
+  myselfCharaId,
+  vote,
+}: {
+  village: VillageView;
+  myselfCharaId: number;
+  vote: MyselfVoteView;
+}) {
+  if (!vote.canVote) return null;
+  return (
+    <div className="space-y-2 border-t border-slate-700/60 pt-3">
+      <div className="text-xs text-slate-400">投票</div>
+      <VoteForm
+        villageId={village.id}
+        participants={village.participants.list}
+        myselfCharaId={myselfCharaId}
+        vote={vote}
+      />
+    </div>
+  );
+}
+
+function VoteForm({
+  villageId,
+  participants,
+  myselfCharaId,
+  vote,
+}: {
+  villageId: number;
+  participants: VillageParticipantView[];
+  myselfCharaId: number;
+  vote: MyselfVoteView;
+}) {
+  const mutation = useVoteMutation(villageId);
+  const [targetCharaId, setTargetCharaId] = useState<number | null>(
+    vote.targetCharaId ?? null,
+  );
+
+  useEffect(() => {
+    setTargetCharaId(vote.targetCharaId ?? null);
+  }, [vote.targetCharaId]);
+
+  const names = charaNameMap(participants);
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (targetCharaId == null) return;
+    mutation.mutate({ targetCharaId });
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-2">
+      <Row label="投票先">
+        <select
+          value={targetCharaId ?? ""}
+          onChange={(e) =>
+            setTargetCharaId(e.target.value ? Number(e.target.value) : null)
+          }
+          className={inputClass}
+          disabled={mutation.isPending}
+        >
+          <option value="">(選択してください)</option>
+          {vote.targetCharaIds.map((id) => (
+            <option key={id} value={id}>
+              {id === myselfCharaId ? `${names[id] ?? id} (自分)` : names[id] ?? `#${id}`}
+            </option>
+          ))}
+        </select>
+      </Row>
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={mutation.isPending || targetCharaId == null}
+          className={primaryButtonClass}
+        >
+          {mutation.isPending ? "送信中..." : vote.targetCharaId != null ? "投票変更" : "投票"}
+        </button>
+        {mutation.isError && (
+          <span className="text-xs text-rose-300">{mutation.error.message}</span>
+        )}
+      </div>
+    </form>
+  );
+}
+
+// ---------- コミット ----------
+
+function CommitSection({
+  villageId,
+  commit,
+}: {
+  villageId: number;
+  commit: MyselfCommitView;
+}) {
+  const mutation = useCommitMutation(villageId);
+  if (!commit.isAvailable) return null;
+
+  function toggle() {
+    mutation.mutate({ commit: !commit.isCommitting });
+  }
+
+  return (
+    <div className="space-y-2 border-t border-slate-700/60 pt-3">
+      <div className="text-xs text-slate-400">コミット (行動確定)</div>
+      <div className="flex items-center gap-3">
+        <span className="text-sm">
+          {commit.isCommitting ? (
+            <span className="text-emerald-300">確定済み</span>
+          ) : (
+            <span className="text-slate-300">未確定</span>
+          )}
+        </span>
+        <button
+          type="button"
+          onClick={toggle}
+          disabled={mutation.isPending}
+          className={commit.isCommitting ? secondaryButtonClass : primaryButtonClass}
+        >
+          {mutation.isPending
+            ? "送信中..."
+            : commit.isCommitting
+              ? "コミットを取り消し"
+              : "コミットする"}
+        </button>
+        {mutation.isError && (
+          <span className="text-xs text-rose-300">{mutation.error.message}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------- 部品 / utils ----------
+
+function Row({
+  label,
+  suffix,
+  children,
+}: {
+  label: string;
+  suffix?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1">
+      <label className="text-xs text-slate-400">{label}</label>
+      {children}
+      {suffix && <p className="text-xs text-slate-500">{suffix}</p>}
+    </div>
+  );
+}
+
+function charaNameMap(participants: VillageParticipantView[]): Record<number, string> {
+  const map: Record<number, string> = {};
+  for (const p of participants) {
+    map[p.chara.id] = p.name;
+  }
+  return map;
+}
+
+const inputClass =
+  "w-full bg-slate-900 border border-slate-700 rounded px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:outline-none focus:border-indigo-500 disabled:opacity-50";
+
+const primaryButtonClass =
+  "rounded bg-indigo-500 hover:bg-indigo-400 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium";
+
+const secondaryButtonClass =
+  "rounded bg-slate-700 hover:bg-slate-600 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium";

--- a/frontend/app/features/village/detail/ActionPanel.tsx
+++ b/frontend/app/features/village/detail/ActionPanel.tsx
@@ -175,21 +175,20 @@ function AbilityForm({
     if (targetingAndFootstep && footstepCandidates.length > 0 && !footstep) {
       setFootstep(footstepCandidates[0]);
     }
-  }, [footstepCandidates.join(","), targetingAndFootstep]);
+  }, [footstepCandidates, targetingAndFootstep, footstep]);
 
-  // 襲撃希望の対象は別 GET から得た候補に絞る
-  const aliveCharaIds = useMemo(
-    () =>
-      village.participants.list
-        .filter((p) => !p.isSpectator && !p.isDead && !p.isGone)
-        .map((p) => p.chara.id),
-    [village.participants.list],
-  );
+  // 襲撃希望時は別 GET から得た候補に絞る
   const targetCharaIds = isAttacker ? attackTargetIds : ability.targetCharaIds;
 
+  // 参加者数は通常数十名だが、能力フォームは render が多い (mutation pending 等で更新)
+  // のでキャラ名マップは memo 化しておく。
+  const charaNames = useMemo(
+    () => buildCharaNameMap(village.participants.list),
+    [village.participants.list],
+  );
   function nameOf(charaId: number | null): string {
     if (charaId == null) return "";
-    return charaNameMap(village.participants.list)[charaId] ?? `#${charaId}`;
+    return charaNames[charaId] ?? `#${charaId}`;
   }
 
   function submit(e: React.FormEvent) {
@@ -224,7 +223,10 @@ function AbilityForm({
     mutation.mutate({});
   }
 
-  const submittable = !mutation.isPending;
+  // 対象選択が必須 (徘徊系・捜査系を除く) の能力で未選択なら submit させない
+  const targetRequired = !isInvestigate && targetCharaIds.length > 0;
+  const submittable =
+    !mutation.isPending && (!targetRequired || targetCharaId != null);
   const hasCurrent =
     ability.attackerCharaId != null ||
     ability.targetCharaId != null ||
@@ -357,9 +359,6 @@ function AbilityForm({
           <span className="text-xs text-rose-300">{mutation.error.message}</span>
         )}
       </div>
-
-      {/* useMemo の警告抑制のために aliveCharaIds を参照しておく (将来のフィルタ用にメモ化を残す) */}
-      <span hidden aria-hidden="true">{aliveCharaIds.length}</span>
     </form>
   );
 }
@@ -409,7 +408,7 @@ function VoteForm({
     setTargetCharaId(vote.targetCharaId ?? null);
   }, [vote.targetCharaId]);
 
-  const names = charaNameMap(participants);
+  const names = useMemo(() => buildCharaNameMap(participants), [participants]);
 
   function submit(e: React.FormEvent) {
     e.preventDefault();
@@ -519,7 +518,7 @@ function Row({
   );
 }
 
-function charaNameMap(participants: VillageParticipantView[]): Record<number, string> {
+function buildCharaNameMap(participants: VillageParticipantView[]): Record<number, string> {
   const map: Record<number, string> = {};
   for (const p of participants) {
     map[p.chara.id] = p.name;

--- a/frontend/app/features/village/detail/api.ts
+++ b/frontend/app/features/village/detail/api.ts
@@ -22,6 +22,12 @@ export type VillageFootstepsView = components["schemas"]["VillageFootstepsView"]
 export type MessageView = components["schemas"]["MessageView"];
 export type MessagesView = components["schemas"]["MessagesView"];
 export type MyselfView = components["schemas"]["MyselfView"];
+export type MyselfAbilityView = components["schemas"]["MyselfAbilityView"];
+export type MyselfVoteView = components["schemas"]["MyselfVoteView"];
+export type MyselfCommitView = components["schemas"]["MyselfCommitView"];
+export type VillageAbilityBody = components["schemas"]["VillageAbilityBody"];
+export type VillageVoteBody = components["schemas"]["VillageVoteBody"];
+export type VillageCommitBody = components["schemas"]["VillageCommitBody"];
 
 // ---------- fetchers ----------
 
@@ -198,4 +204,93 @@ export async function deleteLeave(
   if (!res.ok) {
     throw new Error(`leave failed: ${res.status} ${await readErrorMessage(res)}`);
   }
+}
+
+// ---------- ability / vote / commit ----------
+
+/** POST /api/v1/villages/{id}/abilities */
+export async function postAbility(
+  villageId: number,
+  body: VillageAbilityBody,
+  fetcher: ApiFetch = browserFetch,
+): Promise<void> {
+  const res = await fetcher(`/api/v1/villages/${villageId}/abilities`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`ability failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+}
+
+/** POST /api/v1/villages/{id}/votes */
+export async function postVote(
+  villageId: number,
+  body: VillageVoteBody,
+  fetcher: ApiFetch = browserFetch,
+): Promise<void> {
+  const res = await fetcher(`/api/v1/villages/${villageId}/votes`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`vote failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+}
+
+/** PUT /api/v1/villages/{id}/commit */
+export async function putCommit(
+  villageId: number,
+  body: VillageCommitBody,
+  fetcher: ApiFetch = browserFetch,
+): Promise<void> {
+  const res = await fetcher(`/api/v1/villages/${villageId}/commit`, {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`commit failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+}
+
+/**
+ * GET /api/v1/villages/{id}/abilities/attack-targets?charaId=...
+ *
+ * 指定キャラが今日襲撃できる対象の charaId 一覧。
+ */
+export async function fetchAttackTargets(
+  villageId: number,
+  charaId: number,
+  fetcher: ApiFetch = browserFetch,
+): Promise<number[]> {
+  const res = await fetcher(
+    `/api/v1/villages/${villageId}/abilities/attack-targets?charaId=${charaId}`,
+  );
+  if (!res.ok) {
+    throw new Error(`attack-targets failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+  return res.json();
+}
+
+/**
+ * GET /api/v1/villages/{id}/abilities/footstep-candidates?charaId=...&targetCharaId=...
+ *
+ * 指定キャラが指定対象に対して残せる足音 (カンマ区切り部屋番号 / 'なし') の候補リスト。
+ */
+export async function fetchFootstepCandidates(
+  villageId: number,
+  params: { charaId?: number; targetCharaId?: number },
+  fetcher: ApiFetch = browserFetch,
+): Promise<string[]> {
+  const qs = new URLSearchParams();
+  if (params.charaId != null) qs.set("charaId", String(params.charaId));
+  if (params.targetCharaId != null) qs.set("targetCharaId", String(params.targetCharaId));
+  const suffix = qs.toString() ? `?${qs.toString()}` : "";
+  const res = await fetcher(
+    `/api/v1/villages/${villageId}/abilities/footstep-candidates${suffix}`,
+  );
+  if (!res.ok) {
+    throw new Error(`footstep-candidates failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+  return res.json();
 }

--- a/frontend/app/features/village/detail/hooks.ts
+++ b/frontend/app/features/village/detail/hooks.ts
@@ -8,23 +8,31 @@ import {
 } from "@tanstack/react-query";
 import {
   deleteLeave,
+  fetchAttackTargets,
+  fetchFootstepCandidates,
   fetchMyself,
   fetchSelectableCharas,
   fetchVillage,
   fetchVillageFootsteps,
   fetchVillageMessages,
+  postAbility,
   postParticipate,
   postSay,
   postSwitchParticipate,
+  postVote,
   putChangeRequestSkill,
+  putCommit,
   type CharaView,
   type MessagesView,
   type MyselfView,
   type SayInput,
+  type VillageAbilityBody,
   type VillageChangeRequestSkillBody,
+  type VillageCommitBody,
   type VillageFootstepsView,
   type VillageParticipateBody,
   type VillageView,
+  type VillageVoteBody,
 } from "./api";
 
 /** 30s polling — plan.md「TanStack Query `refetchInterval: 30000`」に合わせる */
@@ -172,5 +180,93 @@ export function useLeaveMutation(villageId: number): UseMutationResult<void, Err
   return useMutation<void, Error, void>({
     mutationFn: () => deleteLeave(villageId),
     onSuccess: () => invalidateVillage(queryClient, villageId),
+  });
+}
+
+// ---------- ability / vote / commit ----------
+
+/**
+ * 能力 / 投票 / commit を更新したら、myself (当日の選択状態) と messages
+ * (能力セットの非公開メッセージ反映) をどちらも refetch する。
+ */
+function invalidateActionState(
+  queryClient: ReturnType<typeof useQueryClient>,
+  villageId: number,
+) {
+  queryClient.invalidateQueries({ queryKey: ["village", villageId, "myself"] });
+  queryClient.invalidateQueries({ queryKey: ["village", villageId, "messages"] });
+}
+
+export function useAbilityMutation(
+  villageId: number,
+): UseMutationResult<void, Error, VillageAbilityBody> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, VillageAbilityBody>({
+    mutationFn: (body) => postAbility(villageId, body),
+    onSuccess: () => invalidateActionState(queryClient, villageId),
+  });
+}
+
+export function useVoteMutation(
+  villageId: number,
+): UseMutationResult<void, Error, VillageVoteBody> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, VillageVoteBody>({
+    mutationFn: (body) => postVote(villageId, body),
+    onSuccess: () => invalidateActionState(queryClient, villageId),
+  });
+}
+
+export function useCommitMutation(
+  villageId: number,
+): UseMutationResult<void, Error, VillageCommitBody> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, VillageCommitBody>({
+    mutationFn: (body) => putCommit(villageId, body),
+    onSuccess: () => invalidateActionState(queryClient, villageId),
+  });
+}
+
+/**
+ * 襲撃者を選択するたびに、その襲撃者で襲撃可能な対象の charaId を fetch する。
+ * `charaId` が null のときはクエリを発行せず空配列扱い。
+ */
+export function useAttackTargetsQuery(
+  villageId: number,
+  charaId: number | null,
+): UseQueryResult<number[]> {
+  return useQuery<number[]>({
+    queryKey: ["village", villageId, "attack-targets", charaId],
+    queryFn: () => fetchAttackTargets(villageId, charaId as number),
+    enabled: charaId != null,
+    staleTime: 30_000,
+  });
+}
+
+/**
+ * 能力主体 / 対象が変わるたびに足音候補を fetch する。
+ * 「対象なし」しか選べない (例えば徘徊で target null のとき) ケースでも
+ * backend が ['なし'] を返してくれる前提で常時 fetch。
+ */
+export function useFootstepCandidatesQuery(
+  villageId: number,
+  params: { charaId?: number | null; targetCharaId?: number | null },
+  enabled: boolean,
+): UseQueryResult<string[]> {
+  return useQuery<string[]>({
+    queryKey: [
+      "village",
+      villageId,
+      "footstep-candidates",
+      params.charaId ?? null,
+      params.targetCharaId ?? null,
+    ],
+    queryFn: () =>
+      fetchFootstepCandidates(villageId, {
+        charaId: params.charaId ?? undefined,
+        targetCharaId: params.targetCharaId ?? undefined,
+      }),
+    enabled,
+    staleTime: 30_000,
   });
 }

--- a/frontend/app/routes/villages.$id.tsx
+++ b/frontend/app/routes/villages.$id.tsx
@@ -19,6 +19,7 @@ import {
   useVillageMessagesQuery,
   useVillageQuery,
 } from "~/features/village/detail/hooks";
+import { ActionPanel } from "~/features/village/detail/ActionPanel";
 import { ParticipateActions } from "~/features/village/detail/ParticipateActions";
 import { ssrFetch } from "~/lib/api/client";
 
@@ -66,6 +67,8 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
         {myself && <MyselfPanel myself={myself} />}
 
         <ParticipateActions village={village} myself={myself} />
+
+        {myself && <ActionPanel village={village} myself={myself} />}
 
         <ParticipantsPanel participants={village.participants.list} />
 


### PR DESCRIPTION
## Summary

- `MyselfView` を拡張し、当日の能力選択状態 / 投票対象 / コミット状態と役職別の入力仕様 (target / footstep / attacker の要否、候補一覧、能力履歴等) を `commit` / `vote` / `ability` の 3 サブビューとして同梱
- frontend に進行中専用の `ActionPanel` を追加し、能力 / 投票 / コミットを 1 つのパネルで操作可能に
- 襲撃希望は attacker 連動で attack-targets を fetch、足音同時セット系 (護衛・単独襲撃・襲撃希望) は target 連動で footstep-candidates を fetch

## 影響範囲

- backend: `VillageDetailRestController.myself` が `VillageCoordinator.findParticipantSituation` 経由で votes/abilities/footsteps をロードするので、myself 取得時の DB クエリが増える
- frontend: `ActionPanel` を `villages.\$id.tsx` の MyselfPanel と ParticipantsPanel の間に追加
- `.issues/2` (myself endpoint の空 body) は今回 body を持つ JSON を返すようになり実質前進。`.issues/4` (face-types 認可漏れ) は Step 8c で対応予定 (今回スコープ外)

## Test plan

- [x] backend `./gradlew test` 通過
- [x] frontend `pnpm typecheck && pnpm test && pnpm build` 通過
- [ ] ローカル DB に進行中の村があれば: 進行中の村で能力 / 投票 / コミットを操作し、myself refetch で UI が更新されることを確認
- [ ] 進行中で能力を取消すると abilities/footsteps が空になり、UI からも消えること
- [ ] 進行中以外の状態 (募集中 / エピローグ / 終了 / 廃村) では ActionPanel が描画されないこと
- [ ] 見学者 / 死亡者 / ダミー では能力フォームが出ない / コミット欄が出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)