### PR TITLE
Step 8c: 村画面 RP UI (キャラ名 / メモ / 表情差分) + face-types 認可修正

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/VillageRpController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/VillageRpController.kt
@@ -120,7 +120,7 @@ class VillageRpController(
         } ?: throw WolfMansionBusinessException("ログインしてください")
         try {
             faceTypeModifyForm.faceTypeList!!.forEach {
-                charaService.updateOriginalCharaImage(it.code!!, it.name!!, it.display!!)
+                charaService.updateOriginalCharaImage(myself.charaId, it.code!!, it.name!!, it.display!!)
             }
         } catch (e: WolfMansionBusinessException) {
             model.addAttribute("faceTypeModifyErrorMessage", e.message)

--- a/backend/src/main/kotlin/com/ort/app/api/response/myself/MyselfFaceTypesView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/myself/MyselfFaceTypesView.kt
@@ -1,0 +1,21 @@
+package com.ort.app.api.response.myself
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "自分のキャラに紐づく表情差分一覧 (オリジナルキャラチップ)")
+data class MyselfFaceTypesView(
+    @field:Schema(description = "表情差分の一覧 (キャラの登録順)")
+    val list: List<MyselfFaceTypeView>,
+)
+
+@Schema(description = "表情差分 1 件")
+data class MyselfFaceTypeView(
+    @field:Schema(description = "表情コード (= original_chara_image_id を文字列化したもの)")
+    val code: String,
+    @field:Schema(description = "表情差分名 (1-5 文字)")
+    val name: String,
+    @field:Schema(description = "差分画像 URL")
+    val url: String,
+    @field:Schema(description = "発言時に表示するか")
+    val isDisplay: Boolean,
+)

--- a/backend/src/main/kotlin/com/ort/app/api/response/myself/MyselfRpView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/myself/MyselfRpView.kt
@@ -8,7 +8,11 @@ import io.swagger.v3.oas.annotations.media.Schema
  *
  * - キャラ名変更: 募集中 + チップ仕様 + 自分が変更可能ステータス を全て満たすときのみ true。
  * - メモ変更: 募集中 + 自分が変更可能ステータス。
- * - 画像追加: オリジナルキャラチップ村 + 表情差分追加可能状態。
+ * - 表情差分追加: オリジナルキャラチップ村 + 表情差分追加可能状態。
+ *
+ * NOTE: 表情差分の "編集" (name / display の更新) は API レベルでは所有者検証のみで通すため、
+ *       本フィールド (`canAddFaceType`) は UI の表示制御用途。所有チェックを通れば backend は
+ *       受理する点に留意 (旧 Thymeleaf も同様の挙動)。
  */
 @Schema(description = "RP 系操作の可否")
 data class MyselfRpView(
@@ -16,12 +20,14 @@ data class MyselfRpView(
     val isAvailableChangeName: Boolean,
     @field:Schema(description = "簡易メモを変更できるか")
     val isAvailableMemo: Boolean,
-    @field:Schema(description = "表情差分の編集 / 追加が可能か (オリジナルキャラチップ村のみ true)")
-    val canEditFaceType: Boolean,
+    @field:Schema(description = "表情差分の追加 (および編集 UI 表示) が可能か。オリジナルキャラチップ村でのみ true")
+    val canAddFaceType: Boolean,
 ) {
     constructor(situation: ParticipantRpSituation) : this(
         isAvailableChangeName = situation.isAvailableChangeName,
         isAvailableMemo = situation.isAvailableMemo,
-        canEditFaceType = situation.canAddImage,
+        // ParticipantRpSituation.canAddImage は "画像追加可能か" の意。表情差分編集 (PUT) は
+        // 所有者検証のみで通すため、UI の追加 / 編集パネル表示判定としてそのまま使う。
+        canAddFaceType = situation.canAddImage,
     )
 }

--- a/backend/src/main/kotlin/com/ort/app/api/response/myself/MyselfRpView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/myself/MyselfRpView.kt
@@ -1,0 +1,27 @@
+package com.ort.app.api.response.myself
+
+import com.ort.app.domain.model.situation.participant.ParticipantRpSituation
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * RP 系 (キャラ名 / メモ / 表情差分) 操作の可否。
+ *
+ * - キャラ名変更: 募集中 + チップ仕様 + 自分が変更可能ステータス を全て満たすときのみ true。
+ * - メモ変更: 募集中 + 自分が変更可能ステータス。
+ * - 画像追加: オリジナルキャラチップ村 + 表情差分追加可能状態。
+ */
+@Schema(description = "RP 系操作の可否")
+data class MyselfRpView(
+    @field:Schema(description = "キャラ名 (name + shortName) を変更できるか")
+    val isAvailableChangeName: Boolean,
+    @field:Schema(description = "簡易メモを変更できるか")
+    val isAvailableMemo: Boolean,
+    @field:Schema(description = "表情差分の編集 / 追加が可能か (オリジナルキャラチップ村のみ true)")
+    val canEditFaceType: Boolean,
+) {
+    constructor(situation: ParticipantRpSituation) : this(
+        isAvailableChangeName = situation.isAvailableChangeName,
+        isAvailableMemo = situation.isAvailableMemo,
+        canEditFaceType = situation.canAddImage,
+    )
+}

--- a/backend/src/main/kotlin/com/ort/app/api/response/myself/MyselfView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/myself/MyselfView.kt
@@ -19,6 +19,12 @@ data class MyselfView(
     val charaId: Int,
     @field:Schema(description = "表示名 ([部屋番号略称] 名前)")
     val name: String,
+    @field:Schema(description = "キャラ名 (略称を含まない、RP 編集対象)")
+    val charaName: String,
+    @field:Schema(description = "1 文字略称")
+    val charaShortName: String,
+    @field:Schema(description = "簡易メモ (未設定なら null)")
+    val memo: String?,
     @field:Schema(description = "部屋番号 (未割当なら null)")
     val roomNumber: Int?,
     @field:Schema(description = "見学者か")
@@ -37,11 +43,16 @@ data class MyselfView(
     val vote: MyselfVoteView,
     @field:Schema(description = "能力状態")
     val ability: MyselfAbilityView,
+    @field:Schema(description = "RP 状態 (キャラ名 / メモ / 表情差分の編集可否)")
+    val rp: MyselfRpView,
 ) {
     constructor(myself: VillageParticipant, situation: ParticipantSituation) : this(
         id = myself.id,
         charaId = myself.charaId,
         name = myself.name(),
+        charaName = myself.charaName.name,
+        charaShortName = myself.charaName.shortName,
+        memo = myself.memo,
         roomNumber = myself.room?.number,
         isSpectator = myself.isSpectator,
         isDead = myself.dead.isDead,
@@ -51,5 +62,6 @@ data class MyselfView(
         commit = MyselfCommitView(situation.commit),
         vote = MyselfVoteView(situation.vote),
         ability = MyselfAbilityView(situation.ability),
+        rp = MyselfRpView(situation.rp),
     )
 }

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageRpRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageRpRestController.kt
@@ -3,13 +3,17 @@ package com.ort.app.api.v1.villages
 import com.ort.app.api.request.village.VillageChangeNameBody
 import com.ort.app.api.request.village.VillageFaceTypeModifyBody
 import com.ort.app.api.request.village.VillageMemoBody
+import com.ort.app.api.response.myself.MyselfFaceTypeView
+import com.ort.app.api.response.myself.MyselfFaceTypesView
 import com.ort.app.application.coordinator.VillageCoordinator
 import com.ort.app.application.service.CharaService
 import com.ort.app.application.service.VillageService
+import com.ort.app.fw.exception.WolfMansionBusinessException
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -30,10 +34,9 @@ import org.springframework.web.bind.annotation.RestController
  *
  * 旧 Thymeleaf 実装は POST だが、REST 的に状態更新は PUT が自然なので統一した。
  *
- * NOTE: face-types は現在 `loadVillageAndRequireMyself` で「参加者である」までしかチェックして
- *       いない。code (= original_chara_image_id) が自分のキャラの画像かどうかの認可チェックは
- *       旧 Thymeleaf でも実施していない既存挙動。引き続き脆弱性として残るが、JSON API 公開で
- *       攻撃面が広がるため別 issue で追跡する想定 (`.issues/` 参照)。
+ * face-types の認可: `myself.charaId` を `CharaService` に渡し、サービス層で `original_chara_image_id`
+ * の所有者が自キャラと一致するかを検証する。旧 Thymeleaf 実装も同じ穴を持っていたため `VillageRpController`
+ * 側も同時に修正済み。
  */
 @RestController
 @RequestMapping("/api/v1/villages")
@@ -67,17 +70,45 @@ class VillageRpRestController(
         villageService.changeMemo(myself, body.memo)
     }
 
+    @GetMapping("/{villageId}/rp/face-types")
+    @Operation(
+        summary = "表情差分一覧取得 (オリジナルキャラチップ)",
+        description = "自分のキャラに紐づく表情差分一覧 (code / name / 画像 URL / display) を返す。" +
+                "オリジナルキャラチップ村以外は空配列を返す。",
+    )
+    fun listFaceTypes(
+        @PathVariable villageId: Int,
+    ): MyselfFaceTypesView {
+        val (village, myself) = villageContextLoader.loadVillageAndRequireMyself(villageId)
+        if (!village.setting.chara.isOriginalCharachip) {
+            return MyselfFaceTypesView(list = emptyList())
+        }
+        val chara = charaService.findChara(myself.charaId, isOriginal = true)
+            ?: throw WolfMansionBusinessException("自分のキャラが見つかりません")
+        val list = chara.images.list.map {
+            MyselfFaceTypeView(
+                code = it.faceType.code,
+                name = it.faceType.name,
+                url = it.url,
+                isDisplay = it.isDisplay,
+            )
+        }
+        return MyselfFaceTypesView(list = list)
+    }
+
     @PutMapping("/{villageId}/rp/face-types")
     @Operation(
         summary = "表情差分編集 (オリジナルキャラチップ)",
-        description = "既存の表情差分の name / display を一括更新する。画像追加は別 endpoint (multipart)。",
+        description = "既存の表情差分の name / display を一括更新する。画像追加は別 endpoint (multipart、未実装)。",
     )
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun modifyFaceTypes(
         @PathVariable villageId: Int,
         @Valid @RequestBody body: VillageFaceTypeModifyBody,
     ) {
-        villageContextLoader.loadVillageAndRequireMyself(villageId)  // 参加していなければ拒否
-        body.faceTypeList.forEach { charaService.updateOriginalCharaImage(it.code, it.name, it.display) }
+        val (_, myself) = villageContextLoader.loadVillageAndRequireMyself(villageId)
+        body.faceTypeList.forEach {
+            charaService.updateOriginalCharaImage(myself.charaId, it.code, it.name, it.display)
+        }
     }
 }

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageRpRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageRpRestController.kt
@@ -74,7 +74,8 @@ class VillageRpRestController(
     @Operation(
         summary = "表情差分一覧取得 (オリジナルキャラチップ)",
         description = "自分のキャラに紐づく表情差分一覧 (code / name / 画像 URL / display) を返す。" +
-                "オリジナルキャラチップ村以外は空配列を返す。",
+                "オリジナルキャラチップ村以外は空配列。" +
+                "アクセス要件は『この村に参加している (=参加者または見学者)』。未参加ユーザは 400。",
     )
     fun listFaceTypes(
         @PathVariable villageId: Int,

--- a/backend/src/main/kotlin/com/ort/app/application/service/CharaService.kt
+++ b/backend/src/main/kotlin/com/ort/app/application/service/CharaService.kt
@@ -58,7 +58,8 @@ class CharaService(
         faceTypeName: String,
         isDisplay: Boolean
     ) {
-        val charaImageId = faceTypeCode.toInt()
+        val charaImageId = faceTypeCode.toIntOrNull()
+            ?: throw WolfMansionBusinessException("表情コードが不正です")
         val ownerId = charaRepository.findOriginalCharaIdByCharaImageId(charaImageId)
             ?: throw WolfMansionBusinessException("表情差分が見つかりません")
         if (ownerId != ownerCharaId) {

--- a/backend/src/main/kotlin/com/ort/app/application/service/CharaService.kt
+++ b/backend/src/main/kotlin/com/ort/app/application/service/CharaService.kt
@@ -5,6 +5,7 @@ import com.ort.app.domain.model.chara.CharaRepository
 import com.ort.app.domain.model.chara.Charachip
 import com.ort.app.domain.model.chara.Charachips
 import com.ort.app.domain.model.chara.Charas
+import com.ort.app.fw.exception.WolfMansionBusinessException
 import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
 
@@ -47,11 +48,22 @@ class CharaService(
         charaRepository.registerOriginalCharaImage(charachipId, charaId, faceTypeName, charaImageFile)
     }
 
+    /**
+     * 自分の original_chara に属する表情差分のみを更新する。
+     * `ownerCharaId` の所有レコードでなければ [WolfMansionBusinessException] を投げて拒否する。
+     */
     fun updateOriginalCharaImage(
+        ownerCharaId: Int,
         faceTypeCode: String,
         faceTypeName: String,
         isDisplay: Boolean
     ) {
-        charaRepository.updateOriginalCharaImage(faceTypeCode.toInt(), faceTypeName, isDisplay)
+        val charaImageId = faceTypeCode.toInt()
+        val ownerId = charaRepository.findOriginalCharaIdByCharaImageId(charaImageId)
+            ?: throw WolfMansionBusinessException("表情差分が見つかりません")
+        if (ownerId != ownerCharaId) {
+            throw WolfMansionBusinessException("他のキャラの表情差分は編集できません")
+        }
+        charaRepository.updateOriginalCharaImage(charaImageId, faceTypeName, isDisplay)
     }
 }

--- a/backend/src/main/kotlin/com/ort/app/domain/model/chara/CharaRepository.kt
+++ b/backend/src/main/kotlin/com/ort/app/domain/model/chara/CharaRepository.kt
@@ -38,4 +38,7 @@ interface CharaRepository {
         faceTypeName: String,
         isDisplay: Boolean
     )
+
+    /** 指定された original_chara_image が属する original_chara_id を返す。存在しなければ null。 */
+    fun findOriginalCharaIdByCharaImageId(charaImageId: Int): Int?
 }

--- a/backend/src/main/kotlin/com/ort/app/infrastructure/datasource/CharaDataSource.kt
+++ b/backend/src/main/kotlin/com/ort/app/infrastructure/datasource/CharaDataSource.kt
@@ -118,6 +118,13 @@ class CharaDataSource(
         updateOriginalCharaImageName(charaImageId, faceTypeName, isDisplay)
     }
 
+    override fun findOriginalCharaIdByCharaImageId(charaImageId: Int): Int? {
+        val opt = originalCharaImageBhv.selectEntity {
+            it.query().setOriginalCharaImageId_Equal(charaImageId)
+        }
+        return if (opt.isPresent) opt.get().originalCharaId else null
+    }
+
     private fun selectOriginalCharaGroups(ids: List<Int>): ListResultBean<OriginalCharaGroup> {
         val groupList = originalCharaGroupBhv.selectList {
             it.query().setOriginalCharaGroupId_InScope(ids)

--- a/backend/src/test/kotlin/com/ort/app/api/v1/villages/VillageRpRestControllerTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/api/v1/villages/VillageRpRestControllerTest.kt
@@ -4,6 +4,11 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.ort.app.application.coordinator.VillageCoordinator
 import com.ort.app.application.service.CharaService
 import com.ort.app.application.service.VillageService
+import com.ort.app.domain.model.chara.Chara
+import com.ort.app.domain.model.chara.CharaImage
+import com.ort.app.domain.model.chara.CharaImages
+import com.ort.app.domain.model.chara.CharaSize
+import com.ort.app.domain.model.chara.FaceType
 import com.ort.app.domain.model.village.createDay1Village
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -17,7 +22,9 @@ import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
@@ -97,8 +104,8 @@ class VillageRpRestControllerTest {
                 .content(mapper.writeValueAsString(body))
         ).andExpect(status().isNoContent)
 
-        verify(charaService).updateOriginalCharaImage(eq("F01"), eq("笑顔"), eq(true))
-        verify(charaService).updateOriginalCharaImage(eq("F02"), eq("怒"), eq(false))
+        verify(charaService).updateOriginalCharaImage(eq(myself.charaId), eq("F01"), eq("笑顔"), eq(true))
+        verify(charaService).updateOriginalCharaImage(eq(myself.charaId), eq("F02"), eq("怒"), eq(false))
     }
 
     @Test
@@ -115,6 +122,70 @@ class VillageRpRestControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(mapper.writeValueAsString(body))
         ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `GET rp_face-types 通常村は空 list を返す`() {
+        val village = createDay1Village().copy(id = 10)
+        // createDay1Village は isOriginalCharachip=false なので通常村
+        val myself = village.participants.list.first()
+        whenever(villageService.findVillage(eq(10), any())).thenReturn(village)
+        whenever(villageService.findVillageParticipant(eq(10), eq("tester"), any())).thenReturn(myself)
+
+        mockMvc.perform(
+            get("/api/v1/villages/10/rp/face-types").with(authed())
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.list.length()").value(0))
+    }
+
+    @Test
+    fun `GET rp_face-types オリジナルキャラチップ村は自キャラの表情を返す`() {
+        val baseVillage = createDay1Village().copy(id = 11)
+        // setting を書き換えてオリジナルキャラチップ村に
+        val village = baseVillage.copy(
+            setting = baseVillage.setting.copy(
+                chara = baseVillage.setting.chara.copy(isOriginalCharachip = true)
+            )
+        )
+        val myself = village.participants.list.first()
+        whenever(villageService.findVillage(eq(11), any())).thenReturn(village)
+        whenever(villageService.findVillageParticipant(eq(11), eq("tester"), any())).thenReturn(myself)
+        whenever(charaService.findChara(eq(myself.charaId), eq(true))).thenReturn(
+            Chara(
+                id = myself.charaId,
+                name = "テス太郎",
+                shortName = "テ",
+                defaultJoinMessage = null,
+                defaultFirstdayMessage = null,
+                size = CharaSize(width = 60, height = 60),
+                images = CharaImages(
+                    list = listOf(
+                        CharaImage(
+                            faceType = FaceType(code = "100", name = "通常"),
+                            url = "https://example.test/100.png",
+                            isDisplay = true,
+                        ),
+                        CharaImage(
+                            faceType = FaceType(code = "101", name = "笑顔"),
+                            url = "https://example.test/101.png",
+                            isDisplay = false,
+                        ),
+                    )
+                ),
+            )
+        )
+
+        mockMvc.perform(
+            get("/api/v1/villages/11/rp/face-types").with(authed())
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.list.length()").value(2))
+            .andExpect(jsonPath("$.list[0].code").value("100"))
+            .andExpect(jsonPath("$.list[0].name").value("通常"))
+            .andExpect(jsonPath("$.list[0].isDisplay").value(true))
+            .andExpect(jsonPath("$.list[1].code").value("101"))
+            .andExpect(jsonPath("$.list[1].isDisplay").value(false))
     }
 
     @Test

--- a/backend/src/test/kotlin/com/ort/app/application/service/CharaServiceTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/application/service/CharaServiceTest.kt
@@ -50,6 +50,23 @@ class CharaServiceTest {
     }
 
     @Test
+    fun `updateOriginalCharaImage 数値でない faceTypeCode で例外 (400 相当)`() {
+        val charaRepository = mock<CharaRepository>()
+        val service = CharaService(charaRepository)
+
+        assertThatThrownBy {
+            service.updateOriginalCharaImage(
+                ownerCharaId = 42,
+                faceTypeCode = "abc",
+                faceTypeName = "笑顔",
+                isDisplay = true,
+            )
+        }.isInstanceOf(WolfMansionBusinessException::class.java)
+            .extracting { (it as WolfMansionBusinessException).message }
+            .satisfies({ assertThat(it as String).contains("不正") })
+    }
+
+    @Test
     fun `updateOriginalCharaImage 存在しない faceTypeCode で例外`() {
         val charaRepository = mock<CharaRepository>()
         whenever(charaRepository.findOriginalCharaIdByCharaImageId(eq(999))).thenReturn(null)

--- a/backend/src/test/kotlin/com/ort/app/application/service/CharaServiceTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/application/service/CharaServiceTest.kt
@@ -1,0 +1,71 @@
+package com.ort.app.application.service
+
+import com.ort.app.domain.model.chara.CharaRepository
+import com.ort.app.fw.exception.WolfMansionBusinessException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class CharaServiceTest {
+
+    @Test
+    fun `updateOriginalCharaImage 自キャラの表情なら更新が委譲される`() {
+        val charaRepository = mock<CharaRepository>()
+        whenever(charaRepository.findOriginalCharaIdByCharaImageId(eq(100))).thenReturn(42)
+        val service = CharaService(charaRepository)
+
+        service.updateOriginalCharaImage(
+            ownerCharaId = 42,
+            faceTypeCode = "100",
+            faceTypeName = "笑顔",
+            isDisplay = true,
+        )
+
+        verify(charaRepository).updateOriginalCharaImage(eq(100), eq("笑顔"), eq(true))
+    }
+
+    @Test
+    fun `updateOriginalCharaImage 他人キャラの表情を指定すると例外`() {
+        val charaRepository = mock<CharaRepository>()
+        whenever(charaRepository.findOriginalCharaIdByCharaImageId(eq(100))).thenReturn(43)
+        val service = CharaService(charaRepository)
+
+        assertThatThrownBy {
+            service.updateOriginalCharaImage(
+                ownerCharaId = 42,
+                faceTypeCode = "100",
+                faceTypeName = "笑顔",
+                isDisplay = true,
+            )
+        }.isInstanceOf(WolfMansionBusinessException::class.java)
+            .extracting { (it as WolfMansionBusinessException).message }
+            .satisfies({ assertThat(it as String).contains("他のキャラ") })
+
+        verify(charaRepository, never()).updateOriginalCharaImage(eq(100), eq("笑顔"), eq(true))
+    }
+
+    @Test
+    fun `updateOriginalCharaImage 存在しない faceTypeCode で例外`() {
+        val charaRepository = mock<CharaRepository>()
+        whenever(charaRepository.findOriginalCharaIdByCharaImageId(eq(999))).thenReturn(null)
+        val service = CharaService(charaRepository)
+
+        assertThatThrownBy {
+            service.updateOriginalCharaImage(
+                ownerCharaId = 42,
+                faceTypeCode = "999",
+                faceTypeName = "笑顔",
+                isDisplay = true,
+            )
+        }.isInstanceOf(WolfMansionBusinessException::class.java)
+            .extracting { (it as WolfMansionBusinessException).message }
+            .satisfies({ assertThat(it as String).contains("見つかりません") })
+
+        verify(charaRepository, never()).updateOriginalCharaImage(eq(999), eq("笑顔"), eq(true))
+    }
+}

--- a/frontend/app/features/village/detail/RpActions.tsx
+++ b/frontend/app/features/village/detail/RpActions.tsx
@@ -1,0 +1,285 @@
+import { useEffect, useState } from "react";
+import type { MyselfFaceTypeView, MyselfView, VillageView } from "./api";
+import {
+  useChangeNameMutation,
+  useFaceTypesMutation,
+  useFaceTypesQuery,
+  useMemoMutation,
+} from "./hooks";
+
+/**
+ * RP 系 (キャラ名 / 簡易メモ / 表情差分) の編集パネル。
+ *
+ * - キャラ名変更: 募集中 + キャラチップが変更を許可 + 自分がまだ変更可能ステータス、のとき。
+ * - 簡易メモ: 募集中 + 自分がまだ変更可能ステータス、のとき。
+ * - 表情差分: オリジナルキャラチップ村のときのみ。
+ *   別 endpoint `/rp/face-types` で取得した自キャラ分のみを編集する。multipart の画像追加は未実装。
+ *
+ * 編集可能項目が 1 つも無い場合は何も描画しない。
+ */
+export function RpActions({
+  village,
+  myself,
+}: {
+  village: VillageView;
+  myself: MyselfView;
+}) {
+  const { rp } = myself;
+  const showChangeName = rp.isAvailableChangeName;
+  const showMemo = rp.isAvailableMemo;
+  // canEditFaceType は backend 側で「オリジナルキャラチップ村 + 募集中相当」のときに true。
+  // 但しオリジナルキャラチップ村でない通常村でも、過去に追加したオリジナル差分はない (チップ
+  // 全体が差分 1 つのみ) ので、ここでは canEditFaceType に従う。
+  const showFaceType = rp.canEditFaceType;
+
+  if (!showChangeName && !showMemo && !showFaceType) return null;
+
+  return (
+    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4 space-y-4">
+      <h2 className="text-sm text-slate-400">RP</h2>
+      {showChangeName && <ChangeNameForm villageId={village.id} myself={myself} />}
+      {showMemo && <MemoForm villageId={village.id} myself={myself} />}
+      {showFaceType && <FaceTypesForm villageId={village.id} />}
+    </section>
+  );
+}
+
+// ---------- キャラ名変更 ----------
+
+function ChangeNameForm({ villageId, myself }: { villageId: number; myself: MyselfView }) {
+  const mutation = useChangeNameMutation(villageId);
+  const [name, setName] = useState(myself.charaName);
+  const [shortName, setShortName] = useState(myself.charaShortName);
+
+  // 他の操作 (例えば管理者操作) で名前が変わったら同期。
+  useEffect(() => {
+    setName(myself.charaName);
+    setShortName(myself.charaShortName);
+  }, [myself.charaName, myself.charaShortName]);
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmedName = name.trim();
+    const trimmedShort = shortName.trim();
+    if (!trimmedName || trimmedShort.length !== 1) return;
+    mutation.mutate({ name: trimmedName, shortName: trimmedShort });
+  }
+
+  const submittable =
+    !mutation.isPending &&
+    name.trim().length > 0 &&
+    name.trim().length <= 40 &&
+    shortName.trim().length === 1;
+  const dirty = name !== myself.charaName || shortName !== myself.charaShortName;
+
+  return (
+    <form onSubmit={submit} className="space-y-2 first:border-t-0 first:pt-0 border-t border-slate-700/60 pt-3">
+      <p className="text-xs text-slate-400">キャラ名変更</p>
+      <div className="grid grid-cols-[1fr_5rem] gap-2 items-end">
+        <Field label="表示名 (40 文字以内)">
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            maxLength={40}
+            className={inputClass}
+            disabled={mutation.isPending}
+          />
+        </Field>
+        <Field label="略称 (1 文字)">
+          <input
+            type="text"
+            value={shortName}
+            onChange={(e) => setShortName(e.target.value)}
+            maxLength={1}
+            className={inputClass}
+            disabled={mutation.isPending}
+          />
+        </Field>
+      </div>
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={!submittable || !dirty}
+          className={primaryButtonClass}
+        >
+          {mutation.isPending ? "送信中..." : "名前を変更"}
+        </button>
+        {mutation.isError && (
+          <span className="text-xs text-rose-300">{mutation.error.message}</span>
+        )}
+      </div>
+    </form>
+  );
+}
+
+// ---------- 簡易メモ ----------
+
+const MEMO_MAX_LENGTH = 20;
+
+function MemoForm({ villageId, myself }: { villageId: number; myself: MyselfView }) {
+  const mutation = useMemoMutation(villageId);
+  const [memo, setMemo] = useState(myself.memo ?? "");
+
+  useEffect(() => {
+    setMemo(myself.memo ?? "");
+  }, [myself.memo]);
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (memo.length > MEMO_MAX_LENGTH) return;
+    mutation.mutate({ memo });
+  }
+
+  const submittable = !mutation.isPending && memo.length <= MEMO_MAX_LENGTH;
+  const dirty = memo !== (myself.memo ?? "");
+
+  return (
+    <form onSubmit={submit} className="space-y-2 border-t border-slate-700/60 pt-3">
+      <p className="text-xs text-slate-400">簡易メモ ({MEMO_MAX_LENGTH} 文字以内、自分しか見えない)</p>
+      <input
+        type="text"
+        value={memo}
+        onChange={(e) => setMemo(e.target.value)}
+        maxLength={MEMO_MAX_LENGTH}
+        placeholder="(空文字でクリア)"
+        className={inputClass}
+        disabled={mutation.isPending}
+      />
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={!submittable || !dirty}
+          className={primaryButtonClass}
+        >
+          {mutation.isPending ? "送信中..." : "メモを保存"}
+        </button>
+        <span className="text-xs text-slate-500">
+          {memo.length} / {MEMO_MAX_LENGTH}
+        </span>
+        {mutation.isError && (
+          <span className="text-xs text-rose-300">{mutation.error.message}</span>
+        )}
+      </div>
+    </form>
+  );
+}
+
+// ---------- 表情差分 ----------
+
+function FaceTypesForm({ villageId }: { villageId: number }) {
+  // RpActions が canEditFaceType=true のときだけマウントするので、ここでは常に enabled.
+  const query = useFaceTypesQuery(villageId, true);
+  const mutation = useFaceTypesMutation(villageId);
+
+  // ローカル編集状態。backend からの最新が入ってきたら再初期化する。
+  const [items, setItems] = useState<MyselfFaceTypeView[]>([]);
+  useEffect(() => {
+    if (query.data) setItems(query.data.list);
+  }, [query.data]);
+
+  function update(idx: number, patch: Partial<MyselfFaceTypeView>) {
+    setItems((prev) => prev.map((it, i) => (i === idx ? { ...it, ...patch } : it)));
+  }
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (items.length === 0) return;
+    // backend は name に @Size(1,5) を持つ。1 件でも違反していたら submit を弾く。
+    if (items.some((it) => it.name.trim().length < 1 || it.name.trim().length > 5)) return;
+    mutation.mutate({
+      faceTypeList: items.map((it) => ({
+        code: it.code,
+        name: it.name.trim(),
+        display: it.isDisplay,
+      })),
+    });
+  }
+
+  const submittable =
+    !mutation.isPending &&
+    items.length > 0 &&
+    items.every((it) => it.name.trim().length >= 1 && it.name.trim().length <= 5);
+
+  return (
+    <form onSubmit={submit} className="space-y-3 border-t border-slate-700/60 pt-3">
+      <p className="text-xs text-slate-400">
+        表情差分編集 (画像追加は未対応、編集のみ)
+      </p>
+      {query.isLoading && <p className="text-slate-400 text-sm">読み込み中...</p>}
+      {query.isError && (
+        <p className="text-rose-300 text-sm">表情差分の取得に失敗しました</p>
+      )}
+      {query.data && items.length === 0 && (
+        <p className="text-slate-400 text-sm">編集可能な表情差分がありません</p>
+      )}
+      {items.length > 0 && (
+        <ul className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {items.map((it, idx) => (
+            <li
+              key={it.code}
+              className="flex gap-3 items-start rounded border border-slate-700 p-2 bg-slate-900/40"
+            >
+              <img
+                src={it.url}
+                alt={it.name}
+                width={60}
+                height={60}
+                className="rounded shrink-0"
+              />
+              <div className="flex-1 space-y-1">
+                <input
+                  type="text"
+                  value={it.name}
+                  onChange={(e) => update(idx, { name: e.target.value })}
+                  maxLength={5}
+                  className={inputClass}
+                  placeholder="表情名 (1-5 文字)"
+                  disabled={mutation.isPending}
+                />
+                <label className="flex items-center gap-1 text-xs text-slate-300">
+                  <input
+                    type="checkbox"
+                    checked={it.isDisplay}
+                    onChange={(e) => update(idx, { isDisplay: e.target.checked })}
+                    disabled={mutation.isPending}
+                  />
+                  発言フォームに表示する
+                </label>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={!submittable}
+          className={primaryButtonClass}
+        >
+          {mutation.isPending ? "送信中..." : "表情差分を更新"}
+        </button>
+        {mutation.isError && (
+          <span className="text-xs text-rose-300">{mutation.error.message}</span>
+        )}
+      </div>
+    </form>
+  );
+}
+
+// ---------- 部品 ----------
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1">
+      <label className="text-xs text-slate-400">{label}</label>
+      {children}
+    </div>
+  );
+}
+
+const inputClass =
+  "w-full bg-slate-900 border border-slate-700 rounded px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:outline-none focus:border-indigo-500 disabled:opacity-50";
+
+const primaryButtonClass =
+  "rounded bg-indigo-500 hover:bg-indigo-400 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium";

--- a/frontend/app/features/village/detail/RpActions.tsx
+++ b/frontend/app/features/village/detail/RpActions.tsx
@@ -168,7 +168,7 @@ function MemoForm({ villageId, myself }: { villageId: number; myself: MyselfView
 // ---------- 表情差分 ----------
 
 function FaceTypesForm({ villageId }: { villageId: number }) {
-  // RpActions が canEditFaceType=true のときだけマウントするので、ここでは常に enabled.
+  // RpActions が canAddFaceType=true のときだけマウントするので、ここでは常に enabled.
   const query = useFaceTypesQuery(villageId, true);
   const mutation = useFaceTypesMutation(villageId);
 

--- a/frontend/app/features/village/detail/RpActions.tsx
+++ b/frontend/app/features/village/detail/RpActions.tsx
@@ -27,10 +27,10 @@ export function RpActions({
   const { rp } = myself;
   const showChangeName = rp.isAvailableChangeName;
   const showMemo = rp.isAvailableMemo;
-  // canEditFaceType は backend 側で「オリジナルキャラチップ村 + 募集中相当」のときに true。
-  // 但しオリジナルキャラチップ村でない通常村でも、過去に追加したオリジナル差分はない (チップ
-  // 全体が差分 1 つのみ) ので、ここでは canEditFaceType に従う。
-  const showFaceType = rp.canEditFaceType;
+  // canAddFaceType は backend 側で「オリジナルキャラチップ村 + 募集中相当」のときに true。
+  // ここでは編集 UI (PUT 系) の表示判定にも使う (backend の編集 PUT は所有者検証のみで
+  // 通すため UI 表示が唯一のガード)。
+  const showFaceType = rp.canAddFaceType;
 
   if (!showChangeName && !showMemo && !showFaceType) return null;
 
@@ -173,6 +173,10 @@ function FaceTypesForm({ villageId }: { villageId: number }) {
   const mutation = useFaceTypesMutation(villageId);
 
   // ローカル編集状態。backend からの最新が入ってきたら再初期化する。
+  // face-types クエリは polling なし (staleTime=60s) なので、編集中に意図しない reset が
+  // 起きるのは mutation 成功後の invalidate or window focus refetch のみ。前者は送信済み
+  // 状態なので reset で問題なく、後者も「他端末で先に編集した結果に揃える」挙動として
+  // 受け入れる。
   const [items, setItems] = useState<MyselfFaceTypeView[]>([]);
   useEffect(() => {
     if (query.data) setItems(query.data.list);

--- a/frontend/app/features/village/detail/api.ts
+++ b/frontend/app/features/village/detail/api.ts
@@ -28,6 +28,12 @@ export type MyselfCommitView = components["schemas"]["MyselfCommitView"];
 export type VillageAbilityBody = components["schemas"]["VillageAbilityBody"];
 export type VillageVoteBody = components["schemas"]["VillageVoteBody"];
 export type VillageCommitBody = components["schemas"]["VillageCommitBody"];
+export type VillageChangeNameBody = components["schemas"]["VillageChangeNameBody"];
+export type VillageMemoBody = components["schemas"]["VillageMemoBody"];
+export type VillageFaceTypeModifyBody = components["schemas"]["VillageFaceTypeModifyBody"];
+export type MyselfRpView = components["schemas"]["MyselfRpView"];
+export type MyselfFaceTypeView = components["schemas"]["MyselfFaceTypeView"];
+export type MyselfFaceTypesView = components["schemas"]["MyselfFaceTypesView"];
 
 // ---------- fetchers ----------
 
@@ -270,6 +276,76 @@ export async function fetchAttackTargets(
     throw new Error(`attack-targets failed: ${res.status} ${await readErrorMessage(res)}`);
   }
   return res.json();
+}
+
+// ---------- RP (キャラ名 / メモ / 表情差分) ----------
+
+/**
+ * PUT /api/v1/villages/{id}/rp/name — キャラ名 + 略称変更。成功時 204。
+ */
+export async function putChangeName(
+  villageId: number,
+  body: VillageChangeNameBody,
+  fetcher: ApiFetch = browserFetch,
+): Promise<void> {
+  const res = await fetcher(`/api/v1/villages/${villageId}/rp/name`, {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`change name failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+}
+
+/**
+ * PUT /api/v1/villages/{id}/rp/memo — 簡易メモ変更。成功時 204。
+ *
+ * 空文字を送るとメモをクリア (backend は @Size(max=20) のみ、NotBlank ではない)。
+ */
+export async function putMemo(
+  villageId: number,
+  body: VillageMemoBody,
+  fetcher: ApiFetch = browserFetch,
+): Promise<void> {
+  const res = await fetcher(`/api/v1/villages/${villageId}/rp/memo`, {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`memo failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+}
+
+/**
+ * GET /api/v1/villages/{id}/rp/face-types — 自キャラに紐づく表情差分一覧。
+ * オリジナルキャラチップ村以外は空配列。
+ */
+export async function fetchFaceTypes(
+  villageId: number,
+  fetcher: ApiFetch = browserFetch,
+): Promise<MyselfFaceTypesView> {
+  const res = await fetcher(`/api/v1/villages/${villageId}/rp/face-types`);
+  if (!res.ok) {
+    throw new Error(`face-types fetch failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+  return res.json();
+}
+
+/**
+ * PUT /api/v1/villages/{id}/rp/face-types — 表情差分の name / display を一括更新。成功時 204。
+ */
+export async function putFaceTypes(
+  villageId: number,
+  body: VillageFaceTypeModifyBody,
+  fetcher: ApiFetch = browserFetch,
+): Promise<void> {
+  const res = await fetcher(`/api/v1/villages/${villageId}/rp/face-types`, {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`face-types update failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
 }
 
 /**

--- a/frontend/app/features/village/detail/hooks.ts
+++ b/frontend/app/features/village/detail/hooks.ts
@@ -239,11 +239,15 @@ export function useCommitMutation(
 
 /**
  * RP 系操作後は myself (キャラ名 / メモ / RP 可否) と、表示名が映る箇所 (村ヘッダ /
- * 参加者一覧 / 発言) を更新するため村全体と発言を invalidate する。
+ * 参加者一覧 / 発言) を更新する。
+ *
+ * `invalidateQueries({ queryKey: ["village", villageId] })` は prefix match なので
+ * `["village", villageId]` 本体に加えて `["village", villageId, "myself"]` /
+ * `["village", villageId, "messages"]` / `["village", villageId, "footsteps"]` 等
+ * 全ての配下クエリを invalidate する (= キャラ名変更時に myself も refetch される)。
  */
 function invalidateRp(queryClient: ReturnType<typeof useQueryClient>, villageId: number) {
   queryClient.invalidateQueries({ queryKey: ["village", villageId] });
-  queryClient.invalidateQueries({ queryKey: ["village", villageId, "messages"] });
 }
 
 export function useChangeNameMutation(

--- a/frontend/app/features/village/detail/hooks.ts
+++ b/frontend/app/features/village/detail/hooks.ts
@@ -9,6 +9,7 @@ import {
 import {
   deleteLeave,
   fetchAttackTargets,
+  fetchFaceTypes,
   fetchFootstepCandidates,
   fetchMyself,
   fetchSelectableCharas,
@@ -20,16 +21,23 @@ import {
   postSay,
   postSwitchParticipate,
   postVote,
+  putChangeName,
   putChangeRequestSkill,
   putCommit,
+  putFaceTypes,
+  putMemo,
   type CharaView,
   type MessagesView,
+  type MyselfFaceTypesView,
   type MyselfView,
   type SayInput,
   type VillageAbilityBody,
+  type VillageChangeNameBody,
   type VillageChangeRequestSkillBody,
   type VillageCommitBody,
+  type VillageFaceTypeModifyBody,
   type VillageFootstepsView,
+  type VillageMemoBody,
   type VillageParticipateBody,
   type VillageView,
   type VillageVoteBody,
@@ -224,6 +232,68 @@ export function useCommitMutation(
   return useMutation<void, Error, VillageCommitBody>({
     mutationFn: (body) => putCommit(villageId, body),
     onSuccess: () => invalidateActionState(queryClient, villageId),
+  });
+}
+
+// ---------- RP (キャラ名 / メモ / 表情差分) ----------
+
+/**
+ * RP 系操作後は myself (キャラ名 / メモ / RP 可否) と、表示名が映る箇所 (村ヘッダ /
+ * 参加者一覧 / 発言) を更新するため村全体と発言を invalidate する。
+ */
+function invalidateRp(queryClient: ReturnType<typeof useQueryClient>, villageId: number) {
+  queryClient.invalidateQueries({ queryKey: ["village", villageId] });
+  queryClient.invalidateQueries({ queryKey: ["village", villageId, "messages"] });
+}
+
+export function useChangeNameMutation(
+  villageId: number,
+): UseMutationResult<void, Error, VillageChangeNameBody> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, VillageChangeNameBody>({
+    mutationFn: (body) => putChangeName(villageId, body),
+    onSuccess: () => invalidateRp(queryClient, villageId),
+  });
+}
+
+export function useMemoMutation(
+  villageId: number,
+): UseMutationResult<void, Error, VillageMemoBody> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, VillageMemoBody>({
+    mutationFn: (body) => putMemo(villageId, body),
+    onSuccess: () => {
+      // memo は myself にしか乗っていない (村全体には出していない) ので myself のみ refetch
+      queryClient.invalidateQueries({ queryKey: ["village", villageId, "myself"] });
+    },
+  });
+}
+
+/**
+ * GET /api/v1/villages/{id}/rp/face-types: 表情差分の編集元データ。
+ * `enabled=false` でクエリを抑止 (オリジナルキャラチップ村でないときは fetch しない)。
+ */
+export function useFaceTypesQuery(
+  villageId: number,
+  enabled: boolean,
+): UseQueryResult<MyselfFaceTypesView> {
+  return useQuery<MyselfFaceTypesView>({
+    queryKey: ["village", villageId, "face-types"],
+    queryFn: () => fetchFaceTypes(villageId),
+    enabled,
+    staleTime: 60_000,
+  });
+}
+
+export function useFaceTypesMutation(
+  villageId: number,
+): UseMutationResult<void, Error, VillageFaceTypeModifyBody> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, VillageFaceTypeModifyBody>({
+    mutationFn: (body) => putFaceTypes(villageId, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["village", villageId, "face-types"] });
+    },
   });
 }
 

--- a/frontend/app/routes/villages.$id.tsx
+++ b/frontend/app/routes/villages.$id.tsx
@@ -21,6 +21,7 @@ import {
 } from "~/features/village/detail/hooks";
 import { ActionPanel } from "~/features/village/detail/ActionPanel";
 import { ParticipateActions } from "~/features/village/detail/ParticipateActions";
+import { RpActions } from "~/features/village/detail/RpActions";
 import { ssrFetch } from "~/lib/api/client";
 
 export function meta({ data }: Route.MetaArgs) {
@@ -67,6 +68,8 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
         {myself && <MyselfPanel myself={myself} />}
 
         <ParticipateActions village={village} myself={myself} />
+
+        {myself && <RpActions village={village} myself={myself} />}
 
         {myself && <ActionPanel village={village} myself={myself} />}
 


### PR DESCRIPTION
## Summary

- backend: `MyselfView` に `charaName` / `charaShortName` / `memo` / `rp` (RP 操作可否) を追加し、`GET /api/v1/villages/{id}/rp/face-types` (自キャラ表情差分一覧) を新設
- backend: issue #4 (`face-types-authz`) を解消。`CharaService.updateOriginalCharaImage` に `ownerCharaId` を渡し、`original_chara_image_id` の所有者検証をサービス層で実施 (旧 Thymeleaf controller も同時修正)
- frontend: `RpActions` コンポーネントを追加。`isAvailableChangeName` / `isAvailableMemo` / `canEditFaceType` に従い、キャラ名変更 / 簡易メモ / 表情差分編集の 3 種フォームを描画

## 仕様メモ

- 表情差分は `MyselfView.rp.canEditFaceType` が `true` (オリジナルキャラチップ村 + 自身が編集可能ステータス) のときのみ表示
- 表情差分の編集元データは `GET /rp/face-types` で別取得 (`MyselfView` に詰め込まず軽量化)
- 表情差分の追加 (multipart) は本 PR スコープ外で `.issues/` 持ち越し

## Test plan

- [x] backend: `./gradlew test` 全件 PASS (新規 `CharaServiceTest` で他人 chara_image_id 拒否 / `VillageRpRestControllerTest` で GET face-types 通常村 / オリジナル村)
- [x] frontend: `pnpm typecheck && pnpm test && pnpm build` PASS
- [ ] (動作確認) ローカル DB 起動 → 進行中村でキャラ名 / メモ更新 / オリジナルキャラチップ村で表情差分編集

🤖 Generated with [Claude Code](https://claude.com/claude-code)