### PR TITLE
Step 8d: プレイヤー画面 (プロフィール / パスワード変更 / 戦績)

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/request/player/PlayerPasswordBody.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/request/player/PlayerPasswordBody.kt
@@ -1,0 +1,29 @@
+package com.ort.app.api.request.player
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+
+/**
+ * パスワード変更リクエスト。
+ *
+ * 旧 `PlayerChangePasswordForm` の置き換え。確認用パスワードとの一致は
+ * controller 側で検証する (validator を別途立てずに済ませる)。
+ *
+ * NOTE: 旧実装と同じく現パスワードの再入力は要求しない。JWT cookie 経由で認証済みの
+ * ユーザのみアクセスできる前提に立っている。
+ */
+@Schema(description = "パスワード変更リクエスト")
+data class PlayerPasswordBody(
+    @field:NotBlank
+    @field:Size(min = 3, max = 12)
+    @field:Pattern(regexp = "[a-zA-Z0-9]*")
+    @field:Schema(description = "新しいパスワード (英数字 3〜12 文字)")
+    val password: String,
+    @field:NotBlank
+    @field:Size(min = 3, max = 12)
+    @field:Pattern(regexp = "[a-zA-Z0-9]*")
+    @field:Schema(description = "確認用パスワード (password と一致する必要がある)")
+    val confirmPassword: String,
+)

--- a/backend/src/main/kotlin/com/ort/app/api/request/player/PlayerProfileBody.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/request/player/PlayerProfileBody.kt
@@ -8,6 +8,8 @@ import jakarta.validation.constraints.Size
  *
  * 旧 `UserDetailForm` の置き換え。null 指定で各フィールドをクリアできる。
  */
+// NOTE: `nullable = true` を明示しないと SpringDoc が `?` を `required: false` だけに
+// 変換し、生成側で `string` 扱いになる。null クリアを明示的にリクエストできるよう nullable も付与。
 @Schema(description = "プロフィール更新リクエスト")
 data class PlayerProfileBody(
     @field:Size(max = 50)

--- a/backend/src/main/kotlin/com/ort/app/api/request/player/PlayerProfileBody.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/request/player/PlayerProfileBody.kt
@@ -1,0 +1,19 @@
+package com.ort.app.api.request.player
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
+
+/**
+ * プロフィール (Twitter ユーザ名 / 自己紹介) 更新リクエスト。
+ *
+ * 旧 `UserDetailForm` の置き換え。null 指定で各フィールドをクリアできる。
+ */
+@Schema(description = "プロフィール更新リクエスト")
+data class PlayerProfileBody(
+    @field:Size(max = 50)
+    @field:Schema(description = "Twitter ユーザ名 (50 文字以内、null でクリア)", nullable = true)
+    val twitterUserName: String? = null,
+    @field:Size(max = 2000)
+    @field:Schema(description = "自己紹介 (2000 文字以内、null でクリア)", nullable = true)
+    val introduction: String? = null,
+)

--- a/backend/src/main/kotlin/com/ort/app/api/response/player/MePlayerView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/player/MePlayerView.kt
@@ -8,14 +8,17 @@ import io.swagger.v3.oas.annotations.media.Schema
  *
  * `/api/v1/players/me` で返す軽量プロフィール。村作成 / 参加可否などの導線判定に必要な
  * フラグも含む。戦績や参加履歴は `PlayerDetailView` (`/api/v1/players/{userName}`) を参照。
+ *
+ * NOTE: 旧 `com.ort.app.api.view.player.PlayerView` (Step 9 で削除予定の legacy) と
+ * OpenAPI スキーマ名が衝突するため `MePlayerView` で別名にしている。
  */
 @Schema(description = "プレイヤー (自分視点)")
-data class PlayerView(
+data class MePlayerView(
     @field:Schema(description = "プレイヤー名")
     val name: String,
-    @field:Schema(description = "Twitter ユーザ名 (未設定なら null)")
+    @field:Schema(description = "Twitter ユーザ名 (未設定なら null)", nullable = true)
     val twitterUserName: String?,
-    @field:Schema(description = "自己紹介 (未設定なら null)")
+    @field:Schema(description = "自己紹介 (未設定なら null)", nullable = true)
     val introduction: String?,
     @field:Schema(description = "権限コード", example = "プレイヤー")
     val authorityCode: String,

--- a/backend/src/main/kotlin/com/ort/app/api/response/player/PlayerDetailView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/player/PlayerDetailView.kt
@@ -1,0 +1,166 @@
+package com.ort.app.api.response.player
+
+import com.ort.app.domain.model.chara.Chara
+import com.ort.app.domain.model.chara.Charas
+import com.ort.app.domain.model.player.ParticipateVillage
+import com.ort.app.domain.model.player.Player
+import com.ort.app.domain.model.player.PlayerRecords
+import com.ort.app.domain.model.village.participant.VillageParticipant
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * プレイヤー詳細 (プロフィール + 戦績 + 参加履歴)。
+ *
+ * 旧 `/user/{userName}` (Thymeleaf) の置き換え。
+ *
+ * - 認証不要 (誰でも他人の戦績を閲覧できる)
+ * - `isSelf=true` のときフロント側で Twitter / 自己紹介 / パスワード変更フォームを出す
+ */
+@Schema(description = "プレイヤー詳細 (戦績 + 参加履歴)")
+data class PlayerDetailView(
+    @field:Schema(description = "プレイヤー名")
+    val name: String,
+    @field:Schema(description = "Twitter ユーザ名 (未設定なら null)")
+    val twitterUserName: String?,
+    @field:Schema(description = "自己紹介 (未設定なら null)")
+    val introduction: String?,
+    @field:Schema(description = "閲覧者自身のページか")
+    val isSelf: Boolean,
+    @field:Schema(description = "総合戦績")
+    val wholeStats: RecordView,
+    @field:Schema(description = "陣営別戦績")
+    val campStatsList: List<CampStatsView>,
+    @field:Schema(description = "役職別戦績 (参加実績のあるもののみ)")
+    val skillStatsList: List<SkillStatsView>,
+    @field:Schema(description = "参加村一覧 (新着順)")
+    val participateVillageList: List<ParticipateVillageView>,
+    @field:Schema(description = "見学村一覧 (新着順)")
+    val spectateVillageList: List<ParticipateVillageView>,
+) {
+
+    @Schema(description = "戦績サマリ")
+    data class RecordView(
+        @field:Schema(description = "参加数")
+        val participateNum: Int,
+        @field:Schema(description = "勝利数")
+        val winNum: Int,
+        @field:Schema(description = "勝率 (0.0 〜 1.0)")
+        val winRate: Float,
+    )
+
+    @Schema(description = "陣営別戦績")
+    data class CampStatsView(
+        @field:Schema(description = "陣営名")
+        val campName: String,
+        @field:Schema(description = "戦績")
+        val stats: RecordView,
+    )
+
+    @Schema(description = "役職別戦績")
+    data class SkillStatsView(
+        @field:Schema(description = "役職名")
+        val skillName: String,
+        @field:Schema(description = "戦績")
+        val stats: RecordView,
+    )
+
+    @Schema(description = "参加村")
+    data class ParticipateVillageView(
+        @field:Schema(description = "村 ID")
+        val villageId: Int,
+        @field:Schema(description = "村名")
+        val villageName: String,
+        @field:Schema(description = "キャラ名")
+        val characterName: String,
+        @field:Schema(description = "キャラ画像 URL")
+        val characterImgUrl: String,
+        @field:Schema(description = "キャラ画像横幅 (px)")
+        val characterImgWidth: Int,
+        @field:Schema(description = "キャラ画像縦幅 (px)")
+        val characterImgHeight: Int,
+        @field:Schema(description = "役職名 (未確定なら空文字)")
+        val skillName: String,
+        @field:Schema(description = "生死表示 (例: 生存 / 1d 処刑死。見学は空文字)")
+        val liveStatus: String,
+        @field:Schema(description = "陣営名 (未確定なら空文字)")
+        val campName: String,
+        @field:Schema(description = "勝敗 (勝利 / 敗北 / 未確定なら空文字)")
+        val winStatus: String,
+    )
+
+    companion object {
+        fun of(
+            player: Player,
+            records: PlayerRecords,
+            charas: Charas,
+            originalCharas: Charas,
+            isSelf: Boolean,
+        ): PlayerDetailView {
+            val (participates, spectates) = records.participateVillageList.partition { !it.participant.isSpectator }
+            return PlayerDetailView(
+                name = player.name,
+                twitterUserName = player.twitterUserName,
+                introduction = player.introduction,
+                isSelf = isSelf,
+                wholeStats = toRecordView(records.wholeRecord.participateCount, records.wholeRecord.winCount, records.wholeRecord.winRate),
+                campStatsList = records.campRecordList.map {
+                    CampStatsView(
+                        campName = it.camp.name,
+                        stats = toRecordView(it.record.participateCount, it.record.winCount, it.record.winRate),
+                    )
+                },
+                skillStatsList = records.skillRecordList
+                    .filter { it.record.participateCount > 0 }
+                    .map {
+                        SkillStatsView(
+                            skillName = it.skill.name,
+                            stats = toRecordView(it.record.participateCount, it.record.winCount, it.record.winRate),
+                        )
+                    },
+                participateVillageList = participates.map { toParticipateVillageView(it, charas, originalCharas) },
+                spectateVillageList = spectates.map { toParticipateVillageView(it, charas, originalCharas) },
+            )
+        }
+
+        private fun toRecordView(participate: Int, win: Int, winRate: Float): RecordView =
+            RecordView(participateNum = participate, winNum = win, winRate = winRate)
+
+        private fun toParticipateVillageView(
+            pv: ParticipateVillage,
+            charas: Charas,
+            originalCharas: Charas,
+        ): ParticipateVillageView {
+            val chara = lookupChara(pv, charas, originalCharas)
+            return ParticipateVillageView(
+                villageId = pv.village.id,
+                villageName = pv.village.name,
+                characterName = pv.participant.charaName.name,
+                characterImgUrl = chara.defaultImage().url,
+                characterImgWidth = chara.size.width,
+                characterImgHeight = chara.size.height,
+                skillName = pv.participant.skill?.name.orEmpty(),
+                liveStatus = liveStatusOf(pv.participant).orEmpty(),
+                campName = pv.participant.camp?.name.orEmpty(),
+                winStatus = pv.participant.isWin?.let { if (it) "勝利" else "敗北" }.orEmpty(),
+            )
+        }
+
+        private fun lookupChara(pv: ParticipateVillage, charas: Charas, originalCharas: Charas): Chara {
+            val charaId = pv.participant.charaId
+            return if (pv.village.setting.chara.isOriginalCharachip) {
+                originalCharas.chara(charaId)
+            } else {
+                charas.chara(charaId)
+            }
+        }
+
+        private fun liveStatusOf(participant: VillageParticipant): String? {
+            if (participant.isSpectator) return null
+            if (!participant.dead.isDead) return "生存"
+            val deadDay = participant.dead.deadDay!!
+            val reason = participant.dead.reason!!.name
+            return if (reason.endsWith("死")) "${deadDay}d $reason"
+            else "${deadDay}d ${reason}死"
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/response/player/PlayerDetailView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/player/PlayerDetailView.kt
@@ -20,9 +20,9 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class PlayerDetailView(
     @field:Schema(description = "プレイヤー名")
     val name: String,
-    @field:Schema(description = "Twitter ユーザ名 (未設定なら null)")
+    @field:Schema(description = "Twitter ユーザ名 (未設定なら null)", nullable = true)
     val twitterUserName: String?,
-    @field:Schema(description = "自己紹介 (未設定なら null)")
+    @field:Schema(description = "自己紹介 (未設定なら null)", nullable = true)
     val introduction: String?,
     @field:Schema(description = "閲覧者自身のページか")
     val isSelf: Boolean,
@@ -130,14 +130,16 @@ data class PlayerDetailView(
             charas: Charas,
             originalCharas: Charas,
         ): ParticipateVillageView {
+            // 古い村ではキャラ画像 / サイズ情報が削除されている可能性があるため null 許容にし、
+            // 不一致時は表示用フォールバック ("不明" + 空 URL + 0px) を返してリスト全体の 500 を防ぐ。
             val chara = lookupChara(pv, charas, originalCharas)
             return ParticipateVillageView(
                 villageId = pv.village.id,
                 villageName = pv.village.name,
                 characterName = pv.participant.charaName.name,
-                characterImgUrl = chara.defaultImage().url,
-                characterImgWidth = chara.size.width,
-                characterImgHeight = chara.size.height,
+                characterImgUrl = chara?.defaultImage()?.url.orEmpty(),
+                characterImgWidth = chara?.size?.width ?: 0,
+                characterImgHeight = chara?.size?.height ?: 0,
                 skillName = pv.participant.skill?.name.orEmpty(),
                 liveStatus = liveStatusOf(pv.participant).orEmpty(),
                 campName = pv.participant.camp?.name.orEmpty(),
@@ -145,20 +147,18 @@ data class PlayerDetailView(
             )
         }
 
-        private fun lookupChara(pv: ParticipateVillage, charas: Charas, originalCharas: Charas): Chara {
+        private fun lookupChara(pv: ParticipateVillage, charas: Charas, originalCharas: Charas): Chara? {
             val charaId = pv.participant.charaId
-            return if (pv.village.setting.chara.isOriginalCharachip) {
-                originalCharas.chara(charaId)
-            } else {
-                charas.chara(charaId)
-            }
+            val pool = if (pv.village.setting.chara.isOriginalCharachip) originalCharas else charas
+            return pool.list.firstOrNull { it.id == charaId }
         }
 
         private fun liveStatusOf(participant: VillageParticipant): String? {
             if (participant.isSpectator) return null
             if (!participant.dead.isDead) return "生存"
-            val deadDay = participant.dead.deadDay!!
-            val reason = participant.dead.reason!!.name
+            // isDead=true なら deadDay / reason は必ず set される (ドメイン制約) が、データ不整合への防御。
+            val deadDay = participant.dead.deadDay ?: return "不明"
+            val reason = participant.dead.reason?.name ?: return "${deadDay}d 不明"
             return if (reason.endsWith("死")) "${deadDay}d $reason"
             else "${deadDay}d ${reason}死"
         }

--- a/backend/src/main/kotlin/com/ort/app/api/response/player/PlayerView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/player/PlayerView.kt
@@ -1,0 +1,38 @@
+package com.ort.app.api.response.player
+
+import com.ort.app.domain.model.player.Player
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 自分視点のプレイヤー基本情報。
+ *
+ * `/api/v1/players/me` で返す軽量プロフィール。村作成 / 参加可否などの導線判定に必要な
+ * フラグも含む。戦績や参加履歴は `PlayerDetailView` (`/api/v1/players/{userName}`) を参照。
+ */
+@Schema(description = "プレイヤー (自分視点)")
+data class PlayerView(
+    @field:Schema(description = "プレイヤー名")
+    val name: String,
+    @field:Schema(description = "Twitter ユーザ名 (未設定なら null)")
+    val twitterUserName: String?,
+    @field:Schema(description = "自己紹介 (未設定なら null)")
+    val introduction: String?,
+    @field:Schema(description = "権限コード", example = "プレイヤー")
+    val authorityCode: String,
+    @field:Schema(description = "権限名", example = "プレイヤー")
+    val authorityName: String,
+    @field:Schema(description = "参加制限中か")
+    val isRestrictedParticipation: Boolean,
+    @field:Schema(description = "村作成可能か")
+    val isAvailableCreateVillage: Boolean,
+) {
+    constructor(player: Player) : this(
+        name = player.name,
+        twitterUserName = player.twitterUserName,
+        introduction = player.introduction,
+        authorityCode = player.authority.code,
+        authorityName = player.authority.name,
+        isRestrictedParticipation = player.isRestrictedParticipation,
+        isAvailableCreateVillage = player.isAvailableCreateVillage(),
+    )
+}

--- a/backend/src/main/kotlin/com/ort/app/api/response/player/PlayersView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/player/PlayersView.kt
@@ -1,0 +1,61 @@
+package com.ort.app.api.response.player
+
+import com.ort.app.domain.model.player.Players
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * プレイヤー一覧 (ページング付き)。
+ *
+ * 旧 `/user-list` (Thymeleaf) の置き換え。1 件あたりは `name` のみで、詳細は
+ * `/api/v1/players/{userName}` で別途取得する。
+ */
+@Schema(description = "プレイヤー一覧 (ページング)")
+data class PlayersView(
+    @field:Schema(description = "プレイヤーリスト")
+    val list: List<PlayerSummaryView>,
+    @field:Schema(description = "総ページ数")
+    val allPageCount: Int,
+    @field:Schema(description = "前ページが存在するか")
+    val isExistPrePage: Boolean,
+    @field:Schema(description = "次ページが存在するか")
+    val isExistNextPage: Boolean,
+    @field:Schema(description = "現在のページ番号 (1 起点)")
+    val currentPageNum: Int,
+    @field:Schema(description = "ページャに表示するページ番号 (現在ページ前後 ±2 / 端でクランプ)")
+    val pageNumList: List<Int>,
+) {
+    @Schema(description = "プレイヤーサマリ")
+    data class PlayerSummaryView(
+        @field:Schema(description = "プレイヤー名")
+        val name: String,
+    )
+
+    constructor(players: Players) : this(
+        list = players.list.map { PlayerSummaryView(name = it.name) },
+        allPageCount = players.allPageCount,
+        isExistPrePage = players.isExistPrePage,
+        isExistNextPage = players.isExistNextPage,
+        currentPageNum = players.currentPageNum,
+        pageNumList = buildPageNumList(players),
+    )
+
+    companion object {
+        private fun buildPageNumList(players: Players): List<Int> {
+            val allPageCount = players.allPageCount
+            if (allPageCount <= 0) return emptyList()
+            val currentPageNumber = players.currentPageNum
+            var startPage = currentPageNumber - 2
+            var endPage = currentPageNumber + 2
+            if (startPage < 1) {
+                startPage = 1
+                endPage = 5
+            }
+            if (endPage > allPageCount) {
+                endPage = allPageCount
+                startPage = allPageCount - 4
+                if (startPage < 1) startPage = 1
+            }
+            return (startPage..endPage).toList()
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/response/player/PlayersView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/player/PlayersView.kt
@@ -40,21 +40,15 @@ data class PlayersView(
     )
 
     companion object {
+        // 現在ページの ±2 を表示し、端では 5 件埋め (1〜5 / N-4〜N)。総ページ 0 件なら空。
         private fun buildPageNumList(players: Players): List<Int> {
             val allPageCount = players.allPageCount
             if (allPageCount <= 0) return emptyList()
-            val currentPageNumber = players.currentPageNum
-            var startPage = currentPageNumber - 2
-            var endPage = currentPageNumber + 2
-            if (startPage < 1) {
-                startPage = 1
-                endPage = 5
-            }
-            if (endPage > allPageCount) {
-                endPage = allPageCount
-                startPage = allPageCount - 4
-                if (startPage < 1) startPage = 1
-            }
+            val current = players.currentPageNum
+            val rawStart = maxOf(1, current - 2)
+            val rawEnd = rawStart + 4
+            val endPage = minOf(rawEnd, allPageCount)
+            val startPage = maxOf(1, endPage - 4)
             return (startPage..endPage).toList()
         }
     }

--- a/backend/src/main/kotlin/com/ort/app/api/v1/players/PlayerRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/players/PlayerRestController.kt
@@ -2,8 +2,8 @@ package com.ort.app.api.v1.players
 
 import com.ort.app.api.request.player.PlayerPasswordBody
 import com.ort.app.api.request.player.PlayerProfileBody
+import com.ort.app.api.response.player.MePlayerView
 import com.ort.app.api.response.player.PlayerDetailView
-import com.ort.app.api.response.player.PlayerView
 import com.ort.app.api.response.player.PlayersView
 import com.ort.app.application.coordinator.PlayerCoordinator
 import com.ort.app.application.service.CharaService
@@ -40,7 +40,12 @@ import org.springframework.web.bind.annotation.RestController
  * (HTTP 400)。旧 Thymeleaf 系の他 controller と同じ規約に揃えている。
  *
  * パスワード変更は現パスワード再入力を要求しない (旧実装に合わせる)。JWT cookie で
- * 既に認証されているユーザのみが叩ける前提。
+ * 既に認証されているユーザのみが叩ける前提。トレードオフ:
+ * - 強み: ユーザビリティ重視、旧 Thymeleaf 実装からの行動互換
+ * - 弱み: XSS で cookie を奪われた攻撃者がパスワードを書き換えてセッション奪取を持続できる
+ *         (それでも HttpOnly cookie の前提があるので XSS が必要なため敷居は高い)
+ * Step 12 / 13 で旧画面復元 → デザインモダナイズの過程でセキュリティ強化 (現パスワード要求 +
+ * パスワード長制限緩和) を一括検討する見込み。
  */
 @RestController
 @RequestMapping("/api/v1/players")
@@ -69,9 +74,9 @@ class PlayerRestController(
         summary = "自プロフィール取得",
         description = "ログイン中のプレイヤーの基本情報を返す。未ログインなら 400。",
     )
-    fun me(): PlayerView {
+    fun me(): MePlayerView {
         val player = currentPlayer()
-        return PlayerView(player)
+        return MePlayerView(player)
     }
 
     @PutMapping("/me/profile")

--- a/backend/src/main/kotlin/com/ort/app/api/v1/players/PlayerRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/players/PlayerRestController.kt
@@ -1,0 +1,140 @@
+package com.ort.app.api.v1.players
+
+import com.ort.app.api.request.player.PlayerPasswordBody
+import com.ort.app.api.request.player.PlayerProfileBody
+import com.ort.app.api.response.player.PlayerDetailView
+import com.ort.app.api.response.player.PlayerView
+import com.ort.app.api.response.player.PlayersView
+import com.ort.app.application.coordinator.PlayerCoordinator
+import com.ort.app.application.service.CharaService
+import com.ort.app.application.service.PlayerService
+import com.ort.app.fw.exception.WolfMansionBusinessException
+import com.ort.app.fw.exception.WolfMansionRecordNotFoundException
+import com.ort.app.fw.util.WolfMansionUserInfoUtil
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * プレイヤー (= ユーザ) 系の REST API。
+ *
+ * 旧 `PlayerController` (Thymeleaf) の置き換え。
+ *
+ * - `GET /api/v1/players` 一覧 (ページング、認証不要)
+ * - `GET /api/v1/players/me` 自プロフィール (認証必須)
+ * - `PUT /api/v1/players/me/profile` 自プロフィール更新 (認証必須)
+ * - `PUT /api/v1/players/me/password` 自パスワード変更 (認証必須)
+ * - `GET /api/v1/players/{userName}` 詳細 (戦績 + 参加履歴、認証不要)
+ *
+ * 認証必須エンドポイントは未ログイン時に [WolfMansionBusinessException] を投げる
+ * (HTTP 400)。旧 Thymeleaf 系の他 controller と同じ規約に揃えている。
+ *
+ * パスワード変更は現パスワード再入力を要求しない (旧実装に合わせる)。JWT cookie で
+ * 既に認証されているユーザのみが叩ける前提。
+ */
+@RestController
+@RequestMapping("/api/v1/players")
+@Tag(name = "players", description = "プレイヤー")
+class PlayerRestController(
+    private val playerService: PlayerService,
+    private val playerCoordinator: PlayerCoordinator,
+    private val charaService: CharaService,
+) {
+
+    @GetMapping
+    @Operation(
+        summary = "プレイヤー一覧取得",
+        description = "ページング付き。1 ページあたり 30 件。",
+    )
+    fun list(
+        @Parameter(description = "ページ番号 (1 起点、未指定なら 1)")
+        @RequestParam(required = false) pageNum: Int?,
+    ): PlayersView {
+        val players = playerService.findAllPlayers(pageSize = PAGE_SIZE, pageNum = pageNum ?: 1)
+        return PlayersView(players)
+    }
+
+    @GetMapping("/me")
+    @Operation(
+        summary = "自プロフィール取得",
+        description = "ログイン中のプレイヤーの基本情報を返す。未ログインなら 400。",
+    )
+    fun me(): PlayerView {
+        val player = currentPlayer()
+        return PlayerView(player)
+    }
+
+    @PutMapping("/me/profile")
+    @Operation(
+        summary = "自プロフィール更新",
+        description = "Twitter ユーザ名 / 自己紹介を更新する。各フィールド null でクリア。",
+    )
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun updateProfile(@Valid @RequestBody body: PlayerProfileBody) {
+        val player = currentPlayer()
+        playerService.updatePlayerDetail(player.name, body.twitterUserName, body.introduction)
+    }
+
+    @PutMapping("/me/password")
+    @Operation(
+        summary = "自パスワード変更",
+        description = "新しいパスワードと確認用パスワードが一致する場合のみ更新する。" +
+                "現パスワードの再入力は要求しない (旧実装互換)。",
+    )
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun changePassword(@Valid @RequestBody body: PlayerPasswordBody) {
+        val player = currentPlayer()
+        if (body.password != body.confirmPassword) {
+            throw WolfMansionBusinessException("確認用パスワードが一致しません")
+        }
+        playerService.updatePassword(player.name, body.password)
+    }
+
+    @GetMapping("/{userName}")
+    @Operation(
+        summary = "プレイヤー詳細取得",
+        description = "プロフィール + 戦績 + 参加 / 見学した村の履歴を返す。認証不要。" +
+                "閲覧者自身のページなら `isSelf=true` を返す。",
+    )
+    fun detail(@PathVariable userName: String): PlayerDetailView {
+        val player = playerService.findPlayer(userName)
+            ?: throw WolfMansionRecordNotFoundException("player not found. name=$userName")
+        val records = playerCoordinator.findPlayerRecords(player)
+
+        val (originalVillages, normalVillages) = records.participateVillageList.partition {
+            it.village.setting.chara.isOriginalCharachip
+        }
+        val originalCharas = charaService.findCharasByCharachipId(originalVillages.map { it.participant.charaId }, true)
+        val charas = charaService.findCharasByCharachipId(normalVillages.map { it.participant.charaId }, false)
+
+        val viewer = WolfMansionUserInfoUtil.getUserInfo()?.username
+        val isSelf = viewer != null && viewer == player.name
+
+        return PlayerDetailView.of(
+            player = player,
+            records = records,
+            charas = charas,
+            originalCharas = originalCharas,
+            isSelf = isSelf,
+        )
+    }
+
+    private fun currentPlayer() =
+        WolfMansionUserInfoUtil.getUserInfo()?.username
+            ?.let { playerService.findPlayer(it) }
+            ?: throw WolfMansionBusinessException("ログインが必要です")
+
+    companion object {
+        private const val PAGE_SIZE = 30
+    }
+}

--- a/backend/src/test/kotlin/com/ort/app/api/v1/players/PlayerRestControllerTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/api/v1/players/PlayerRestControllerTest.kt
@@ -1,0 +1,263 @@
+package com.ort.app.api.v1.players
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ort.app.api.v1.villages.authed
+import com.ort.app.application.coordinator.PlayerCoordinator
+import com.ort.app.application.service.CharaService
+import com.ort.app.application.service.PlayerService
+import com.ort.app.domain.model.chara.Charas
+import com.ort.app.domain.model.player.Authority
+import com.ort.app.domain.model.player.Player
+import com.ort.app.domain.model.player.PlayerRecords
+import com.ort.app.domain.model.player.Players
+import com.ort.app.domain.model.player.Record
+import com.ort.app.domain.model.village.Villages
+import com.ort.dbflute.allcommon.CDef
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+
+@SpringBootTest
+class PlayerRestControllerTest {
+
+    @Autowired private lateinit var context: WebApplicationContext
+    @Autowired private lateinit var mapper: ObjectMapper
+
+    @MockitoBean private lateinit var playerService: PlayerService
+    @MockitoBean private lateinit var playerCoordinator: PlayerCoordinator
+    @MockitoBean private lateinit var charaService: CharaService
+
+    private lateinit var mockMvc: MockMvc
+
+    @BeforeEach
+    fun setup() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+            .apply<org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder>(springSecurity())
+            .build()
+    }
+
+    private fun player(
+        id: Int = 1,
+        name: String = "tester",
+        twitter: String? = null,
+        introduction: String? = null,
+        participateFinished: List<Int> = emptyList(),
+    ): Player = Player(
+        id = id,
+        name = name,
+        twitterUserName = twitter,
+        introduction = introduction,
+        authority = Authority(CDef.Authority.プレイヤー),
+        isRestrictedParticipation = false,
+        shouldCheckAccessInfo = true,
+        participateFinishedVillageIdList = participateFinished,
+    )
+
+    @Test
+    fun `GET _players 認証不要で 200 と list を返す`() {
+        whenever(playerService.findAllPlayers(eq(30), eq(1))).thenReturn(
+            Players(
+                list = listOf(player(id = 1, name = "alice"), player(id = 2, name = "bob")),
+                allPageCount = 1,
+                isExistPrePage = false,
+                isExistNextPage = false,
+                currentPageNum = 1,
+            )
+        )
+
+        mockMvc.perform(get("/api/v1/players"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.list[0].name").value("alice"))
+            .andExpect(jsonPath("$.list[1].name").value("bob"))
+            .andExpect(jsonPath("$.currentPageNum").value(1))
+            .andExpect(jsonPath("$.pageNumList[0]").value(1))
+    }
+
+    @Test
+    fun `GET _players pageNum を渡すと service に伝わる`() {
+        whenever(playerService.findAllPlayers(any(), any())).thenReturn(
+            Players(list = emptyList(), allPageCount = 0, currentPageNum = 5)
+        )
+
+        mockMvc.perform(get("/api/v1/players").param("pageNum", "5"))
+            .andExpect(status().isOk)
+
+        verify(playerService).findAllPlayers(eq(30), eq(5))
+    }
+
+    @Test
+    fun `GET _players_me 認証ありで 200 を返す`() {
+        whenever(playerService.findPlayer(eq("tester"))).thenReturn(player(twitter = "tw", introduction = "hi"))
+
+        mockMvc.perform(get("/api/v1/players/me").with(authed()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.name").value("tester"))
+            .andExpect(jsonPath("$.twitterUserName").value("tw"))
+            .andExpect(jsonPath("$.introduction").value("hi"))
+            .andExpect(jsonPath("$.authorityCode").value(CDef.Authority.プレイヤー.code()))
+            .andExpect(jsonPath("$.isRestrictedParticipation").value(false))
+            .andExpect(jsonPath("$.isAvailableCreateVillage").value(false))
+    }
+
+    @Test
+    fun `GET _players_me 未認証なら 400`() {
+        mockMvc.perform(get("/api/v1/players/me"))
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `PUT _players_me_profile 204 で service が呼ばれる`() {
+        whenever(playerService.findPlayer(eq("tester"))).thenReturn(player())
+
+        val body = mapOf("twitterUserName" to "tw", "introduction" to "hello")
+        mockMvc.perform(
+            put("/api/v1/players/me/profile")
+                .with(authed())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(body))
+        ).andExpect(status().isNoContent)
+
+        verify(playerService).updatePlayerDetail(eq("tester"), eq("tw"), eq("hello"))
+    }
+
+    @Test
+    fun `PUT _players_me_profile null フィールドで両方クリア`() {
+        whenever(playerService.findPlayer(eq("tester"))).thenReturn(player())
+
+        val body = mapOf<String, Any?>("twitterUserName" to null, "introduction" to null)
+        mockMvc.perform(
+            put("/api/v1/players/me/profile")
+                .with(authed())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(body))
+        ).andExpect(status().isNoContent)
+
+        verify(playerService).updatePlayerDetail(eq("tester"), eq<String?>(null), eq<String?>(null))
+    }
+
+    @Test
+    fun `PUT _players_me_profile twitter 51 文字で 400`() {
+        whenever(playerService.findPlayer(eq("tester"))).thenReturn(player())
+
+        val body = mapOf("twitterUserName" to "a".repeat(51))
+        mockMvc.perform(
+            put("/api/v1/players/me/profile")
+                .with(authed())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(body))
+        ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `PUT _players_me_password 204 で service が呼ばれる`() {
+        whenever(playerService.findPlayer(eq("tester"))).thenReturn(player())
+
+        val body = mapOf("password" to "abc123", "confirmPassword" to "abc123")
+        mockMvc.perform(
+            put("/api/v1/players/me/password")
+                .with(authed())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(body))
+        ).andExpect(status().isNoContent)
+
+        verify(playerService).updatePassword(eq("tester"), eq("abc123"))
+    }
+
+    @Test
+    fun `PUT _players_me_password 確認用と不一致なら 400`() {
+        whenever(playerService.findPlayer(eq("tester"))).thenReturn(player())
+
+        val body = mapOf("password" to "abc123", "confirmPassword" to "xyz999")
+        mockMvc.perform(
+            put("/api/v1/players/me/password")
+                .with(authed())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(body))
+        ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `PUT _players_me_password 形式 NG (記号混入) で 400`() {
+        whenever(playerService.findPlayer(eq("tester"))).thenReturn(player())
+
+        val body = mapOf("password" to "abc!@#", "confirmPassword" to "abc!@#")
+        mockMvc.perform(
+            put("/api/v1/players/me/password")
+                .with(authed())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(body))
+        ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `PUT _players_me_password 未認証なら 400`() {
+        val body = mapOf("password" to "abc123", "confirmPassword" to "abc123")
+        mockMvc.perform(
+            put("/api/v1/players/me/password")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(body))
+        ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `GET _players_userName 200 で detail を返す`() {
+        val target = player(name = "alice", twitter = "alice_tw", introduction = "hi alice")
+        whenever(playerService.findPlayer(eq("alice"))).thenReturn(target)
+        whenever(playerCoordinator.findPlayerRecords(eq(target))).thenReturn(
+            PlayerRecords(
+                player = target,
+                wholeRecord = Record(participateCount = 3, winCount = 2, winRate = 0.6667f),
+                campRecordList = emptyList(),
+                skillRecordList = emptyList(),
+                participateVillageList = emptyList(),
+            )
+        )
+        whenever(charaService.findCharasByCharachipId(any(), any())).thenReturn(Charas(list = emptyList()))
+
+        mockMvc.perform(get("/api/v1/players/alice"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.name").value("alice"))
+            .andExpect(jsonPath("$.twitterUserName").value("alice_tw"))
+            .andExpect(jsonPath("$.introduction").value("hi alice"))
+            .andExpect(jsonPath("$.isSelf").value(false))
+            .andExpect(jsonPath("$.wholeStats.participateNum").value(3))
+            .andExpect(jsonPath("$.wholeStats.winNum").value(2))
+    }
+
+    @Test
+    fun `GET _players_userName 認証ありで自分のページなら isSelf=true`() {
+        val target = player(name = "tester")
+        whenever(playerService.findPlayer(eq("tester"))).thenReturn(target)
+        whenever(playerCoordinator.findPlayerRecords(eq(target))).thenReturn(
+            PlayerRecords(player = target, villages = Villages(list = emptyList()))
+        )
+        whenever(charaService.findCharasByCharachipId(any(), any())).thenReturn(Charas(list = emptyList()))
+
+        mockMvc.perform(get("/api/v1/players/tester").with(authed()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.isSelf").value(true))
+    }
+
+    @Test
+    fun `GET _players_userName 存在しないユーザは 404`() {
+        whenever(playerService.findPlayer(eq("ghost"))).thenReturn(null)
+
+        mockMvc.perform(get("/api/v1/players/ghost"))
+            .andExpect(status().isNotFound)
+    }
+}

--- a/frontend/app/features/player/PasswordChangeForm.tsx
+++ b/frontend/app/features/player/PasswordChangeForm.tsx
@@ -1,0 +1,104 @@
+import { useState, type FormEvent } from "react";
+import { useChangePasswordMutation } from "./hooks";
+
+/**
+ * 自分のパスワード変更フォーム。
+ *
+ * backend 側は新パスワード + 確認用 2 つだけを受け取る (旧実装互換、現パスワード再入力なし)。
+ * 文字数 3〜12、英数字のみ、というルールも backend と揃える。
+ */
+export function PasswordChangeForm() {
+  const mutation = useChangePasswordMutation();
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [done, setDone] = useState(false);
+  const [clientError, setClientError] = useState<string | null>(null);
+
+  function validate(): string | null {
+    if (password.length < 3 || password.length > 12) {
+      return "パスワードは英数字 3〜12 文字で入力してください。";
+    }
+    if (!/^[a-zA-Z0-9]+$/.test(password)) {
+      return "パスワードは英数字のみ使用できます。";
+    }
+    if (password !== confirmPassword) {
+      return "確認用パスワードが一致しません。";
+    }
+    return null;
+  }
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setDone(false);
+    const err = validate();
+    if (err) {
+      setClientError(err);
+      return;
+    }
+    setClientError(null);
+    try {
+      await mutation.mutateAsync({ password, confirmPassword });
+      setDone(true);
+      setPassword("");
+      setConfirmPassword("");
+    } catch {
+      // mutation.error で表示
+    }
+  }
+
+  const errorMessage =
+    clientError ??
+    (mutation.error ? "パスワード変更に失敗しました。入力を見直すか、しばらく経ってから再試行してください。" : null);
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-3">
+      <div className="space-y-1">
+        <label htmlFor="new-password" className="block text-sm font-medium text-slate-300">
+          新しいパスワード
+        </label>
+        <input
+          id="new-password"
+          type="password"
+          value={password}
+          autoComplete="new-password"
+          onChange={(e) => setPassword(e.target.value)}
+          className="w-full rounded-md bg-slate-900 border border-slate-600 px-3 py-2 text-slate-100 focus:border-indigo-400 focus:outline-none"
+          placeholder="英数字 3〜12 文字"
+        />
+      </div>
+
+      <div className="space-y-1">
+        <label htmlFor="confirm-password" className="block text-sm font-medium text-slate-300">
+          確認用パスワード
+        </label>
+        <input
+          id="confirm-password"
+          type="password"
+          value={confirmPassword}
+          autoComplete="new-password"
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          className="w-full rounded-md bg-slate-900 border border-slate-600 px-3 py-2 text-slate-100 focus:border-indigo-400 focus:outline-none"
+        />
+      </div>
+
+      {errorMessage && (
+        <p role="alert" className="text-sm text-red-400">
+          {errorMessage}
+        </p>
+      )}
+      {done && (
+        <p role="status" className="text-sm text-emerald-400">
+          パスワードを変更しました。
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={mutation.isPending}
+        className="rounded-md bg-rose-600 hover:bg-rose-500 disabled:bg-slate-600 disabled:cursor-not-allowed px-5 py-2 font-semibold transition"
+      >
+        {mutation.isPending ? "変更中..." : "パスワードを変更"}
+      </button>
+    </form>
+  );
+}

--- a/frontend/app/features/player/PlayerProfileForm.tsx
+++ b/frontend/app/features/player/PlayerProfileForm.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState, type FormEvent } from "react";
+import { useUpdateProfileMutation } from "./hooks";
+
+/**
+ * 自分のプロフィール (Twitter / 自己紹介) 編集フォーム。
+ *
+ * 親 (`players.$userName.tsx`) で `isSelf=true` のときのみ描画される前提。
+ * 成功すると detail / me cache が invalidate される → 親側で最新値が再 fetch される。
+ */
+export function PlayerProfileForm(props: {
+  userName: string;
+  initialTwitter: string | null | undefined;
+  initialIntroduction: string | null | undefined;
+}) {
+  const { userName, initialTwitter, initialIntroduction } = props;
+  const mutation = useUpdateProfileMutation(userName);
+  const [twitter, setTwitter] = useState(initialTwitter ?? "");
+  const [introduction, setIntroduction] = useState(initialIntroduction ?? "");
+  const [done, setDone] = useState(false);
+
+  // detail 再 fetch で初期値が変わった場合は同期する (自身の編集成功後など)
+  useEffect(() => {
+    setTwitter(initialTwitter ?? "");
+  }, [initialTwitter]);
+  useEffect(() => {
+    setIntroduction(initialIntroduction ?? "");
+  }, [initialIntroduction]);
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setDone(false);
+    try {
+      await mutation.mutateAsync({
+        twitterUserName: twitter.trim() === "" ? null : twitter.trim(),
+        introduction: introduction.trim() === "" ? null : introduction.trim(),
+      });
+      setDone(true);
+    } catch {
+      // mutation.error で表示する
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-3">
+      <div className="space-y-1">
+        <label htmlFor="twitter" className="block text-sm font-medium text-slate-300">
+          Twitter ユーザ名
+        </label>
+        <input
+          id="twitter"
+          type="text"
+          value={twitter}
+          maxLength={50}
+          onChange={(e) => setTwitter(e.target.value)}
+          className="w-full rounded-md bg-slate-900 border border-slate-600 px-3 py-2 text-slate-100 focus:border-indigo-400 focus:outline-none"
+          placeholder="例: my_handle (@ なし)"
+        />
+      </div>
+
+      <div className="space-y-1">
+        <label htmlFor="introduction" className="block text-sm font-medium text-slate-300">
+          自己紹介
+        </label>
+        <textarea
+          id="introduction"
+          value={introduction}
+          maxLength={2000}
+          rows={4}
+          onChange={(e) => setIntroduction(e.target.value)}
+          className="w-full rounded-md bg-slate-900 border border-slate-600 px-3 py-2 text-slate-100 focus:border-indigo-400 focus:outline-none"
+          placeholder="他プレイヤーに見せる自己紹介 (2000 文字まで)"
+        />
+        <p className="text-xs text-slate-500">{introduction.length} / 2000</p>
+      </div>
+
+      {mutation.error && (
+        <p role="alert" className="text-sm text-red-400">
+          更新に失敗しました。入力を見直すか、しばらく経ってから再試行してください。
+        </p>
+      )}
+      {done && (
+        <p role="status" className="text-sm text-emerald-400">
+          プロフィールを更新しました。
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={mutation.isPending}
+        className="rounded-md bg-indigo-500 hover:bg-indigo-400 disabled:bg-slate-600 disabled:cursor-not-allowed px-5 py-2 font-semibold transition"
+      >
+        {mutation.isPending ? "更新中..." : "プロフィールを更新"}
+      </button>
+    </form>
+  );
+}

--- a/frontend/app/features/player/PlayerRecords.tsx
+++ b/frontend/app/features/player/PlayerRecords.tsx
@@ -1,0 +1,169 @@
+import { Link } from "react-router";
+import type { PlayerDetailView } from "./api";
+
+/**
+ * 戦績 + 参加村 / 見学村 履歴の表示。閲覧者によらず常に同じ内容。
+ */
+export function PlayerRecords(props: { detail: PlayerDetailView }) {
+  const { detail } = props;
+  return (
+    <div className="space-y-6">
+      <WholeStats detail={detail} />
+      <CampStats detail={detail} />
+      <SkillStats detail={detail} />
+      <ParticipateVillages
+        title="参加した村"
+        list={detail.participateVillageList}
+        emptyMessage="参加した村はまだありません。"
+      />
+      <ParticipateVillages
+        title="見学した村"
+        list={detail.spectateVillageList}
+        emptyMessage="見学した村はまだありません。"
+      />
+    </div>
+  );
+}
+
+function formatRate(rate: number | undefined): string {
+  if (rate == null) return "0%";
+  return `${Math.round(rate * 1000) / 10}%`;
+}
+
+function WholeStats({ detail }: { detail: PlayerDetailView }) {
+  const s = detail.wholeStats;
+  return (
+    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
+      <h2 className="text-lg font-bold mb-3">総合戦績</h2>
+      <dl className="grid grid-cols-3 gap-3 text-center">
+        <div>
+          <dt className="text-xs text-slate-400">参加</dt>
+          <dd className="text-2xl font-mono">{s?.participateNum ?? 0}</dd>
+        </div>
+        <div>
+          <dt className="text-xs text-slate-400">勝利</dt>
+          <dd className="text-2xl font-mono">{s?.winNum ?? 0}</dd>
+        </div>
+        <div>
+          <dt className="text-xs text-slate-400">勝率</dt>
+          <dd className="text-2xl font-mono">{formatRate(s?.winRate)}</dd>
+        </div>
+      </dl>
+    </section>
+  );
+}
+
+function CampStats({ detail }: { detail: PlayerDetailView }) {
+  const list = detail.campStatsList ?? [];
+  const haveData = list.some((c) => (c.stats?.participateNum ?? 0) > 0);
+  if (!haveData) return null;
+  return (
+    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
+      <h2 className="text-lg font-bold mb-3">陣営別戦績</h2>
+      <table className="w-full text-sm">
+        <thead className="text-xs text-slate-400">
+          <tr>
+            <th className="text-left py-1">陣営</th>
+            <th className="text-right">参加</th>
+            <th className="text-right">勝利</th>
+            <th className="text-right">勝率</th>
+          </tr>
+        </thead>
+        <tbody>
+          {list.map((c) => {
+            const n = c.stats?.participateNum ?? 0;
+            if (n === 0) return null;
+            return (
+              <tr key={c.campName} className="border-t border-slate-700">
+                <td className="py-1">{c.campName}</td>
+                <td className="text-right font-mono">{n}</td>
+                <td className="text-right font-mono">{c.stats?.winNum ?? 0}</td>
+                <td className="text-right font-mono">{formatRate(c.stats?.winRate)}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </section>
+  );
+}
+
+function SkillStats({ detail }: { detail: PlayerDetailView }) {
+  const list = detail.skillStatsList ?? [];
+  if (list.length === 0) return null;
+  return (
+    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
+      <h2 className="text-lg font-bold mb-3">役職別戦績</h2>
+      <table className="w-full text-sm">
+        <thead className="text-xs text-slate-400">
+          <tr>
+            <th className="text-left py-1">役職</th>
+            <th className="text-right">参加</th>
+            <th className="text-right">勝利</th>
+            <th className="text-right">勝率</th>
+          </tr>
+        </thead>
+        <tbody>
+          {list.map((s) => (
+            <tr key={s.skillName} className="border-t border-slate-700">
+              <td className="py-1">{s.skillName}</td>
+              <td className="text-right font-mono">{s.stats?.participateNum ?? 0}</td>
+              <td className="text-right font-mono">{s.stats?.winNum ?? 0}</td>
+              <td className="text-right font-mono">{formatRate(s.stats?.winRate)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}
+
+function ParticipateVillages(props: {
+  title: string;
+  list: PlayerDetailView["participateVillageList"] | undefined;
+  emptyMessage: string;
+}) {
+  const list = props.list ?? [];
+  return (
+    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
+      <h2 className="text-lg font-bold mb-3">
+        {props.title} ({list.length})
+      </h2>
+      {list.length === 0 ? (
+        <p className="text-sm text-slate-400">{props.emptyMessage}</p>
+      ) : (
+        <ul className="space-y-2">
+          {list.map((pv) => (
+            <li key={pv.villageId} className="flex items-center gap-3 text-sm">
+              {pv.characterImgUrl && (
+                <img
+                  src={pv.characterImgUrl}
+                  alt={pv.characterName}
+                  width={Math.min(pv.characterImgWidth ?? 60, 60)}
+                  height={Math.min(pv.characterImgHeight ?? 60, 60)}
+                  loading="lazy"
+                  className="rounded bg-slate-900"
+                />
+              )}
+              <div className="flex-1 min-w-0">
+                <Link
+                  to={`/villages/${pv.villageId}`}
+                  className="font-medium hover:text-indigo-300 transition truncate block"
+                >
+                  {pv.villageName}
+                </Link>
+                <p className="text-xs text-slate-400">
+                  {pv.characterName}
+                  {pv.skillName && ` / ${pv.skillName}`}
+                  {pv.campName && ` / ${pv.campName}`}
+                  {pv.liveStatus && ` / ${pv.liveStatus}`}
+                  {pv.winStatus && ` / ${pv.winStatus}`}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/app/features/player/api.ts
+++ b/frontend/app/features/player/api.ts
@@ -6,20 +6,24 @@
 import type { components } from "~/lib/api/generated";
 import { browserFetch, type ApiFetch } from "~/lib/api/client";
 
-export type PlayersView = components["schemas"]["PlayersView"];
-export type PlayerSummaryView = components["schemas"]["PlayerSummaryView"];
-export type PlayerView = components["schemas"]["PlayerView"];
-export type PlayerDetailView = components["schemas"]["PlayerDetailView"];
-
-// NOTE: backend の Kotlin `String?` は SpringDoc 経由で `string` (optional) として出てきて
-// しまい、`null` をリテラル値として受け付ける型情報が落ちる。null 渡し (= 値クリア) を
-// 明示できるよう、generated 型をベースに値側を `| null` に広げて使う。
-// 既存値クリアは `null`、フィールド省略 (undefined) は backend 側で同じく `null` 扱い。
-type Generated = components["schemas"];
-export type PlayerProfileBody = {
-  [K in keyof Generated["PlayerProfileBody"]]: Generated["PlayerProfileBody"][K] | null;
+// NOTE: backend の Kotlin `String?` には `@field:Schema(nullable = true)` も付けているが、
+// SpringDoc + OpenAPI 3.1 では `nullable: true` ではなく `type: ["string", "null"]` 形式に
+// 変換されるべきところを変換せず、`required: false` (= TypeScript の optional) のみが反映される。
+// 結果として generated 型は `twitterUserName?: string` となり、`null` をリテラル値として
+// 受け取る情報が落ちる。フロント側で null を許容するため optional フィールドを `| null` に
+// 広げたエイリアス型を露出する。既存値クリアは `null`、フィールド省略 (undefined) は
+// backend で同じく `null` 扱い。
+type Schemas = components["schemas"];
+type WidenOptionalsToNull<T> = {
+  [K in keyof T]: undefined extends T[K] ? T[K] | null : T[K];
 };
-export type PlayerPasswordBody = Generated["PlayerPasswordBody"];
+
+export type PlayersView = Schemas["PlayersView"];
+export type PlayerSummaryView = Schemas["PlayerSummaryView"];
+export type PlayerView = WidenOptionalsToNull<Schemas["MePlayerView"]>;
+export type PlayerDetailView = WidenOptionalsToNull<Schemas["PlayerDetailView"]>;
+export type PlayerProfileBody = WidenOptionalsToNull<Schemas["PlayerProfileBody"]>;
+export type PlayerPasswordBody = Schemas["PlayerPasswordBody"];
 
 async function readErrorMessage(res: Response): Promise<string> {
   const errBody = await res.text();

--- a/frontend/app/features/player/api.ts
+++ b/frontend/app/features/player/api.ts
@@ -1,0 +1,90 @@
+/**
+ * プレイヤー画面用の型と fetch 関数。
+ * 型は SpringDoc → `pnpm gen:api` で取得した `~/lib/api/generated.ts` を参照する。
+ */
+
+import type { components } from "~/lib/api/generated";
+import { browserFetch, type ApiFetch } from "~/lib/api/client";
+
+export type PlayersView = components["schemas"]["PlayersView"];
+export type PlayerSummaryView = components["schemas"]["PlayerSummaryView"];
+export type PlayerView = components["schemas"]["PlayerView"];
+export type PlayerDetailView = components["schemas"]["PlayerDetailView"];
+
+// NOTE: backend の Kotlin `String?` は SpringDoc 経由で `string` (optional) として出てきて
+// しまい、`null` をリテラル値として受け付ける型情報が落ちる。null 渡し (= 値クリア) を
+// 明示できるよう、generated 型をベースに値側を `| null` に広げて使う。
+// 既存値クリアは `null`、フィールド省略 (undefined) は backend 側で同じく `null` 扱い。
+type Generated = components["schemas"];
+export type PlayerProfileBody = {
+  [K in keyof Generated["PlayerProfileBody"]]: Generated["PlayerProfileBody"][K] | null;
+};
+export type PlayerPasswordBody = Generated["PlayerPasswordBody"];
+
+async function readErrorMessage(res: Response): Promise<string> {
+  const errBody = await res.text();
+  try {
+    const parsed = JSON.parse(errBody) as { message?: string };
+    if (parsed.message) return parsed.message;
+  } catch {
+    // not JSON
+  }
+  return errBody;
+}
+
+/** GET /api/v1/players?pageNum=... — 認証不要 */
+export async function fetchPlayers(
+  pageNum: number,
+  fetcher: ApiFetch = browserFetch,
+): Promise<PlayersView> {
+  const res = await fetcher(`/api/v1/players?pageNum=${pageNum}`);
+  if (!res.ok) throw new Error(`players fetch failed: ${res.status}`);
+  return res.json();
+}
+
+/** GET /api/v1/players/me — 認証必須 (失敗時は例外) */
+export async function fetchMyPlayer(
+  fetcher: ApiFetch = browserFetch,
+): Promise<PlayerView> {
+  const res = await fetcher(`/api/v1/players/me`);
+  if (!res.ok) throw new Error(`my player fetch failed: ${res.status}`);
+  return res.json();
+}
+
+/** GET /api/v1/players/{userName} — 認証不要 */
+export async function fetchPlayerDetail(
+  userName: string,
+  fetcher: ApiFetch = browserFetch,
+): Promise<PlayerDetailView> {
+  const res = await fetcher(`/api/v1/players/${encodeURIComponent(userName)}`);
+  if (!res.ok) throw new Error(`player detail fetch failed: ${res.status}`);
+  return res.json();
+}
+
+/** PUT /api/v1/players/me/profile */
+export async function putMyProfile(
+  body: PlayerProfileBody,
+  fetcher: ApiFetch = browserFetch,
+): Promise<void> {
+  const res = await fetcher(`/api/v1/players/me/profile`, {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`update profile failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+}
+
+/** PUT /api/v1/players/me/password */
+export async function putMyPassword(
+  body: PlayerPasswordBody,
+  fetcher: ApiFetch = browserFetch,
+): Promise<void> {
+  const res = await fetcher(`/api/v1/players/me/password`, {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`change password failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+}

--- a/frontend/app/features/player/hooks.ts
+++ b/frontend/app/features/player/hooks.ts
@@ -1,0 +1,76 @@
+import { useMutation, useQuery, useQueryClient, type UseQueryResult } from "@tanstack/react-query";
+import {
+  fetchMyPlayer,
+  fetchPlayerDetail,
+  fetchPlayers,
+  putMyPassword,
+  putMyProfile,
+  type PlayerDetailView,
+  type PlayerPasswordBody,
+  type PlayerProfileBody,
+  type PlayersView,
+  type PlayerView,
+} from "./api";
+
+export const PLAYERS_QUERY_KEY = (pageNum: number) => ["players", { pageNum }] as const;
+export const PLAYER_DETAIL_QUERY_KEY = (userName: string) => ["players", "detail", userName] as const;
+export const MY_PLAYER_QUERY_KEY = ["players", "me"] as const;
+
+/** GET /api/v1/players */
+export function usePlayersQuery(
+  pageNum: number,
+  initialData?: PlayersView,
+): UseQueryResult<PlayersView> {
+  return useQuery<PlayersView>({
+    queryKey: PLAYERS_QUERY_KEY(pageNum),
+    queryFn: () => fetchPlayers(pageNum),
+    initialData,
+    initialDataUpdatedAt: initialData ? Date.now() : undefined,
+    staleTime: 30 * 1000,
+  });
+}
+
+/** GET /api/v1/players/{userName} */
+export function usePlayerDetailQuery(
+  userName: string,
+  initialData?: PlayerDetailView,
+): UseQueryResult<PlayerDetailView> {
+  return useQuery<PlayerDetailView>({
+    queryKey: PLAYER_DETAIL_QUERY_KEY(userName),
+    queryFn: () => fetchPlayerDetail(userName),
+    initialData,
+    initialDataUpdatedAt: initialData ? Date.now() : undefined,
+    staleTime: 30 * 1000,
+    enabled: userName.length > 0,
+  });
+}
+
+/** GET /api/v1/players/me */
+export function useMyPlayerQuery(initialData?: PlayerView): UseQueryResult<PlayerView> {
+  return useQuery<PlayerView>({
+    queryKey: MY_PLAYER_QUERY_KEY,
+    queryFn: () => fetchMyPlayer(),
+    initialData,
+    initialDataUpdatedAt: initialData ? Date.now() : undefined,
+    staleTime: 30 * 1000,
+  });
+}
+
+/** PUT /api/v1/players/me/profile */
+export function useUpdateProfileMutation(userName: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: PlayerProfileBody) => putMyProfile(body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: PLAYER_DETAIL_QUERY_KEY(userName) });
+      qc.invalidateQueries({ queryKey: MY_PLAYER_QUERY_KEY });
+    },
+  });
+}
+
+/** PUT /api/v1/players/me/password */
+export function useChangePasswordMutation() {
+  return useMutation({
+    mutationFn: (body: PlayerPasswordBody) => putMyPassword(body),
+  });
+}

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -5,6 +5,9 @@ export default [
   route("login", "routes/login.tsx"),
   route("villages", "routes/villages._index.tsx"),
   route("villages/:id", "routes/villages.$id.tsx"),
+  route("players", "routes/players._index.tsx"),
+  // NOTE: 認証不要。`isSelf=true` のときだけ編集 UI が出る (backend が viewer JWT を読んで判定)。
+  route("players/:userName", "routes/players.$userName.tsx"),
   // 認証必須エリア
   layout("routes/_auth.tsx", [
     route("me", "routes/me.tsx"),

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -55,6 +55,12 @@ export default function Home({ loaderData }: Route.ComponentProps) {
             全村一覧
           </Link>
           <Link
+            to="/players"
+            className="rounded-md border border-slate-600 hover:border-slate-400 px-5 py-2 font-semibold transition"
+          >
+            プレイヤー一覧
+          </Link>
+          <Link
             to="/login"
             className="rounded-md border border-slate-600 hover:border-slate-400 px-5 py-2 font-semibold transition"
           >

--- a/frontend/app/routes/me.tsx
+++ b/frontend/app/routes/me.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate, useRouteLoaderData } from "react-router";
+import { Link, useNavigate, useRouteLoaderData } from "react-router";
 import type { Route } from "./+types/me";
 import { useLogoutMutation } from "~/features/auth/hooks";
 
@@ -16,6 +16,8 @@ export default function MePage() {
   const logoutMutation = useLogoutMutation();
   const [logoutError, setLogoutError] = useState<string | null>(null);
 
+  const user = authData.user;
+
   async function onLogout() {
     setLogoutError(null);
     try {
@@ -28,8 +30,6 @@ export default function MePage() {
     }
   }
 
-  const user = authData.user;
-
   return (
     <main className="min-h-screen bg-slate-900 text-slate-100 px-6 py-12">
       <div className="max-w-2xl mx-auto space-y-6">
@@ -39,6 +39,14 @@ export default function MePage() {
           <p className="text-xl font-mono">{user.userId}</p>
           <p className="text-sm text-slate-400 mt-4">権限</p>
           <p className="text-base">{user.authority}</p>
+          <div className="pt-2">
+            <Link
+              to={`/players/${encodeURIComponent(user.userId)}`}
+              className="text-sm text-indigo-300 hover:text-indigo-200 underline"
+            >
+              プロフィール / 戦績 / パスワード変更 →
+            </Link>
+          </div>
         </div>
         {logoutError && (
           <p role="alert" className="text-sm text-red-400">

--- a/frontend/app/routes/players.$userName.tsx
+++ b/frontend/app/routes/players.$userName.tsx
@@ -1,0 +1,111 @@
+import { Link } from "react-router";
+import type { Route } from "./+types/players.$userName";
+import { fetchPlayerDetail } from "~/features/player/api";
+import { usePlayerDetailQuery } from "~/features/player/hooks";
+import { PasswordChangeForm } from "~/features/player/PasswordChangeForm";
+import { PlayerProfileForm } from "~/features/player/PlayerProfileForm";
+import { PlayerRecords } from "~/features/player/PlayerRecords";
+import { ssrFetch } from "~/lib/api/client";
+
+export function meta({ params }: Route.MetaArgs) {
+  return [{ title: `${params.userName} - プレイヤー詳細 - wolf-mansion` }];
+}
+
+export async function loader({ params, request }: Route.LoaderArgs) {
+  const api = ssrFetch(request);
+  const res = await api(`/api/v1/players/${encodeURIComponent(params.userName)}`);
+  if (res.status === 404) {
+    throw new Response("プレイヤーが見つかりません", { status: 404 });
+  }
+  if (!res.ok) {
+    // 5xx 等は CSR で再 fetch させる: 最低限の placeholder を返す
+    return { detail: null as Awaited<ReturnType<typeof fetchPlayerDetail>> | null, userName: params.userName };
+  }
+  const detail = (await res.json()) as Awaited<ReturnType<typeof fetchPlayerDetail>>;
+  return { detail, userName: params.userName };
+}
+
+export default function PlayerDetailPage({ loaderData }: Route.ComponentProps) {
+  const { userName } = loaderData;
+  const detailQuery = usePlayerDetailQuery(userName, loaderData.detail ?? undefined);
+  const detail = detailQuery.data ?? loaderData.detail;
+
+  if (!detail) {
+    return (
+      <main className="min-h-screen bg-slate-900 text-slate-100">
+        <section className="max-w-3xl mx-auto px-6 py-10">
+          <p className="text-sm text-slate-400">読み込み中…</p>
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-900 text-slate-100">
+      <section className="max-w-3xl mx-auto px-6 py-10 space-y-6">
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold">{detail.name}</h1>
+          <Link to="/players" className="text-sm text-slate-400 hover:text-slate-200">
+            ← プレイヤー一覧
+          </Link>
+        </div>
+
+        <ProfileBlock detail={detail} />
+
+        {detail.isSelf && (
+          <>
+            <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4 space-y-3">
+              <h2 className="text-lg font-bold">プロフィール編集</h2>
+              <PlayerProfileForm
+                userName={detail.name}
+                initialTwitter={detail.twitterUserName}
+                initialIntroduction={detail.introduction}
+              />
+            </section>
+
+            <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4 space-y-3">
+              <h2 className="text-lg font-bold">パスワード変更</h2>
+              <PasswordChangeForm />
+            </section>
+          </>
+        )}
+
+        <PlayerRecords detail={detail} />
+      </section>
+    </main>
+  );
+}
+
+function ProfileBlock(props: { detail: NonNullable<Route.ComponentProps["loaderData"]["detail"]> }) {
+  const { detail } = props;
+  return (
+    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4 space-y-2">
+      <h2 className="text-lg font-bold">プロフィール</h2>
+      <dl className="space-y-1 text-sm">
+        <div className="flex gap-2">
+          <dt className="text-slate-400 w-20 shrink-0">Twitter</dt>
+          <dd className="text-slate-100">
+            {detail.twitterUserName ? (
+              <a
+                href={`https://twitter.com/${encodeURIComponent(detail.twitterUserName)}`}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="text-indigo-300 hover:text-indigo-200 underline"
+              >
+                @{detail.twitterUserName}
+              </a>
+            ) : (
+              <span className="text-slate-500">未設定</span>
+            )}
+          </dd>
+        </div>
+        <div className="flex gap-2">
+          <dt className="text-slate-400 w-20 shrink-0">自己紹介</dt>
+          <dd className="text-slate-100 whitespace-pre-wrap break-words">
+            {detail.introduction ? detail.introduction : <span className="text-slate-500">未設定</span>}
+          </dd>
+        </div>
+      </dl>
+    </section>
+  );
+}

--- a/frontend/app/routes/players.$userName.tsx
+++ b/frontend/app/routes/players.$userName.tsx
@@ -30,6 +30,24 @@ export default function PlayerDetailPage({ loaderData }: Route.ComponentProps) {
   const detailQuery = usePlayerDetailQuery(userName, loaderData.detail ?? undefined);
   const detail = detailQuery.data ?? loaderData.detail;
 
+  // SSR で 5xx を握り潰した場合でも、CSR の再 fetch がさらに失敗したら
+  // 永久スピナーにならないようエラー表示に倒す。
+  if (!detail && detailQuery.isError) {
+    return (
+      <main className="min-h-screen bg-slate-900 text-slate-100">
+        <section className="max-w-3xl mx-auto px-6 py-10 space-y-3">
+          <h1 className="text-2xl font-bold">読み込みに失敗しました</h1>
+          <p className="text-sm text-slate-400">
+            プレイヤー情報を取得できませんでした。時間をおいて再度お試しください。
+          </p>
+          <Link to="/players" className="text-sm text-indigo-300 hover:text-indigo-200 underline">
+            ← プレイヤー一覧へ
+          </Link>
+        </section>
+      </main>
+    );
+  }
+
   if (!detail) {
     return (
       <main className="min-h-screen bg-slate-900 text-slate-100">

--- a/frontend/app/routes/players._index.tsx
+++ b/frontend/app/routes/players._index.tsx
@@ -1,0 +1,120 @@
+import { Link, useNavigate, useSearchParams } from "react-router";
+import type { Route } from "./+types/players._index";
+import { fetchPlayers, type PlayersView } from "~/features/player/api";
+import { usePlayersQuery } from "~/features/player/hooks";
+import { ssrFetch } from "~/lib/api/client";
+
+export function meta(_: Route.MetaArgs) {
+  return [{ title: "プレイヤー一覧 - wolf-mansion" }];
+}
+
+function parsePageNum(raw: string | null): number {
+  if (!raw) return 1;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : 1;
+}
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const url = new URL(request.url);
+  const pageNum = parsePageNum(url.searchParams.get("page"));
+  const api = ssrFetch(request);
+  try {
+    const players = await fetchPlayers(pageNum, api);
+    return { players, pageNum };
+  } catch {
+    // SSR fallback (DB ダウン等): 空のページを返してフロントから再取得
+    const empty: PlayersView = {
+      list: [],
+      allPageCount: 0,
+      isExistPrePage: false,
+      isExistNextPage: false,
+      currentPageNum: pageNum,
+      pageNumList: [],
+    };
+    return { players: empty, pageNum };
+  }
+}
+
+export default function PlayersIndex({ loaderData }: Route.ComponentProps) {
+  const [params, setParams] = useSearchParams();
+  const navigate = useNavigate();
+  const pageNum = parsePageNum(params.get("page"));
+  const playersQuery = usePlayersQuery(pageNum, loaderData.players);
+
+  const view = playersQuery.data ?? loaderData.players;
+
+  function goTo(p: number) {
+    const next = new URLSearchParams(params);
+    if (p <= 1) next.delete("page");
+    else next.set("page", String(p));
+    setParams(next, { replace: true });
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-900 text-slate-100">
+      <section className="max-w-3xl mx-auto px-6 py-10 space-y-6">
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold">プレイヤー一覧</h1>
+          <Link to="/" className="text-sm text-slate-400 hover:text-slate-200">
+            ← トップへ
+          </Link>
+        </div>
+
+        {view.list.length === 0 ? (
+          <p className="text-sm text-slate-400">プレイヤーが見つかりません。</p>
+        ) : (
+          <ul className="divide-y divide-slate-700 rounded-xl bg-slate-800/40 border border-slate-700">
+            {view.list.map((p) => (
+              <li key={p.name} className="px-4 py-3 flex items-center justify-between">
+                <button
+                  type="button"
+                  onClick={() => navigate(`/players/${encodeURIComponent(p.name)}`)}
+                  className="text-left text-base hover:text-indigo-300 transition"
+                >
+                  {p.name}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {view.allPageCount > 1 && (
+          <nav className="flex items-center justify-center gap-1 text-sm">
+            <button
+              type="button"
+              onClick={() => goTo(pageNum - 1)}
+              disabled={!view.isExistPrePage}
+              className="rounded-md border border-slate-600 px-2 py-1 hover:border-slate-400 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              前へ
+            </button>
+            {view.pageNumList.map((p) => (
+              <button
+                key={p}
+                type="button"
+                onClick={() => goTo(p)}
+                aria-current={p === view.currentPageNum ? "page" : undefined}
+                className={
+                  "rounded-md px-3 py-1 border transition " +
+                  (p === view.currentPageNum
+                    ? "bg-indigo-500/30 border-indigo-400 text-indigo-100"
+                    : "border-slate-600 text-slate-300 hover:border-slate-400")
+                }
+              >
+                {p}
+              </button>
+            ))}
+            <button
+              type="button"
+              onClick={() => goTo(pageNum + 1)}
+              disabled={!view.isExistNextPage}
+              className="rounded-md border border-slate-600 px-2 py-1 hover:border-slate-400 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              次へ
+            </button>
+          </nav>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/frontend/app/routes/players._index.tsx
+++ b/frontend/app/routes/players._index.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate, useSearchParams } from "react-router";
+import { Link, useSearchParams } from "react-router";
 import type { Route } from "./+types/players._index";
 import { fetchPlayers, type PlayersView } from "~/features/player/api";
 import { usePlayersQuery } from "~/features/player/hooks";
@@ -37,7 +37,6 @@ export async function loader({ request }: Route.LoaderArgs) {
 
 export default function PlayersIndex({ loaderData }: Route.ComponentProps) {
   const [params, setParams] = useSearchParams();
-  const navigate = useNavigate();
   const pageNum = parsePageNum(params.get("page"));
   const playersQuery = usePlayersQuery(pageNum, loaderData.players);
 
@@ -66,13 +65,12 @@ export default function PlayersIndex({ loaderData }: Route.ComponentProps) {
           <ul className="divide-y divide-slate-700 rounded-xl bg-slate-800/40 border border-slate-700">
             {view.list.map((p) => (
               <li key={p.name} className="px-4 py-3 flex items-center justify-between">
-                <button
-                  type="button"
-                  onClick={() => navigate(`/players/${encodeURIComponent(p.name)}`)}
+                <Link
+                  to={`/players/${encodeURIComponent(p.name)}`}
                   className="text-left text-base hover:text-indigo-300 transition"
                 >
                   {p.name}
-                </button>
+                </Link>
               </li>
             ))}
           </ul>

--- a/plan.md
+++ b/plan.md
@@ -549,6 +549,26 @@ WebSocket/SSE 未導入なので、リアルタイム性の e2e は polling 待�
     - `.k8s/` 配下に manifest 配置
     - 画像の外部移管 (ユーザ側で実施) 完了確認
 
+### Step 11 以降 (cutover 後の追加フェーズ、2026-05-19 合意)
+
+monorepo 化 / 機能網羅 / cutover が一通り終わった後に、ユーザ体験の品質を引き上げる
+ためのフェーズを別途設ける。Step 8 系では「機能カバレッジ優先」で、デザインは Tailwind
+素の slate 系を簡素に当てているだけなので、ここで巻き取る。順序は以下:
+
+12. **既存画面のフィーチャー / 視覚的復元**
+    - 旧 Thymeleaf 画面 (削除済) と現 React Router 画面の機能差分を一覧化
+    - 旧画面で当たり前に出ていた情報 (投票結果、墓下、密談、暗号、コミット可否、陣営
+      メンバー一覧、表情差分付き発言フォーム、足音履歴の見せ方など) を React 側に揃える
+    - レイアウト・色味・情報密度も旧画面のメンタルモデルにある程度寄せる (記憶想起しやすさ優先)
+    - スコープが大きいので機能ブロック単位 (村画面 / プレイヤー / admin / creator) で
+      複数 PR に分割
+13. **デザインモダナイズ**
+    - `frontend-design` skill (`Skill(frontend-design ...)`) を使い、12 で揃えた情報構造の
+      上にモダンな visual language を被せる
+    - 共通コンポーネント (`frontend/app/components/ui/`) を整理し、トークン (色 / 余白 / 字游)
+      を集約
+    - Step 13 はビジュアル中心なので機能テストへの影響を最小化する
+
 ## Critical Files
 
 - `/Users/h-orito/ort/wolf/workspace/wolf-mansion/backend/src/main/kotlin/com/ort/app/fw/security/WolfMansionWebSecurityConfig.kt` — security config 全面書き換え (JWT resource server, CORS)


### PR DESCRIPTION
## Summary

Step 8d。旧 Thymeleaf 系の `PlayerController` のうち、プロフィール表示・編集・パスワード変更・戦績/参加履歴を React Router v7 側に移植する。

- backend: `/api/v1/players` REST 群を新設
  - `GET /api/v1/players` ページング付き一覧 (旧 `/user-list` 相当、認証不要)
  - `GET /api/v1/players/me` 自プロフィール (認証必須)
  - `PUT /api/v1/players/me/profile` Twitter / 自己紹介更新
  - `PUT /api/v1/players/me/password` パスワード変更 (新パスワード + 確認用、旧実装互換で現パスワード再入力なし)
  - `GET /api/v1/players/{userName}` 詳細 = プロフィール + 戦績 + 参加 / 見学した村 (旧 `/user/{userName}` 相当)。閲覧者が同名なら `isSelf=true` を返してフロントが編集 UI を出し分ける
- frontend: `/players`, `/players/:userName` 2 routes を新設
  - 詳細画面で `isSelf=true` の時のみ `PlayerProfileForm` (Twitter / 自己紹介) と `PasswordChangeForm` を描画
  - 戦績 (総合 / 陣営別 / 役職別) + 参加 / 見学した村一覧をカード状に並べる
  - `/me` から `/players/{userId}` への動線、トップから `/players` への動線を追加
- plan.md に Step 11 以降 (Step 12 機能/視覚復元 → Step 13 デザインモダナイズ) を明文化

Step 8c までと同様に Tailwind 素デザインのまま。デザインは Step 12 / 13 に集約する方針。

## Test plan

- [ ] `JAVA_HOME=... ./gradlew test --tests com.ort.app.api.v1.players.PlayerRestControllerTest` (14 tests、ローカルで pass 済)
- [ ] `JAVA_HOME=... ./gradlew test` 全体パス確認
- [ ] frontend `pnpm typecheck && pnpm test && pnpm build` (ローカルで pass 済)
- [ ] `pnpm dev` + `./gradlew bootRun` でブラウザ確認: ログイン後 `/players/testuser01` でプロフィール編集 + パスワード変更が動作、他人ページでは編集 UI が出ない、存在しないユーザは 404
- [ ] `/me` の "プロフィール / 戦績 / パスワード変更" リンクから `/players/{userId}` に到達できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)