### PR TITLE
chore: .playwright-mcp/ を gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ backend/dbflute_wolf_mansiondb/log/*
 .serena
 .reviews/
 .issues/
+.playwright-mcp/


### PR DESCRIPTION
## Summary

- Playwright MCP がローカル動作確認時に `.playwright-mcp/` 配下にスクリーンショット / コンソールログを保存するため、tracked にしないよう gitignore に追加。

## Test plan

- [ ] `git status` で `.playwright-mcp/` が untracked にも出てこないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)