### PR TITLE
Step 8e: 村画面 creator / admin 操作 UI (kick / 廃村 / 村建て発言 / epilogue / 全員アクセス / 全員自票 / 強制退村 / プレイヤー確認)

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/request/village/VillageAdminLeaveBody.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/request/village/VillageAdminLeaveBody.kt
@@ -1,0 +1,11 @@
+package com.ort.app.api.request.village
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+
+@Schema(description = "管理者による強制退村リクエスト")
+data class VillageAdminLeaveBody(
+    @field:NotNull
+    @field:Schema(description = "退村させる villagePlayerId (= 参加者 ID)")
+    val villagePlayerId: Int,
+)

--- a/backend/src/main/kotlin/com/ort/app/api/request/village/VillageCreatorSayBody.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/request/village/VillageCreatorSayBody.kt
@@ -1,0 +1,15 @@
+package com.ort.app.api.request.village
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+@Schema(description = "村建て発言リクエスト")
+data class VillageCreatorSayBody(
+    @field:NotBlank
+    @field:Size(max = 400)
+    @field:Schema(description = "発言本文 (400 文字以内)")
+    val message: String,
+    @field:Schema(description = "変換無効フラグ")
+    val convertDisable: Boolean? = null,
+)

--- a/backend/src/main/kotlin/com/ort/app/api/request/village/VillageKickBody.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/request/village/VillageKickBody.kt
@@ -1,0 +1,11 @@
+package com.ort.app.api.request.village
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+
+@Schema(description = "村建てによる強制退村リクエスト")
+data class VillageKickBody(
+    @field:NotNull
+    @field:Schema(description = "退村させるキャラ ID")
+    val charaId: Int,
+)

--- a/backend/src/main/kotlin/com/ort/app/api/response/village/VillageAdminPlayerView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/village/VillageAdminPlayerView.kt
@@ -1,0 +1,11 @@
+package com.ort.app.api.response.village
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "管理者向け: 村参加プレイヤー (キャラ ↔ 中の人) 1 行")
+data class VillageAdminPlayerView(
+    @field:Schema(description = "キャラ名 (略称含む)")
+    val charaName: String,
+    @field:Schema(description = "中の人プレイヤー名")
+    val playerName: String,
+)

--- a/backend/src/main/kotlin/com/ort/app/api/v1/admin/VillageAdminRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/admin/VillageAdminRestController.kt
@@ -1,0 +1,92 @@
+package com.ort.app.api.v1.admin
+
+import com.ort.app.api.request.village.VillageAdminLeaveBody
+import com.ort.app.api.response.village.VillageAdminPlayerView
+import com.ort.app.application.coordinator.VillageCoordinator
+import com.ort.app.application.service.AdminVillageService
+import com.ort.app.application.service.VillageService
+import com.ort.app.fw.exception.WolfMansionBusinessException
+import com.ort.app.fw.exception.WolfMansionRecordNotFoundException
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 管理者 (ROLE_ADMIN) 専用 操作の REST API。
+ *
+ * `/api/v1/admin/` 配下は SecurityConfig で `hasRole("ADMIN")` 必須に設定済みのため、
+ * controller 内で追加の権限チェックは不要。
+ *
+ * 旧 `AdminController` (Thymeleaf form) の置き換え。strong-side operation 用なので
+ * UI 上は管理者のみ AdminPanel から呼び出す想定。
+ *
+ * - GET  /api/v1/admin/villages/{id}/players: 村参加プレイヤー一覧 (キャラ ↔ 中の人)
+ * - POST /api/v1/admin/villages/{id}/access:  全参加者の最終アクセス時刻を now に更新
+ * - POST /api/v1/admin/villages/{id}/vote:    当日未投票の参加者に「自分票」を一括追加
+ * - POST /api/v1/admin/villages/{id}/leave:   指定 villagePlayerId を強制退村
+ */
+@RestController
+@RequestMapping("/api/v1/admin/villages")
+@Tag(name = "admin-villages", description = "管理者向け村操作")
+class VillageAdminRestController(
+    private val adminVillageService: AdminVillageService,
+    private val villageService: VillageService,
+    private val villageCoordinator: VillageCoordinator,
+) {
+
+    @GetMapping("/{villageId}/players")
+    @Operation(
+        summary = "参加プレイヤー一覧",
+        description = "村に参加中のキャラ名と中の人プレイヤー名を返す。退村済 (gone) は除外。",
+    )
+    fun players(@PathVariable villageId: Int): List<VillageAdminPlayerView> {
+        return adminVillageService.listVillageCharaPlayers(villageId).map {
+            VillageAdminPlayerView(charaName = it.charaName, playerName = it.playerName)
+        }
+    }
+
+    @PostMapping("/{villageId}/access")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(
+        summary = "全員アクセス",
+        description = "全参加者の最終アクセス時刻を now() に更新する (突然死しないようにする救済操作)。",
+    )
+    fun forceAccess(@PathVariable villageId: Int) {
+        adminVillageService.updateAllLastAccess(villageId)
+    }
+
+    @PostMapping("/{villageId}/vote")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(
+        summary = "全員自分投票",
+        description = "当日まだ投票していない生存者全員に「自分票」を入れる (進行不能回避用)。",
+    )
+    fun forceVoteForSelf(@PathVariable villageId: Int) {
+        adminVillageService.voteForSelfAll(villageId)
+    }
+
+    @PostMapping("/{villageId}/leave")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(
+        summary = "強制退村 (管理者)",
+        description = "指定 villagePlayerId の参加者を退村させる。assertLeave を通すためプロローグ中のみ成功する。",
+    )
+    fun forceLeave(
+        @PathVariable villageId: Int,
+        @Valid @RequestBody body: VillageAdminLeaveBody,
+    ) {
+        val village = villageService.findVillage(villageId)
+            ?: throw WolfMansionRecordNotFoundException("village not found. id=$villageId")
+        val participant = villageService.findVillageParticipant(body.villagePlayerId)
+            ?: throw WolfMansionBusinessException("参加者が見つかりません")
+        villageCoordinator.leave(village, participant)
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageContextLoader.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageContextLoader.kt
@@ -1,5 +1,6 @@
 package com.ort.app.api.v1.villages
 
+import com.ort.app.application.coordinator.CreatorCoordinator
 import com.ort.app.application.service.PlayerService
 import com.ort.app.application.service.VillageService
 import com.ort.app.domain.model.player.Player
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Component
 class VillageContextLoader(
     private val villageService: VillageService,
     private val playerService: PlayerService,
+    private val creatorCoordinator: CreatorCoordinator,
 ) {
 
     /** 村だけをロードする (匿名 OK)。村が見つからなければ 404。 */
@@ -56,5 +58,20 @@ class VillageContextLoader(
         val user = WolfMansionUserInfoUtil.getUserInfo() ?: return village to null
         val myself = villageService.findVillageParticipant(village.id, user.username)
         return village to myself
+    }
+
+    /**
+     * 村をロードし、現在ユーザがその村の村建てであることを確認する。
+     * 旧 `CreatorCoordinator.isCreator` の判定 (Player ID=1 は全村 creator 扱い) に従う。
+     * 未認証 / creator でない場合は 400。
+     */
+    fun loadVillageAndRequireCreator(villageId: Int): Village {
+        val village = loadVillage(villageId)
+        val user = WolfMansionUserInfoUtil.getUserInfo()
+            ?: throw WolfMansionBusinessException("ログインが必要です")
+        if (!creatorCoordinator.isCreator(user.username, villageId)) {
+            throw WolfMansionBusinessException("この村の村建てではありません")
+        }
+        return village
     }
 }

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageCreatorRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageCreatorRestController.kt
@@ -3,6 +3,7 @@ package com.ort.app.api.v1.villages
 import com.ort.app.api.request.village.VillageCreatorSayBody
 import com.ort.app.api.request.village.VillageKickBody
 import com.ort.app.application.coordinator.CreatorCoordinator
+import com.ort.app.fw.exception.WolfMansionBusinessException
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
@@ -63,7 +64,15 @@ class VillageCreatorRestController(
         @PathVariable villageId: Int,
         @Valid @RequestBody body: VillageKickBody,
     ) {
-        villageContextLoader.loadVillageAndRequireCreator(villageId)
+        val village = villageContextLoader.loadVillageAndRequireCreator(villageId)
+        // CreatorCoordinator.kick は VillageParticipants.chara() (= list.first { ... }) で
+        // 取り出すため、存在しない charaId が来ると NoSuchElementException (= 500) になる。
+        // 事前に参加者に含まれるかを確認して 400 に倒す。
+        val targetExists = village.allParticipants(excludeDummy = true).list
+            .any { it.charaId == body.charaId }
+        if (!targetExists) {
+            throw WolfMansionBusinessException("対象の参加者が見つかりません")
+        }
         creatorCoordinator.kick(villageId, body.charaId)
     }
 

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageCreatorRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageCreatorRestController.kt
@@ -1,0 +1,102 @@
+package com.ort.app.api.v1.villages
+
+import com.ort.app.api.request.village.VillageCreatorSayBody
+import com.ort.app.api.request.village.VillageKickBody
+import com.ort.app.application.coordinator.CreatorCoordinator
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 村建て (creator) 専用操作の REST API。
+ *
+ * 旧 `CreatorController` (Thymeleaf form) の置き換え。本 controller の全 endpoint は
+ * `VillageContextLoader.loadVillageAndRequireCreator` で creator 権限を検証してから
+ * 既存 `CreatorCoordinator` を呼ぶ。Player ID=1 (= 旧 admin user) は全村の creator として
+ * 扱われる仕様 (旧 `CreatorCoordinator.isCreator` 踏襲)。
+ *
+ * - POST /api/v1/villages/{id}/creator-say:    村建て発言 (確認画面なし、preview なし)
+ * - POST /api/v1/villages/{id}/kick:           参加者 1 名を強制退村
+ * - POST /api/v1/villages/{id}/cancel:         廃村 (プロローグ中のみ)
+ * - POST /api/v1/villages/{id}/extend-epilogue: エピローグを 1 日延長
+ * - POST /api/v1/villages/{id}/shorten-epilogue: エピローグを 1 日短縮
+ *
+ * NOTE: 設定変更 (`/settings` の旧 GET/POST) は項目数が膨大なため Step 8e から分離し
+ * 別 step (8f) でまとめて REST 化する。
+ */
+@RestController
+@RequestMapping("/api/v1/villages")
+@Tag(name = "villages", description = "村")
+class VillageCreatorRestController(
+    private val villageContextLoader: VillageContextLoader,
+    private val creatorCoordinator: CreatorCoordinator,
+) {
+
+    @PostMapping("/{villageId}/creator-say")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(
+        summary = "村建て発言",
+        description = "村建てとして発言を登録する。preview なし、確認は frontend のダイアログに委ねる。",
+    )
+    fun creatorSay(
+        @PathVariable villageId: Int,
+        @Valid @RequestBody body: VillageCreatorSayBody,
+    ) {
+        villageContextLoader.loadVillageAndRequireCreator(villageId)
+        creatorCoordinator.say(villageId, body.message, body.convertDisable ?: false)
+    }
+
+    @PostMapping("/{villageId}/kick")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(
+        summary = "強制退村 (村建て)",
+        description = "プロローグ中、指定キャラを村建て権限で退村させる。退村メッセージも自動登録される。",
+    )
+    fun kick(
+        @PathVariable villageId: Int,
+        @Valid @RequestBody body: VillageKickBody,
+    ) {
+        villageContextLoader.loadVillageAndRequireCreator(villageId)
+        creatorCoordinator.kick(villageId, body.charaId)
+    }
+
+    @PostMapping("/{villageId}/cancel")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(
+        summary = "廃村",
+        description = "プロローグ中のみ村を廃村にする。",
+    )
+    fun cancel(@PathVariable villageId: Int) {
+        villageContextLoader.loadVillageAndRequireCreator(villageId)
+        creatorCoordinator.cancel(villageId)
+    }
+
+    @PostMapping("/{villageId}/extend-epilogue")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(
+        summary = "エピローグ延長",
+        description = "エピローグの最終日を 1 日後ろにずらす。",
+    )
+    fun extendEpilogue(@PathVariable villageId: Int) {
+        villageContextLoader.loadVillageAndRequireCreator(villageId)
+        creatorCoordinator.extendEpilogue(villageId)
+    }
+
+    @PostMapping("/{villageId}/shorten-epilogue")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(
+        summary = "エピローグ短縮",
+        description = "エピローグの最終日を 1 日前にずらす (残り 1 日超の場合のみ)。",
+    )
+    fun shortenEpilogue(@PathVariable villageId: Int) {
+        villageContextLoader.loadVillageAndRequireCreator(villageId)
+        creatorCoordinator.shortenEpilogue(villageId)
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
@@ -7,6 +7,7 @@ import com.ort.app.api.response.village.VillageFootstepsView
 import com.ort.app.api.response.village.VillageParticipantView
 import com.ort.app.api.response.village.VillageParticipantsView
 import com.ort.app.api.response.village.VillageView
+import com.ort.app.application.coordinator.CreatorCoordinator
 import com.ort.app.application.coordinator.VillageCoordinator
 import com.ort.app.application.service.AbilityService
 import com.ort.app.application.service.CharaService
@@ -47,6 +48,7 @@ class VillageDetailRestController(
     private val abilityService: AbilityService,
     private val voteService: VoteApplicationService,
     private val villageCoordinator: VillageCoordinator,
+    private val creatorCoordinator: CreatorCoordinator,
     private val spoilerDomainService: SpoilerDomainService,
     private val footstepRevealDomainService: FootstepRevealDomainService,
 ) {
@@ -61,10 +63,15 @@ class VillageDetailRestController(
     ): VillageView {
         val ctx = loadContext(villageId)
         val participants = buildParticipants(ctx)
+        // 旧 Thymeleaf 系 (`CreatorController`) と新 REST creator endpoints の認可判定
+        // (`VillageContextLoader.loadVillageAndRequireCreator`) はどちらも
+        // `CreatorCoordinator.isCreator` を使う = Player ID=1 (管理者) は全村 creator 扱い。
+        // 表示用 `isCreator` を同じ判定で揃え、UI と API 認可の見え方を一致させる。
+        val isCreator = ctx.user?.let { creatorCoordinator.isCreator(it.username, ctx.village.id) } ?: false
         return VillageView(
             village = ctx.village,
             participants = participants,
-            isCreator = ctx.player?.let { ctx.village.isCreator(it) } ?: false,
+            isCreator = isCreator,
             isParticipating = ctx.myself != null,
         )
     }

--- a/backend/src/main/kotlin/com/ort/app/application/service/AdminVillageService.kt
+++ b/backend/src/main/kotlin/com/ort/app/application/service/AdminVillageService.kt
@@ -1,0 +1,81 @@
+package com.ort.app.application.service
+
+import com.ort.dbflute.cbean.VillageDayCB
+import com.ort.dbflute.cbean.VillagePlayerCB
+import com.ort.dbflute.cbean.VoteCB
+import com.ort.dbflute.exbhv.VillageDayBhv
+import com.ort.dbflute.exbhv.VillagePlayerBhv
+import com.ort.dbflute.exbhv.VoteBhv
+import com.ort.dbflute.exentity.VillagePlayer
+import com.ort.dbflute.exentity.Vote
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+/**
+ * 管理者向けの村操作。
+ *
+ * 旧 `AdminController` (Thymeleaf form) で controller 内に書かれていた DBFlute Bhv 直叩きを
+ * application 層に移してテスト境界を整理したもの。本来は infrastructure 層 (DataSource)
+ * に切り出すのがレイヤー的に正しいが、Step 8e の差分を小さく保つため旧実装に合わせ Bhv を
+ * 直接利用している。 Step 11 cutover 後の整理で DataSource 化を検討する。
+ */
+@Service
+class AdminVillageService(
+    private val villageDayBhv: VillageDayBhv,
+    private val villagePlayerBhv: VillagePlayerBhv,
+    private val voteBhv: VoteBhv,
+) {
+
+    /** 村の全参加者の最終アクセス時刻を `now` に更新する。 */
+    fun updateAllLastAccess(villageId: Int) {
+        val vp = VillagePlayer()
+        vp.lastAccessDatetime = LocalDateTime.now()
+        villagePlayerBhv.queryUpdate(vp) { cb: VillagePlayerCB ->
+            cb.query().setVillageId_Equal(villageId)
+        }
+    }
+
+    /** 当日の生存中・現存参加者のうち、まだ投票していない者を全員「自分に投票」させる。 */
+    fun voteForSelfAll(villageId: Int) {
+        val latestDay = villageDayBhv.selectEntity { cb: VillageDayCB ->
+            cb.query().setVillageId_Equal(villageId)
+            cb.query().addOrderBy_Day_Desc()
+            cb.fetchFirst(1)
+        }.get().day
+        val voteCharaIdList = voteBhv.selectList { cb: VoteCB ->
+            cb.query().setVillageId_Equal(villageId)
+            cb.query().setDay_Equal(latestDay)
+        }.map { it.charaId }
+        villagePlayerBhv.selectList { cb: VillagePlayerCB ->
+            cb.query().setVillageId_Equal(villageId)
+            cb.query().setIsGone_Equal_False()
+            cb.query().setIsSpectator_Equal_False()
+            cb.query().setIsDead_Equal_False()
+            if (voteCharaIdList.isNotEmpty()) cb.query().setCharaId_NotInScope(voteCharaIdList)
+        }.forEach { vp ->
+            val vote = Vote()
+            vote.villageId = villageId
+            vote.day = latestDay
+            vote.charaId = vp.charaId
+            vote.voteCharaId = vp.charaId
+            voteBhv.insert(vote)
+        }
+    }
+
+    /** 村の全参加者の「キャラ名 / 中の人名」を返す (gone 含まない)。 */
+    fun listVillageCharaPlayers(villageId: Int): List<CharaPlayerPair> {
+        return villagePlayerBhv.selectList { cb: VillagePlayerCB ->
+            cb.setupSelect_Player()
+            cb.query().setVillageId_Equal(villageId)
+            cb.query().setIsGone_Equal_False()
+            cb.query().addOrderBy_VillagePlayerId_Asc()
+        }.map { vp ->
+            CharaPlayerPair(
+                charaName = vp.charaName,
+                playerName = vp.player.get().playerName,
+            )
+        }
+    }
+
+    data class CharaPlayerPair(val charaName: String, val playerName: String)
+}

--- a/backend/src/main/kotlin/com/ort/app/application/service/AdminVillageService.kt
+++ b/backend/src/main/kotlin/com/ort/app/application/service/AdminVillageService.kt
@@ -9,6 +9,7 @@ import com.ort.dbflute.exbhv.VoteBhv
 import com.ort.dbflute.exentity.VillagePlayer
 import com.ort.dbflute.exentity.Vote
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 
 /**
@@ -35,7 +36,11 @@ class AdminVillageService(
         }
     }
 
-    /** 当日の生存中・現存参加者のうち、まだ投票していない者を全員「自分に投票」させる。 */
+    /**
+     * 当日の生存中・現存参加者のうち、まだ投票していない者を全員「自分に投票」させる。
+     * insert ループ中の例外で部分投票が残らないよう、全体を 1 トランザクションでくくる。
+     */
+    @Transactional
     fun voteForSelfAll(villageId: Int) {
         val latestDay = villageDayBhv.selectEntity { cb: VillageDayCB ->
             cb.query().setVillageId_Equal(villageId)
@@ -62,7 +67,10 @@ class AdminVillageService(
         }
     }
 
-    /** 村の全参加者の「キャラ名 / 中の人名」を返す (gone 含まない)。 */
+    /**
+     * 村の全参加者の「キャラ名 (VILLAGE_PLAYER.CHARA_NAME カラム値、部屋番号の略称は含まない)」と
+     * 「中の人プレイヤー名」を返す (gone 含まない)。
+     */
     fun listVillageCharaPlayers(villageId: Int): List<CharaPlayerPair> {
         return villagePlayerBhv.selectList { cb: VillagePlayerCB ->
             cb.setupSelect_Player()

--- a/frontend/app/features/village/detail/AdminPanel.tsx
+++ b/frontend/app/features/village/detail/AdminPanel.tsx
@@ -1,0 +1,176 @@
+import { useState } from "react";
+import {
+  useAdminForceAccessMutation,
+  useAdminForceLeaveMutation,
+  useAdminForceVoteMutation,
+  useAdminPlayersQuery,
+} from "./hooks";
+import type { VillageParticipantView, VillageView } from "./api";
+
+/**
+ * 管理者 (authority=管理者) 専用パネル。
+ *
+ * - 全員アクセス: 突然死回避用に全員の lastAccessDatetime を now() に更新
+ * - 全員自分票: 当日未投票の生存者全員に「自分票」を入れる (進行不能回避用)
+ * - 強制退村: 任意の villagePlayerId を退村 (assertLeave 経由 = プロローグ中のみ)
+ * - プレイヤー確認: キャラ名 ↔ 中の人プレイヤー名 を表示
+ *
+ * 表示判定 (= 現在ユーザが管理者か) は呼び出し側で担う想定。
+ */
+export function AdminPanel({ village }: { village: VillageView }) {
+  return (
+    <section className="rounded-xl bg-rose-900/10 border border-rose-700/40 p-4 space-y-4">
+      <h2 className="text-sm text-rose-200">管理者メニュー</h2>
+
+      <ForceAccessRow villageId={village.id} />
+      <ForceVoteRow villageId={village.id} />
+      <ForceLeaveSection village={village} />
+      <PlayersListSection villageId={village.id} />
+    </section>
+  );
+}
+
+function ForceAccessRow({ villageId }: { villageId: number }) {
+  const mutation = useAdminForceAccessMutation(villageId);
+  function onClick() {
+    if (!confirm("全参加者の最終アクセス時刻を now に更新します。よろしいですか？")) return;
+    mutation.mutate();
+  }
+  return (
+    <div className="flex items-center justify-between gap-3 flex-wrap border-t border-rose-700/30 pt-3 first:border-t-0 first:pt-0">
+      <p className="text-xs text-rose-200/80">全員アクセス (突然死回避)</p>
+      <div className="flex items-center gap-3">
+        {mutation.isSuccess && <span className="text-xs text-emerald-300">更新済み</span>}
+        {mutation.isError && (
+          <span className="text-xs text-rose-300">{mutation.error.message}</span>
+        )}
+        <button
+          type="button"
+          onClick={onClick}
+          disabled={mutation.isPending}
+          className={secondaryButtonClass}
+        >
+          {mutation.isPending ? "送信中..." : "全員アクセス更新"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ForceVoteRow({ villageId }: { villageId: number }) {
+  const mutation = useAdminForceVoteMutation(villageId);
+  function onClick() {
+    if (!confirm("当日未投票の生存者全員に「自分票」を入れます。よろしいですか？")) return;
+    mutation.mutate();
+  }
+  return (
+    <div className="flex items-center justify-between gap-3 flex-wrap border-t border-rose-700/30 pt-3">
+      <p className="text-xs text-rose-200/80">全員自分票 (進行不能回避)</p>
+      <div className="flex items-center gap-3">
+        {mutation.isSuccess && <span className="text-xs text-emerald-300">投票登録済み</span>}
+        {mutation.isError && (
+          <span className="text-xs text-rose-300">{mutation.error.message}</span>
+        )}
+        <button
+          type="button"
+          onClick={onClick}
+          disabled={mutation.isPending}
+          className={secondaryButtonClass}
+        >
+          {mutation.isPending ? "送信中..." : "全員自分票"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ForceLeaveSection({ village }: { village: VillageView }) {
+  const mutation = useAdminForceLeaveMutation(village.id);
+  // 退村可能なのはプロローグ中の参加者のみ (assertLeave に倣う)。
+  // とはいえ admin パネルとしてはステータスにかかわらず一覧を出し、
+  // backend が assertLeave で 400 を返す挙動に従う方が「管理者は何でもできる」感がある。
+  const candidates = village.participants.list.filter(
+    (p) => !p.isSpectator && !p.isDead,
+  );
+
+  function onLeave(p: VillageParticipantView) {
+    if (!confirm(`「${p.name}」を強制退村させます。よろしいですか？`)) return;
+    mutation.mutate({ villagePlayerId: p.id });
+  }
+
+  return (
+    <div className="border-t border-rose-700/30 pt-3 space-y-2">
+      <p className="text-xs text-rose-200/80">強制退村 (admin) — プロローグ中のみ成功</p>
+      {candidates.length === 0 ? (
+        <p className="text-xs text-slate-400">対象の参加者がいません</p>
+      ) : (
+        <ul className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          {candidates.map((p) => (
+            <li key={p.id} className="flex items-center justify-between gap-2 text-sm">
+              <span className="truncate">{p.name}</span>
+              <button
+                type="button"
+                onClick={() => onLeave(p)}
+                disabled={mutation.isPending}
+                className={dangerButtonClass}
+              >
+                強制退村
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {mutation.isError && (
+        <p className="text-xs text-rose-300">{mutation.error.message}</p>
+      )}
+    </div>
+  );
+}
+
+function PlayersListSection({ villageId }: { villageId: number }) {
+  const [open, setOpen] = useState(false);
+  const query = useAdminPlayersQuery(villageId, open);
+
+  return (
+    <div className="border-t border-rose-700/30 pt-3 space-y-2">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <p className="text-xs text-rose-200/80">参加プレイヤー確認 (キャラ ↔ 中の人)</p>
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className={secondaryButtonClass}
+        >
+          {open ? "閉じる" : "表示する"}
+        </button>
+      </div>
+      {open && (
+        <>
+          {query.isLoading && <p className="text-xs text-slate-400">読み込み中...</p>}
+          {query.isError && (
+            <p className="text-xs text-rose-300">{(query.error as Error).message}</p>
+          )}
+          {query.data && (
+            <ul className="text-sm space-y-1 bg-slate-900/40 rounded p-2 max-h-60 overflow-y-auto">
+              {query.data.length === 0 ? (
+                <li className="text-xs text-slate-400">参加者がいません</li>
+              ) : (
+                query.data.map((row, i) => (
+                  <li key={i} className="flex items-center justify-between gap-3">
+                    <span className="truncate">{row.charaName}</span>
+                    <span className="text-xs text-slate-400 truncate">{row.playerName}</span>
+                  </li>
+                ))
+              )}
+            </ul>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+const secondaryButtonClass =
+  "rounded bg-slate-700 hover:bg-slate-600 disabled:opacity-40 disabled:cursor-not-allowed px-3 py-1.5 text-xs font-medium";
+
+const dangerButtonClass =
+  "rounded bg-rose-600 hover:bg-rose-500 disabled:opacity-40 disabled:cursor-not-allowed px-3 py-1 text-xs font-medium";

--- a/frontend/app/features/village/detail/AdminPanel.tsx
+++ b/frontend/app/features/village/detail/AdminPanel.tsx
@@ -155,7 +155,10 @@ function PlayersListSection({ villageId }: { villageId: number }) {
                 <li className="text-xs text-slate-400">参加者がいません</li>
               ) : (
                 query.data.map((row, i) => (
-                  <li key={i} className="flex items-center justify-between gap-3">
+                  <li
+                    key={`${row.charaName}-${row.playerName}-${i}`}
+                    className="flex items-center justify-between gap-3"
+                  >
                     <span className="truncate">{row.charaName}</span>
                     <span className="text-xs text-slate-400 truncate">{row.playerName}</span>
                   </li>

--- a/frontend/app/features/village/detail/CreatorPanel.tsx
+++ b/frontend/app/features/village/detail/CreatorPanel.tsx
@@ -1,0 +1,213 @@
+import { useState } from "react";
+import {
+  useCancelVillageMutation,
+  useCreatorSayMutation,
+  useExtendEpilogueMutation,
+  useKickMutation,
+  useShortenEpilogueMutation,
+} from "./hooks";
+import type { VillageParticipantView, VillageView } from "./api";
+
+/**
+ * 村建て (creator) 専用パネル。
+ *
+ * 表示判定は呼び出し側で行う想定 (creator 本人 + 管理者は呼び出し側で or 判定)。
+ * 各操作の有効条件はパネル側で村ステータスを見て出し分ける。
+ *
+ * - 募集中: 廃村 / kick (参加者選択)
+ * - 進行中以降: なし (村建て発言のみ常時、エピローグ時のみ延長/短縮)
+ * - エピローグ: 延長 / 短縮
+ *
+ * 村建て発言だけは村ステータスに依らず常時可能。
+ */
+export function CreatorPanel({ village }: { village: VillageView }) {
+  const isPrologue = village.statusCode === "IN_PREPARATION";
+  const isEpilogue = village.statusCode === "EPILOGUE";
+
+  return (
+    <section className="rounded-xl bg-amber-900/10 border border-amber-700/40 p-4 space-y-4">
+      <h2 className="text-sm text-amber-200">村建てメニュー</h2>
+
+      <CreatorSayForm villageId={village.id} />
+
+      {isPrologue && (
+        <>
+          <KickForm village={village} />
+          <CancelButton villageId={village.id} />
+        </>
+      )}
+
+      {isEpilogue && <EpilogueControls villageId={village.id} />}
+    </section>
+  );
+}
+
+function CreatorSayForm({ villageId }: { villageId: number }) {
+  const [text, setText] = useState("");
+  const [convertDisable, setConvertDisable] = useState(false);
+  const mutation = useCreatorSayMutation(villageId);
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    if (!confirm("村建てとして発言します。よろしいですか？")) return;
+    mutation.mutate(
+      { message: trimmed, convertDisable },
+      { onSuccess: () => setText("") },
+    );
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-2 border-t border-amber-700/30 pt-3 first:border-t-0 first:pt-0">
+      <p className="text-xs text-amber-200/80">村建て発言</p>
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        rows={3}
+        maxLength={400}
+        placeholder="村建てとしての発言 (400 文字以内)"
+        className={inputClass}
+        disabled={mutation.isPending}
+      />
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <label className="flex items-center gap-2 text-xs text-slate-200">
+          <input
+            type="checkbox"
+            checked={convertDisable}
+            onChange={(e) => setConvertDisable(e.target.checked)}
+            disabled={mutation.isPending}
+          />
+          変換を無効化
+        </label>
+        <div className="flex items-center gap-3">
+          <span className="text-xs text-slate-500">{text.length} / 400</span>
+          <button
+            type="submit"
+            disabled={mutation.isPending || text.trim().length === 0}
+            className={primaryButtonClass}
+          >
+            {mutation.isPending ? "送信中..." : "村建て発言"}
+          </button>
+        </div>
+      </div>
+      {mutation.isError && (
+        <p className="text-xs text-rose-300">{mutation.error.message}</p>
+      )}
+    </form>
+  );
+}
+
+function KickForm({ village }: { village: VillageView }) {
+  const mutation = useKickMutation(village.id);
+  const candidates = village.participants.list.filter(
+    (p) => !p.isSpectator && !p.isDead,
+  );
+
+  function onKick(p: VillageParticipantView) {
+    if (!confirm(`「${p.name}」を強制退村させます。よろしいですか？`)) return;
+    mutation.mutate({ charaId: p.chara.id });
+  }
+
+  if (candidates.length === 0) {
+    return (
+      <div className="border-t border-amber-700/30 pt-3 space-y-2">
+        <p className="text-xs text-amber-200/80">強制退村 (kick)</p>
+        <p className="text-xs text-slate-400">対象の参加者がいません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-t border-amber-700/30 pt-3 space-y-2">
+      <p className="text-xs text-amber-200/80">強制退村 (kick) — プロローグ中のみ</p>
+      <ul className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        {candidates.map((p) => (
+          <li key={p.id} className="flex items-center justify-between gap-2 text-sm">
+            <span className="truncate">{p.name}</span>
+            <button
+              type="button"
+              onClick={() => onKick(p)}
+              disabled={mutation.isPending}
+              className={dangerButtonClass}
+            >
+              kick
+            </button>
+          </li>
+        ))}
+      </ul>
+      {mutation.isError && (
+        <p className="text-xs text-rose-300">{mutation.error.message}</p>
+      )}
+    </div>
+  );
+}
+
+function CancelButton({ villageId }: { villageId: number }) {
+  const mutation = useCancelVillageMutation(villageId);
+  function onClick() {
+    if (!confirm("この村を廃村にします。よろしいですか？")) return;
+    mutation.mutate();
+  }
+  return (
+    <div className="border-t border-amber-700/30 pt-3 flex items-center gap-3 flex-wrap">
+      <p className="text-xs text-amber-200/80">廃村 (プロローグ中のみ)</p>
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={mutation.isPending}
+        className={dangerButtonClass}
+      >
+        {mutation.isPending ? "送信中..." : "廃村にする"}
+      </button>
+      {mutation.isError && (
+        <span className="text-xs text-rose-300">{mutation.error.message}</span>
+      )}
+    </div>
+  );
+}
+
+function EpilogueControls({ villageId }: { villageId: number }) {
+  const extend = useExtendEpilogueMutation(villageId);
+  const shorten = useShortenEpilogueMutation(villageId);
+  return (
+    <div className="border-t border-amber-700/30 pt-3 space-y-2">
+      <p className="text-xs text-amber-200/80">エピローグ日数の調整</p>
+      <div className="flex items-center gap-3 flex-wrap">
+        <button
+          type="button"
+          onClick={() => extend.mutate()}
+          disabled={extend.isPending || shorten.isPending}
+          className={secondaryButtonClass}
+        >
+          {extend.isPending ? "送信中..." : "1日延長"}
+        </button>
+        <button
+          type="button"
+          onClick={() => shorten.mutate()}
+          disabled={extend.isPending || shorten.isPending}
+          className={secondaryButtonClass}
+        >
+          {shorten.isPending ? "送信中..." : "1日短縮"}
+        </button>
+      </div>
+      {(extend.isError || shorten.isError) && (
+        <p className="text-xs text-rose-300">
+          {extend.error?.message ?? shorten.error?.message}
+        </p>
+      )}
+    </div>
+  );
+}
+
+const inputClass =
+  "w-full bg-slate-900 border border-slate-700 rounded px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:outline-none focus:border-indigo-500 disabled:opacity-50";
+
+const primaryButtonClass =
+  "rounded bg-amber-500 hover:bg-amber-400 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium text-slate-900";
+
+const secondaryButtonClass =
+  "rounded bg-slate-700 hover:bg-slate-600 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium";
+
+const dangerButtonClass =
+  "rounded bg-rose-600 hover:bg-rose-500 disabled:opacity-40 disabled:cursor-not-allowed px-3 py-1 text-xs font-medium";

--- a/frontend/app/features/village/detail/api.ts
+++ b/frontend/app/features/village/detail/api.ts
@@ -34,6 +34,10 @@ export type VillageFaceTypeModifyBody = components["schemas"]["VillageFaceTypeMo
 export type MyselfRpView = components["schemas"]["MyselfRpView"];
 export type MyselfFaceTypeView = components["schemas"]["MyselfFaceTypeView"];
 export type MyselfFaceTypesView = components["schemas"]["MyselfFaceTypesView"];
+export type VillageCreatorSayBody = components["schemas"]["VillageCreatorSayBody"];
+export type VillageKickBody = components["schemas"]["VillageKickBody"];
+export type VillageAdminLeaveBody = components["schemas"]["VillageAdminLeaveBody"];
+export type VillageAdminPlayerView = components["schemas"]["VillageAdminPlayerView"];
 
 // ---------- fetchers ----------
 
@@ -345,6 +349,120 @@ export async function putFaceTypes(
   });
   if (!res.ok) {
     throw new Error(`face-types update failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+}
+
+// ---------- creator / admin 操作 (Step 8e) ----------
+
+/** POST /api/v1/villages/{id}/creator-say — 村建て発言。201 成功時 空 body。 */
+export async function postCreatorSay(
+  villageId: number,
+  body: VillageCreatorSayBody,
+  fetcher: ApiFetch = browserFetch,
+): Promise<void> {
+  const res = await fetcher(`/api/v1/villages/${villageId}/creator-say`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`creator-say failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+}
+
+/** POST /api/v1/villages/{id}/kick — 村建てによる強制退村。 */
+export async function postKick(
+  villageId: number,
+  body: VillageKickBody,
+  fetcher: ApiFetch = browserFetch,
+): Promise<void> {
+  const res = await fetcher(`/api/v1/villages/${villageId}/kick`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`kick failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+}
+
+/** POST /api/v1/villages/{id}/cancel — 廃村。 */
+export async function postCancelVillage(
+  villageId: number,
+  fetcher: ApiFetch = browserFetch,
+): Promise<void> {
+  const res = await fetcher(`/api/v1/villages/${villageId}/cancel`, { method: "POST" });
+  if (!res.ok) {
+    throw new Error(`cancel failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+}
+
+/** POST /api/v1/villages/{id}/extend-epilogue — エピローグ 1 日延長。 */
+export async function postExtendEpilogue(
+  villageId: number,
+  fetcher: ApiFetch = browserFetch,
+): Promise<void> {
+  const res = await fetcher(`/api/v1/villages/${villageId}/extend-epilogue`, { method: "POST" });
+  if (!res.ok) {
+    throw new Error(`extend-epilogue failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+}
+
+/** POST /api/v1/villages/{id}/shorten-epilogue — エピローグ 1 日短縮。 */
+export async function postShortenEpilogue(
+  villageId: number,
+  fetcher: ApiFetch = browserFetch,
+): Promise<void> {
+  const res = await fetcher(`/api/v1/villages/${villageId}/shorten-epilogue`, { method: "POST" });
+  if (!res.ok) {
+    throw new Error(`shorten-epilogue failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+}
+
+/** GET /api/v1/admin/villages/{id}/players — 管理者向けキャラ↔中の人一覧。 */
+export async function fetchAdminPlayers(
+  villageId: number,
+  fetcher: ApiFetch = browserFetch,
+): Promise<VillageAdminPlayerView[]> {
+  const res = await fetcher(`/api/v1/admin/villages/${villageId}/players`);
+  if (!res.ok) {
+    throw new Error(`admin players failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+  return res.json();
+}
+
+/** POST /api/v1/admin/villages/{id}/access — 全員アクセス。 */
+export async function postAdminForceAccess(
+  villageId: number,
+  fetcher: ApiFetch = browserFetch,
+): Promise<void> {
+  const res = await fetcher(`/api/v1/admin/villages/${villageId}/access`, { method: "POST" });
+  if (!res.ok) {
+    throw new Error(`admin access failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+}
+
+/** POST /api/v1/admin/villages/{id}/vote — 全員自分投票。 */
+export async function postAdminForceVote(
+  villageId: number,
+  fetcher: ApiFetch = browserFetch,
+): Promise<void> {
+  const res = await fetcher(`/api/v1/admin/villages/${villageId}/vote`, { method: "POST" });
+  if (!res.ok) {
+    throw new Error(`admin vote failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+}
+
+/** POST /api/v1/admin/villages/{id}/leave — 管理者強制退村。 */
+export async function postAdminForceLeave(
+  villageId: number,
+  body: VillageAdminLeaveBody,
+  fetcher: ApiFetch = browserFetch,
+): Promise<void> {
+  const res = await fetcher(`/api/v1/admin/villages/${villageId}/leave`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`admin leave failed: ${res.status} ${await readErrorMessage(res)}`);
   }
 }
 

--- a/frontend/app/features/village/detail/hooks.ts
+++ b/frontend/app/features/village/detail/hooks.ts
@@ -8,6 +8,7 @@ import {
 } from "@tanstack/react-query";
 import {
   deleteLeave,
+  fetchAdminPlayers,
   fetchAttackTargets,
   fetchFaceTypes,
   fetchFootstepCandidates,
@@ -17,8 +18,16 @@ import {
   fetchVillageFootsteps,
   fetchVillageMessages,
   postAbility,
+  postAdminForceAccess,
+  postAdminForceLeave,
+  postAdminForceVote,
+  postCancelVillage,
+  postCreatorSay,
+  postExtendEpilogue,
+  postKick,
   postParticipate,
   postSay,
+  postShortenEpilogue,
   postSwitchParticipate,
   postVote,
   putChangeName,
@@ -32,11 +41,15 @@ import {
   type MyselfView,
   type SayInput,
   type VillageAbilityBody,
+  type VillageAdminLeaveBody,
+  type VillageAdminPlayerView,
   type VillageChangeNameBody,
   type VillageChangeRequestSkillBody,
   type VillageCommitBody,
+  type VillageCreatorSayBody,
   type VillageFaceTypeModifyBody,
   type VillageFootstepsView,
+  type VillageKickBody,
   type VillageMemoBody,
   type VillageParticipateBody,
   type VillageView,
@@ -342,5 +355,114 @@ export function useFootstepCandidatesQuery(
       }),
     enabled,
     staleTime: 30_000,
+  });
+}
+
+// ---------- Creator / Admin operations (Step 8e) ----------
+
+/**
+ * Creator/Admin 系の mutation 成功時は村の状態が大きく変わる可能性があるので
+ * 村ヘッダ / 参加者 / 発言 / myself を一括で refetch する。
+ */
+function invalidateAll(
+  queryClient: ReturnType<typeof useQueryClient>,
+  villageId: number,
+) {
+  queryClient.invalidateQueries({ queryKey: ["village", villageId] });
+}
+
+export function useCreatorSayMutation(
+  villageId: number,
+): UseMutationResult<void, Error, VillageCreatorSayBody> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, VillageCreatorSayBody>({
+    mutationFn: (body) => postCreatorSay(villageId, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["village", villageId, "messages"] });
+    },
+  });
+}
+
+export function useKickMutation(
+  villageId: number,
+): UseMutationResult<void, Error, VillageKickBody> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, VillageKickBody>({
+    mutationFn: (body) => postKick(villageId, body),
+    onSuccess: () => invalidateAll(queryClient, villageId),
+  });
+}
+
+export function useCancelVillageMutation(
+  villageId: number,
+): UseMutationResult<void, Error, void> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, void>({
+    mutationFn: () => postCancelVillage(villageId),
+    onSuccess: () => invalidateAll(queryClient, villageId),
+  });
+}
+
+export function useExtendEpilogueMutation(
+  villageId: number,
+): UseMutationResult<void, Error, void> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, void>({
+    mutationFn: () => postExtendEpilogue(villageId),
+    onSuccess: () => invalidateAll(queryClient, villageId),
+  });
+}
+
+export function useShortenEpilogueMutation(
+  villageId: number,
+): UseMutationResult<void, Error, void> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, void>({
+    mutationFn: () => postShortenEpilogue(villageId),
+    onSuccess: () => invalidateAll(queryClient, villageId),
+  });
+}
+
+/**
+ * GET /api/v1/admin/villages/{id}/players — 管理者向けキャラ↔中の人一覧。
+ * `enabled=false` のときはクエリを発行しない (= 管理者でないユーザでも safe)。
+ */
+export function useAdminPlayersQuery(
+  villageId: number,
+  enabled: boolean,
+): UseQueryResult<VillageAdminPlayerView[]> {
+  return useQuery<VillageAdminPlayerView[]>({
+    queryKey: ["village", villageId, "admin", "players"],
+    queryFn: () => fetchAdminPlayers(villageId),
+    enabled,
+    staleTime: 30_000,
+  });
+}
+
+export function useAdminForceAccessMutation(
+  villageId: number,
+): UseMutationResult<void, Error, void> {
+  return useMutation<void, Error, void>({
+    mutationFn: () => postAdminForceAccess(villageId),
+  });
+}
+
+export function useAdminForceVoteMutation(
+  villageId: number,
+): UseMutationResult<void, Error, void> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, void>({
+    mutationFn: () => postAdminForceVote(villageId),
+    onSuccess: () => invalidateActionState(queryClient, villageId),
+  });
+}
+
+export function useAdminForceLeaveMutation(
+  villageId: number,
+): UseMutationResult<void, Error, VillageAdminLeaveBody> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, VillageAdminLeaveBody>({
+    mutationFn: (body) => postAdminForceLeave(villageId, body),
+    onSuccess: () => invalidateAll(queryClient, villageId),
   });
 }

--- a/frontend/app/routes/villages.$id.tsx
+++ b/frontend/app/routes/villages.$id.tsx
@@ -20,8 +20,11 @@ import {
   useVillageQuery,
 } from "~/features/village/detail/hooks";
 import { ActionPanel } from "~/features/village/detail/ActionPanel";
+import { AdminPanel } from "~/features/village/detail/AdminPanel";
+import { CreatorPanel } from "~/features/village/detail/CreatorPanel";
 import { ParticipateActions } from "~/features/village/detail/ParticipateActions";
 import { RpActions } from "~/features/village/detail/RpActions";
+import { useMeQuery } from "~/features/auth/hooks";
 import { ssrFetch } from "~/lib/api/client";
 
 export function meta({ data }: Route.MetaArgs) {
@@ -54,11 +57,18 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
   const messagesQuery = useVillageMessagesQuery(villageId, undefined, initialMessages ?? undefined);
   const footstepsQuery = useVillageFootstepsQuery(villageId, initialFootsteps ?? undefined);
   const myselfQuery = useMyselfQuery(villageId, initialMyself);
+  // 認証情報を取得して管理者 (CDef.Authority.管理者) 判定に使う。
+  // SSR / 未ログイン時は失敗するが、`error` を握りつぶし `isAdmin=false` 扱いで進める。
+  const meQuery = useMeQuery();
+  const authority = meQuery.data?.user?.authority;
+  const isAdmin = authority === "管理者";
 
   const village = villageQuery.data ?? initialVillage;
   const messages = messagesQuery.data ?? initialMessages ?? null;
   const footsteps = footstepsQuery.data ?? initialFootsteps ?? null;
   const myself = myselfQuery.data ?? initialMyself ?? null;
+  // creator パネルの表示判定: 村建て本人または管理者 (旧仕様: 管理者 = 全村 creator 扱い)。
+  const canSeeCreatorPanel = village.isCreator || isAdmin;
 
   return (
     <main className="min-h-screen bg-slate-900 text-slate-100">
@@ -72,6 +82,10 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
         {myself && <RpActions village={village} myself={myself} />}
 
         {myself && <ActionPanel village={village} myself={myself} />}
+
+        {canSeeCreatorPanel && <CreatorPanel village={village} />}
+
+        {isAdmin && <AdminPanel village={village} />}
 
         <ParticipantsPanel participants={village.participants.list} />
 


### PR DESCRIPTION
## Summary
- 旧 `CreatorController` / `AdminController` (Thymeleaf form) の操作系を REST 化し、村画面に creator/admin 専用パネルを追加
- 設定変更 (settings) は項目数が膨大 (~30 項目 + 闇鍋編成 + 発言制限) で UI 構造も独立しているため Step 8e から分離し `.issues/7` に持ち越し

## 追加した backend endpoint
- **Creator (要 creator 認可)**:
  - `POST /api/v1/villages/{id}/creator-say` 村建て発言
  - `POST /api/v1/villages/{id}/kick` 強制退村 (プロローグ中のみ実効)
  - `POST /api/v1/villages/{id}/cancel` 廃村 (プロローグ中のみ)
  - `POST /api/v1/villages/{id}/extend-epilogue` / `shorten-epilogue` エピローグ調整
- **Admin (`/api/v1/admin/**` で `hasRole(\"ADMIN\")`)**:
  - `GET  /api/v1/admin/villages/{id}/players` キャラ ↔ 中の人一覧
  - `POST /api/v1/admin/villages/{id}/access` 全員アクセス
  - `POST /api/v1/admin/villages/{id}/vote` 全員自分票
  - `POST /api/v1/admin/villages/{id}/leave` 強制退村 (assertLeave 経由)

## 実装メモ
- `VillageContextLoader.loadVillageAndRequireCreator` を新設し creator 認可を一元化 (旧 `CreatorCoordinator.isCreator` の Player ID=1 特例も踏襲)
- admin 系の Bhv 直叩きは `AdminVillageService` に切り出し、controller 層から infrastructure 直叩きを排除
- backend Kotlin の **ネストブロックコメント** に注意 (旧コードで KDoc 内に `/api/v1/admin/**` を書いたら `/*` が新コメント扱いで unclosed comment エラー)
- frontend は `useMeQuery().data?.user?.authority === \"管理者\"` で admin 判定、`village.isCreator || isAdmin` で creator パネル表示

## スコープ外 (`.issues/` 持ち越し)
- **設定変更 (settings)** → `.issues/7-village-settings-rest.md` — 項目数が大きく別 PR で扱う
- HANDOFF.md の "8e: admin 系 (..., 設定変更)" のうち "設定変更" は意図的に分離

## Test plan
- [ ] backend: `./gradlew test` 通過 (compile + 既存テストへの影響なし)
- [ ] frontend: `pnpm typecheck` / `pnpm test` / `pnpm build` 通過
- [ ] 手動 (推奨): 村画面で
  - [ ] 自分が村建てのプロローグ村 → CreatorPanel: 村建て発言 / kick / 廃村が見える
  - [ ] エピローグ村 → CreatorPanel: エピローグ延長/短縮が見える
  - [ ] admin ユーザでログイン → どの村でも CreatorPanel + AdminPanel が見える
  - [ ] AdminPanel: 全員アクセス / 全員自票 / 参加プレイヤー確認 / 強制退村 が動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)