### PR TITLE
Step 8f: 村設定変更 REST 化 (creator) + CreatorCoordinator 二重 SELECT 整理

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/request/village/VillageSettingsUpdateBody.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/request/village/VillageSettingsUpdateBody.kt
@@ -1,0 +1,354 @@
+package com.ort.app.api.request.village
+
+import com.ort.app.api.request.VillageSettingForm
+import com.ort.app.api.request.setting.MessageTypeSayRestrictForm
+import com.ort.app.api.request.setting.RandomOrganizationCampForm
+import com.ort.app.api.request.setting.RandomOrganizationSkillForm
+import com.ort.app.api.request.setting.RandomOrganizationWolfForm
+import com.ort.app.api.request.setting.SkillSayRestrictForm
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+
+/**
+ * 村設定変更 (PUT /api/v1/villages/{id}/settings) リクエスト body。
+ *
+ * 旧 `VillageSettingForm` (Thymeleaf form) の JSON 受信用スリム版。表示専用フィールド
+ * (`campName` / `skillName` / `messageTypeName` 等) は含まない。
+ *
+ * 入力後の cross-field バリデーションは `SettingFormValidator` を再利用するため、
+ * `toForm()` で旧 form に変換してから検証する (一貫性を保つため重複定義は避ける)。
+ *
+ * フィールド単位の必須/範囲チェックは Jakarta Bean Validation で行う
+ * (`@RequestBody @Valid` で自動実行)。
+ */
+@Schema(description = "村設定変更 (creator) 用リクエスト body")
+data class VillageSettingsUpdateBody(
+    @field:Schema(description = "村表示名 (5〜40文字)")
+    @field:NotNull
+    @field:Size(min = 5, max = 40)
+    val villageName: String?,
+
+    @field:Schema(description = "最少開始人数 (8以上)")
+    @field:NotNull
+    @field:Min(8)
+    val startPersonMinNum: Int?,
+
+    @field:Schema(description = "定員 (999以下)")
+    @field:NotNull
+    @field:Max(999)
+    val personMaxNum: Int?,
+
+    @field:Schema(description = "更新間隔: 時間 (0-72)")
+    @field:NotNull
+    @field:Min(0)
+    @field:Max(72)
+    val dayChangeIntervalHours: Int?,
+
+    @field:Schema(description = "更新間隔: 分 (0-59)")
+    @field:NotNull
+    @field:Min(0)
+    @field:Max(59)
+    val dayChangeIntervalMinutes: Int?,
+
+    @field:Schema(description = "更新間隔: 秒 (0-59)")
+    @field:NotNull
+    @field:Min(0)
+    @field:Max(59)
+    val dayChangeIntervalSeconds: Int?,
+
+    @field:Schema(description = "開始年")
+    @field:NotNull
+    @field:Min(0)
+    val startYear: Int?,
+
+    @field:Schema(description = "開始月 (1-12)")
+    @field:NotNull
+    @field:Min(1)
+    @field:Max(12)
+    val startMonth: Int?,
+
+    @field:Schema(description = "開始日 (1-31)")
+    @field:NotNull
+    @field:Min(1)
+    @field:Max(31)
+    val startDay: Int?,
+
+    @field:Schema(description = "開始時 (0-23)")
+    @field:NotNull
+    @field:Min(0)
+    @field:Max(23)
+    val startHour: Int?,
+
+    @field:Schema(description = "開始分 (0-59)")
+    @field:NotNull
+    @field:Min(0)
+    @field:Max(59)
+    val startMinute: Int?,
+
+    @field:Schema(description = "募集範囲タグ (VillageTagItem code: ANYONE_WELCOME / RELATIVES_ONLY)。未指定なら null。")
+    val welcomeRange: String?,
+
+    @field:Schema(description = "年齢制限タグ (VillageTagItem code: R15 / R18)。未指定なら null。")
+    val ageLimit: String?,
+
+    @field:Schema(description = "記名投票か")
+    @field:NotNull
+    val openVote: Boolean?,
+
+    @field:Schema(description = "連続襲撃ありか")
+    @field:NotNull
+    val availableSameWolfAttack: Boolean?,
+
+    @field:Schema(description = "墓下役職公開ありか")
+    @field:NotNull
+    val openSkillInGrave: Boolean?,
+
+    @field:Schema(description = "墓下見学発言を地上から見られるか")
+    @field:NotNull
+    val visibleGraveSpectateMessage: Boolean?,
+
+    @field:Schema(description = "秘話可能範囲 (CDef.AllowedSecretSay code)")
+    @field:NotNull
+    val allowedSecretSayCode: String?,
+
+    @field:Schema(description = "見学可能か")
+    @field:NotNull
+    val availableSpectate: Boolean?,
+
+    @field:Schema(description = "突然死ありか")
+    @field:NotNull
+    val availableSuddenlyDeath: Boolean?,
+
+    @field:Schema(description = "コミット可能か")
+    @field:NotNull
+    val availableCommit: Boolean?,
+
+    @field:Schema(description = "連続ガードありか")
+    @field:NotNull
+    val availableGuardSameTarget: Boolean?,
+
+    @field:Schema(description = "アクションありか")
+    @field:NotNull
+    val availableAction: Boolean?,
+
+    @field:Schema(description = "構成 (改行区切り、闇鍋でないときに参照)")
+    val organization: String?,
+
+    @field:Schema(description = "闇鍋編成か")
+    @field:NotNull
+    val randomOrganization: Boolean?,
+
+    @field:Schema(description = "転生時に全役職を候補とするか")
+    @field:NotNull
+    val reincarnationSkillAll: Boolean?,
+
+    @field:Schema(description = "闇鍋編成詳細 (camp -> skills)")
+    @field:Valid
+    val campAllocationList: List<CampAllocationBody>?,
+
+    @field:Schema(description = "闇鍋編成人狼配分")
+    @field:Valid
+    val wolfAllocation: WolfAllocationBody?,
+
+    @field:Schema(description = "ダミーキャラ1日目発言 (400文字以内)")
+    @field:Size(max = 400)
+    val dummyDay1Message: String?,
+
+    @field:Schema(description = "入村パスワード (3〜12文字、null/空なら不要)")
+    val joinPassword: String?,
+
+    @field:Schema(description = "通常発言の役職別制限一覧 (全役職分を送る)")
+    @field:NotNull
+    @field:Valid
+    val sayRestrictList: List<SkillSayRestrictBody>?,
+
+    @field:Schema(description = "役職発言制限一覧 (人狼の囁き等)")
+    @field:NotNull
+    @field:Valid
+    val skillSayRestrictList: List<MessageTypeSayRestrictBody>?,
+
+    @field:Schema(description = "RP 発言制限一覧 (アクション等)")
+    @field:NotNull
+    @field:Valid
+    val rpSayRestrictList: List<MessageTypeSayRestrictBody>?,
+) {
+    /**
+     * 旧 `VillageSettingForm` に変換する。`SettingFormValidator` を共有するため。
+     * 表示用フィールド (campName / skillName / messageTypeName) は空のまま。
+     */
+    fun toForm(): VillageSettingForm = VillageSettingForm(
+        villageName = villageName,
+        startPersonMinNum = startPersonMinNum,
+        personMaxNum = personMaxNum,
+        dayChangeIntervalHours = dayChangeIntervalHours,
+        dayChangeIntervalMinutes = dayChangeIntervalMinutes,
+        dayChangeIntervalSeconds = dayChangeIntervalSeconds,
+        startYear = startYear,
+        startMonth = startMonth,
+        startDay = startDay,
+        startHour = startHour,
+        startMinute = startMinute,
+        welcomeRange = welcomeRange,
+        ageLimit = ageLimit,
+        openVote = openVote,
+        availableSameWolfAttack = availableSameWolfAttack,
+        openSkillInGrave = openSkillInGrave,
+        visibleGraveSpectateMessage = visibleGraveSpectateMessage,
+        allowedSecretSayCode = allowedSecretSayCode,
+        availableSpectate = availableSpectate,
+        availableSuddonlyDeath = availableSuddenlyDeath,
+        availableCommit = availableCommit,
+        availableGuardSameTarget = availableGuardSameTarget,
+        availableAction = availableAction,
+        organization = organization,
+        randomOrganization = randomOrganization,
+        reincarnationSkillAll = reincarnationSkillAll,
+        campAllocationList = campAllocationList?.map { c ->
+            RandomOrganizationCampForm(
+                campCode = c.campCode,
+                campName = null,
+                minNum = c.minNum,
+                maxNum = c.maxNum,
+                allocation = c.allocation,
+                reincarnationAllocation = c.reincarnationAllocation,
+                skillAllocation = c.skillAllocation?.map { s ->
+                    RandomOrganizationSkillForm(
+                        skillCode = s.skillCode,
+                        skillName = null,
+                        minNum = s.minNum,
+                        maxNum = s.maxNum,
+                        allocation = s.allocation,
+                        reincarnationAllocation = s.reincarnationAllocation,
+                    )
+                },
+            )
+        },
+        wolfAllocation = wolfAllocation?.let {
+            RandomOrganizationWolfForm(
+                minNum = it.minNum,
+                maxNum = it.maxNum,
+            )
+        },
+        dummyDay1Message = dummyDay1Message,
+        joinPassword = joinPassword,
+        sayRestrictList = sayRestrictList?.map { r ->
+            SkillSayRestrictForm(
+                skillName = null,
+                skillCode = r.skillCode,
+                restrict = r.restrict,
+                count = r.count,
+                length = r.length,
+            )
+        },
+        skillSayRestrictList = skillSayRestrictList?.map { r ->
+            MessageTypeSayRestrictForm(
+                messageTypeName = null,
+                messageTypeCode = r.messageTypeCode,
+                restrict = r.restrict,
+                count = r.count,
+                length = r.length,
+            )
+        },
+        rpSayRestrictList = rpSayRestrictList?.map { r ->
+            MessageTypeSayRestrictForm(
+                messageTypeName = null,
+                messageTypeCode = r.messageTypeCode,
+                restrict = r.restrict,
+                count = r.count,
+                length = r.length,
+            )
+        },
+    )
+
+    @Schema(description = "闇鍋: 陣営配分")
+    data class CampAllocationBody(
+        @field:Schema(description = "陣営コード (CDef.Camp)")
+        @field:NotNull
+        val campCode: String?,
+        @field:Schema(description = "最少人数 (0-100)")
+        @field:NotNull
+        @field:Min(0)
+        @field:Max(100)
+        val minNum: Int?,
+        @field:Schema(description = "最多人数 (0-100、null=制限なし)")
+        @field:Min(0)
+        @field:Max(100)
+        val maxNum: Int?,
+        @field:Schema(description = "配分 (0-100)")
+        @field:NotNull
+        @field:Min(0)
+        @field:Max(100)
+        val allocation: Int?,
+        @field:Schema(description = "転生配分 (0-100)")
+        @field:NotNull
+        @field:Min(0)
+        @field:Max(100)
+        val reincarnationAllocation: Int?,
+        @field:Schema(description = "陣営内役職配分")
+        @field:NotNull
+        @field:Valid
+        val skillAllocation: List<SkillAllocationBody>?,
+    )
+
+    @Schema(description = "闇鍋: 役職配分")
+    data class SkillAllocationBody(
+        @field:Schema(description = "役職コード (CDef.Skill)")
+        @field:NotNull
+        val skillCode: String?,
+        @field:NotNull
+        @field:Min(0)
+        @field:Max(100)
+        val minNum: Int?,
+        @field:Min(0)
+        @field:Max(100)
+        val maxNum: Int?,
+        @field:NotNull
+        @field:Min(0)
+        @field:Max(100)
+        val allocation: Int?,
+        @field:NotNull
+        @field:Min(0)
+        @field:Max(100)
+        val reincarnationAllocation: Int?,
+    )
+
+    @Schema(description = "闇鍋: 人狼カウント配分")
+    data class WolfAllocationBody(
+        @field:NotNull
+        @field:Min(1)
+        @field:Max(100)
+        val minNum: Int?,
+        @field:Min(1)
+        @field:Max(100)
+        val maxNum: Int?,
+    )
+
+    @Schema(description = "通常発言制限 (役職単位)")
+    data class SkillSayRestrictBody(
+        @field:Schema(description = "役職コード (CDef.Skill)")
+        @field:NotNull
+        val skillCode: String?,
+        @field:Schema(description = "制限するか")
+        @field:NotNull
+        val restrict: Boolean?,
+        @field:Schema(description = "発言回数 (restrict=true のとき必須、0-100)")
+        val count: Int?,
+        @field:Schema(description = "1発言文字数 (restrict=true のとき必須、0-400)")
+        val length: Int?,
+    )
+
+    @Schema(description = "発言種別単位の制限 (人狼囁き / 共鳴 / 恋人 / 念話 / アクション)")
+    data class MessageTypeSayRestrictBody(
+        @field:Schema(description = "発言種別コード (CDef.MessageType)")
+        @field:NotNull
+        val messageTypeCode: String?,
+        @field:NotNull
+        val restrict: Boolean?,
+        val count: Int?,
+        val length: Int?,
+    )
+}

--- a/backend/src/main/kotlin/com/ort/app/api/request/village/VillageSettingsUpdateBody.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/request/village/VillageSettingsUpdateBody.kt
@@ -32,13 +32,15 @@ data class VillageSettingsUpdateBody(
     @field:Size(min = 5, max = 40)
     val villageName: String?,
 
-    @field:Schema(description = "最少開始人数 (8以上)")
+    @field:Schema(description = "最少開始人数 (8〜999)")
     @field:NotNull
     @field:Min(8)
+    @field:Max(999)
     val startPersonMinNum: Int?,
 
-    @field:Schema(description = "定員 (999以下)")
+    @field:Schema(description = "定員 (8〜999)")
     @field:NotNull
+    @field:Min(8)
     @field:Max(999)
     val personMaxNum: Int?,
 

--- a/backend/src/main/kotlin/com/ort/app/api/response/village/VillageSettingsFormView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/village/VillageSettingsFormView.kt
@@ -1,0 +1,284 @@
+package com.ort.app.api.response.village
+
+import com.ort.app.domain.model.skill.Skills
+import com.ort.app.domain.model.village.Village
+import com.ort.dbflute.allcommon.CDef
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 村設定編集フォーム (GET /api/v1/villages/{id}/settings/form) のレスポンス。
+ *
+ * - `current`: 現在の設定値 (PUT の body 形に合わせた現在値)
+ * - `options`: 候補値 (役職一覧 / 陣営一覧 / 募集範囲 / 年齢制限 / 秘話可能範囲)
+ *
+ * フロントエンドはこの 1 リクエストで編集フォームを完全に描画できる。
+ *
+ * `isOriginalCharachip` と `isOriginalCharachipPasswordRequired` はオリジナルキャラチップ村で
+ * パスワード必須となる UI 表示に使用する。
+ */
+@Schema(description = "村設定編集フォーム (creator 専用)")
+data class VillageSettingsFormView(
+    @field:Schema(description = "村 ID")
+    val villageId: Int,
+    @field:Schema(description = "現在の設定値 (PUT の body と同じ形)")
+    val current: CurrentSettings,
+    @field:Schema(description = "候補値")
+    val options: Options,
+    @field:Schema(description = "オリジナルキャラチップ村か (true なら入村パスワード必須)")
+    val isOriginalCharachip: Boolean,
+) {
+    constructor(village: Village) : this(
+        villageId = village.id,
+        current = CurrentSettings(village),
+        options = Options(village),
+        isOriginalCharachip = village.setting.chara.isOriginalCharachip,
+    )
+
+    @Schema(description = "現在の設定値 (PUT body と同じフィールド構造)")
+    data class CurrentSettings(
+        val villageName: String,
+        val startPersonMinNum: Int,
+        val personMaxNum: Int,
+        val dayChangeIntervalHours: Int,
+        val dayChangeIntervalMinutes: Int,
+        val dayChangeIntervalSeconds: Int,
+        val startYear: Int,
+        val startMonth: Int,
+        val startDay: Int,
+        val startHour: Int,
+        val startMinute: Int,
+        @field:Schema(description = "募集範囲タグ (ANYONE_WELCOME/RELATIVES_ONLY)。未設定なら null。")
+        val welcomeRange: String?,
+        @field:Schema(description = "年齢制限タグ (R15/R18)。未設定なら null。")
+        val ageLimit: String?,
+        val openVote: Boolean,
+        val availableSameWolfAttack: Boolean,
+        val openSkillInGrave: Boolean,
+        val visibleGraveSpectateMessage: Boolean,
+        val allowedSecretSayCode: String,
+        val availableSpectate: Boolean,
+        val availableSuddenlyDeath: Boolean,
+        val availableCommit: Boolean,
+        val availableGuardSameTarget: Boolean,
+        val availableAction: Boolean,
+        val organization: String,
+        val randomOrganization: Boolean,
+        val reincarnationSkillAll: Boolean,
+        val campAllocationList: List<CampAllocation>,
+        val wolfAllocation: WolfAllocation,
+        val dummyDay1Message: String?,
+        val joinPassword: String?,
+        val sayRestrictList: List<SkillSayRestrict>,
+        val skillSayRestrictList: List<MessageTypeSayRestrict>,
+        val rpSayRestrictList: List<MessageTypeSayRestrict>,
+    ) {
+        constructor(village: Village) : this(
+            villageName = village.name,
+            startPersonMinNum = village.setting.personMin,
+            personMaxNum = village.setting.personMax,
+            dayChangeIntervalHours = village.setting.dayChangeIntervalSeconds / 3600,
+            dayChangeIntervalMinutes = (village.setting.dayChangeIntervalSeconds % 3600) / 60,
+            dayChangeIntervalSeconds = village.setting.dayChangeIntervalSeconds % 60,
+            startYear = village.days.list.first().dayChangeDatetime.year,
+            startMonth = village.days.list.first().dayChangeDatetime.monthValue,
+            startDay = village.days.list.first().dayChangeDatetime.dayOfMonth,
+            startHour = village.days.list.first().dayChangeDatetime.hour,
+            startMinute = village.days.list.first().dayChangeDatetime.minute,
+            welcomeRange = village.setting.tags.list.find {
+                it.toCdef() == CDef.VillageTagItem.誰歓 || it.toCdef() == CDef.VillageTagItem.身内
+            }?.code,
+            ageLimit = village.setting.tags.list.find {
+                it.toCdef() == CDef.VillageTagItem.R15 || it.toCdef() == CDef.VillageTagItem.R18
+            }?.code,
+            openVote = village.setting.rule.isOpenVote,
+            availableSameWolfAttack = village.setting.rule.isAvailableSameWolfAttack,
+            openSkillInGrave = village.setting.rule.isOpenSkillInGrave,
+            visibleGraveSpectateMessage = village.setting.rule.isVisibleGraveSpectateMessage,
+            allowedSecretSayCode = village.setting.rule.secretSayRange.code,
+            availableSpectate = village.setting.rule.isAvailableSpectate,
+            availableSuddenlyDeath = village.setting.rule.isAvailableSuddenlyDeath,
+            availableCommit = village.setting.rule.isAvailableCommit,
+            availableGuardSameTarget = village.setting.rule.isAvailableGuardSameTarget,
+            availableAction = village.setting.rule.isAvailableAction,
+            organization = village.setting.organize.fixedOrganization,
+            randomOrganization = village.setting.rule.isRandomOrganization,
+            reincarnationSkillAll = village.setting.rule.isReincarnationSkillAll,
+            campAllocationList = mapCampAllocation(village),
+            wolfAllocation = village.setting.organize.randomOrganization.wolfAllocation
+                ?.let { WolfAllocation(minNum = it.min, maxNum = it.max) }
+                ?: WolfAllocation(minNum = 1, maxNum = null),
+            dummyDay1Message = village.setting.chara.dummyDay1Message,
+            joinPassword = village.setting.joinPassword,
+            sayRestrictList = mapSayRestrictList(village),
+            skillSayRestrictList = mapSkillRestrictList(
+                village,
+                listOf(
+                    CDef.MessageType.人狼の囁き,
+                    CDef.MessageType.共鳴発言,
+                    CDef.MessageType.恋人発言,
+                    CDef.MessageType.念話,
+                ),
+            ),
+            rpSayRestrictList = mapSkillRestrictList(
+                village,
+                listOf(CDef.MessageType.アクション),
+            ),
+        )
+    }
+
+    @Schema(description = "編集 UI で出す候補値一覧")
+    data class Options(
+        @field:Schema(description = "募集範囲候補 (code, name)")
+        val welcomeRanges: List<CodeName>,
+        @field:Schema(description = "年齢制限候補")
+        val ageLimits: List<CodeName>,
+        @field:Schema(description = "秘話可能範囲候補")
+        val allowedSecretSays: List<CodeName>,
+        @field:Schema(description = "陣営一覧 (闇鍋編成の表示用)")
+        val camps: List<CodeName>,
+        @field:Schema(description = "発言種別: 役職発言制限の対象一覧 (人狼の囁き/共鳴/恋人/念話)")
+        val skillMessageTypes: List<CodeName>,
+        @field:Schema(description = "発言種別: RP 発言制限の対象一覧 (アクション)")
+        val rpMessageTypes: List<CodeName>,
+        @field:Schema(description = "全役職一覧 (おまかせ除く)。通常発言制限の対象。")
+        val skills: List<CodeName>,
+    ) {
+        constructor(village: Village) : this(
+            welcomeRanges = listOf(
+                CodeName(CDef.VillageTagItem.誰歓.code(), CDef.VillageTagItem.誰歓.alias()),
+                CodeName(CDef.VillageTagItem.身内.code(), CDef.VillageTagItem.身内.alias()),
+            ),
+            ageLimits = listOf(
+                CodeName(CDef.VillageTagItem.R15.code(), CDef.VillageTagItem.R15.alias()),
+                CodeName(CDef.VillageTagItem.R18.code(), CDef.VillageTagItem.R18.alias()),
+            ),
+            allowedSecretSays = CDef.AllowedSecretSay.listAll().map { CodeName(it.code(), it.alias()) },
+            camps = listOf(
+                CDef.Camp.村人陣営,
+                CDef.Camp.人狼陣営,
+                CDef.Camp.狐陣営,
+                CDef.Camp.恋人陣営,
+                CDef.Camp.愉快犯陣営,
+            ).map { CodeName(it.code(), it.alias()) },
+            skillMessageTypes = listOf(
+                CDef.MessageType.人狼の囁き,
+                CDef.MessageType.共鳴発言,
+                CDef.MessageType.恋人発言,
+                CDef.MessageType.念話,
+            ).map { CodeName(it.code(), it.alias()) },
+            rpMessageTypes = listOf(CDef.MessageType.アクション).map { CodeName(it.code(), it.alias()) },
+            skills = Skills.all().filterNotSomeone().list.map { CodeName(it.code, it.name) },
+        )
+    }
+
+    @Schema(description = "code / name ペア")
+    data class CodeName(val code: String, val name: String)
+
+    data class CampAllocation(
+        val campCode: String,
+        val campName: String,
+        val minNum: Int,
+        val maxNum: Int?,
+        val allocation: Int,
+        val reincarnationAllocation: Int,
+        val skillAllocation: List<SkillAllocation>,
+    )
+
+    data class SkillAllocation(
+        val skillCode: String,
+        val skillName: String,
+        val minNum: Int,
+        val maxNum: Int?,
+        val allocation: Int,
+        val reincarnationAllocation: Int,
+    )
+
+    data class WolfAllocation(
+        val minNum: Int,
+        val maxNum: Int?,
+    )
+
+    data class SkillSayRestrict(
+        val skillCode: String,
+        val skillName: String,
+        val restrict: Boolean,
+        val count: Int,
+        val length: Int,
+    )
+
+    data class MessageTypeSayRestrict(
+        val messageTypeCode: String,
+        val messageTypeName: String,
+        val restrict: Boolean,
+        val count: Int,
+        val length: Int,
+    )
+
+    companion object {
+        private fun mapCampAllocation(village: Village): List<CampAllocation> {
+            return listOf(
+                CDef.Camp.村人陣営,
+                CDef.Camp.人狼陣営,
+                CDef.Camp.狐陣営,
+                CDef.Camp.恋人陣営,
+                CDef.Camp.愉快犯陣営,
+            ).map { cdefCamp ->
+                val campAllocation = village.setting.organize.randomOrganization.campAllocation
+                    .first { it.camp.code == cdefCamp.code() }
+                val skillByCamp = Skills.all().filterNotSomeone().filterByCamp(cdefCamp).list
+                CampAllocation(
+                    campCode = campAllocation.camp.code,
+                    campName = campAllocation.camp.name,
+                    minNum = campAllocation.min,
+                    maxNum = campAllocation.max,
+                    allocation = campAllocation.initAllocation,
+                    reincarnationAllocation = campAllocation.reincarnationAllocation,
+                    skillAllocation = skillByCamp.mapNotNull { skill ->
+                        village.setting.organize.randomOrganization.skillAllocation
+                            .firstOrNull { it.skill.code == skill.code }?.let { s ->
+                                SkillAllocation(
+                                    skillCode = s.skill.code,
+                                    skillName = s.skill.name,
+                                    minNum = s.min,
+                                    maxNum = s.max,
+                                    allocation = s.initAllocation,
+                                    reincarnationAllocation = s.reincarnationAllocation,
+                                )
+                            }
+                    },
+                )
+            }
+        }
+
+        private fun mapSayRestrictList(village: Village): List<SkillSayRestrict> {
+            return Skills.all().filterNotSomeone().list.map { s ->
+                val restrict = village.setting.sayRestriction.normalSayRestriction
+                    .find { it.skill.code == s.code }
+                SkillSayRestrict(
+                    skillCode = s.code,
+                    skillName = s.name,
+                    restrict = restrict != null,
+                    count = restrict?.count ?: 20,
+                    length = restrict?.length ?: 400,
+                )
+            }
+        }
+
+        private fun mapSkillRestrictList(
+            village: Village,
+            types: List<CDef.MessageType>,
+        ): List<MessageTypeSayRestrict> {
+            return types.map { mt ->
+                val restrict = village.setting.sayRestriction.skillSayRestriction
+                    .find { it.messageType.code == mt.code() }
+                MessageTypeSayRestrict(
+                    messageTypeCode = mt.code(),
+                    messageTypeName = mt.alias(),
+                    restrict = restrict != null,
+                    count = restrict?.count ?: 20,
+                    length = restrict?.length ?: 400,
+                )
+            }
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/response/village/VillageSettingsFormView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/village/VillageSettingsFormView.kt
@@ -67,7 +67,9 @@ data class VillageSettingsFormView(
         val campAllocationList: List<CampAllocation>,
         val wolfAllocation: WolfAllocation,
         val dummyDay1Message: String?,
-        val joinPassword: String?,
+        @field:Schema(description = "入村パスワードが設定済みか。値そのものはレスポンスに含めない (creator のみ" +
+                "とはいえ JSON 経路に平文を載せないため)。クリア / 変更は PUT body の joinPassword で行う。")
+        val joinPasswordSet: Boolean,
         val sayRestrictList: List<SkillSayRestrict>,
         val skillSayRestrictList: List<MessageTypeSayRestrict>,
         val rpSayRestrictList: List<MessageTypeSayRestrict>,
@@ -108,7 +110,7 @@ data class VillageSettingsFormView(
                 ?.let { WolfAllocation(minNum = it.min, maxNum = it.max) }
                 ?: WolfAllocation(minNum = 1, maxNum = null),
             dummyDay1Message = village.setting.chara.dummyDay1Message,
-            joinPassword = village.setting.joinPassword,
+            joinPasswordSet = !village.setting.joinPassword.isNullOrBlank(),
             sayRestrictList = mapSayRestrictList(village),
             skillSayRestrictList = mapSkillRestrictList(
                 village,
@@ -222,9 +224,12 @@ data class VillageSettingsFormView(
                 CDef.Camp.狐陣営,
                 CDef.Camp.恋人陣営,
                 CDef.Camp.愉快犯陣営,
-            ).map { cdefCamp ->
+            ).mapNotNull { cdefCamp ->
+                // 旧データ等で当該陣営の randomOrganization 配分が欠落している場合は
+                // 該当陣営を結果から落とす (実害がない範囲で 500 を回避)。
                 val campAllocation = village.setting.organize.randomOrganization.campAllocation
-                    .first { it.camp.code == cdefCamp.code() }
+                    .firstOrNull { it.camp.code == cdefCamp.code() }
+                    ?: return@mapNotNull null
                 val skillByCamp = Skills.all().filterNotSomeone().filterByCamp(cdefCamp).list
                 CampAllocation(
                     campCode = campAllocation.camp.code,

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageCreatorRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageCreatorRestController.kt
@@ -29,8 +29,7 @@ import org.springframework.web.bind.annotation.RestController
  * - POST /api/v1/villages/{id}/extend-epilogue: エピローグを 1 日延長
  * - POST /api/v1/villages/{id}/shorten-epilogue: エピローグを 1 日短縮
  *
- * NOTE: 設定変更 (`/settings` の旧 GET/POST) は項目数が膨大なため Step 8e から分離し
- * 別 step (8f) でまとめて REST 化する。
+ * 設定変更 (`/settings`) は項目数が多いため `VillageSettingsRestController` (Step 8f) に分離。
  */
 @RestController
 @RequestMapping("/api/v1/villages")
@@ -50,8 +49,8 @@ class VillageCreatorRestController(
         @PathVariable villageId: Int,
         @Valid @RequestBody body: VillageCreatorSayBody,
     ) {
-        villageContextLoader.loadVillageAndRequireCreator(villageId)
-        creatorCoordinator.say(villageId, body.message, body.convertDisable ?: false)
+        val village = villageContextLoader.loadVillageAndRequireCreator(villageId)
+        creatorCoordinator.say(village, body.message, body.convertDisable ?: false)
     }
 
     @PostMapping("/{villageId}/kick")
@@ -73,7 +72,7 @@ class VillageCreatorRestController(
         if (!targetExists) {
             throw WolfMansionBusinessException("対象の参加者が見つかりません")
         }
-        creatorCoordinator.kick(villageId, body.charaId)
+        creatorCoordinator.kick(village, body.charaId)
     }
 
     @PostMapping("/{villageId}/cancel")
@@ -83,8 +82,8 @@ class VillageCreatorRestController(
         description = "プロローグ中のみ村を廃村にする。",
     )
     fun cancel(@PathVariable villageId: Int) {
-        villageContextLoader.loadVillageAndRequireCreator(villageId)
-        creatorCoordinator.cancel(villageId)
+        val village = villageContextLoader.loadVillageAndRequireCreator(villageId)
+        creatorCoordinator.cancel(village)
     }
 
     @PostMapping("/{villageId}/extend-epilogue")
@@ -94,8 +93,8 @@ class VillageCreatorRestController(
         description = "エピローグの最終日を 1 日後ろにずらす。",
     )
     fun extendEpilogue(@PathVariable villageId: Int) {
-        villageContextLoader.loadVillageAndRequireCreator(villageId)
-        creatorCoordinator.extendEpilogue(villageId)
+        val village = villageContextLoader.loadVillageAndRequireCreator(villageId)
+        creatorCoordinator.extendEpilogue(village)
     }
 
     @PostMapping("/{villageId}/shorten-epilogue")
@@ -105,7 +104,7 @@ class VillageCreatorRestController(
         description = "エピローグの最終日を 1 日前にずらす (残り 1 日超の場合のみ)。",
     )
     fun shortenEpilogue(@PathVariable villageId: Int) {
-        villageContextLoader.loadVillageAndRequireCreator(villageId)
-        creatorCoordinator.shortenEpilogue(villageId)
+        val village = villageContextLoader.loadVillageAndRequireCreator(villageId)
+        creatorCoordinator.shortenEpilogue(village)
     }
 }

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageSettingsRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageSettingsRestController.kt
@@ -1,0 +1,70 @@
+package com.ort.app.api.v1.villages
+
+import com.ort.app.api.request.village.VillageSettingsUpdateBody
+import com.ort.app.api.response.village.VillageSettingsFormView
+import com.ort.app.application.coordinator.CreatorCoordinator
+import com.ort.app.fw.exception.WolfMansionBusinessException
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 村設定変更 (creator 専用) の REST API。
+ *
+ * 旧 `CreatorController` の `GET/POST /village/{id}/settings` 置き換え。
+ *
+ * - `GET /api/v1/villages/{id}/settings/form`: 編集 UI 用 (現在値 + 候補値) を返す
+ * - `PUT /api/v1/villages/{id}/settings`: 設定を更新する
+ *
+ * Step 8e の `VillageCreatorRestController` に同居せず controller を分けている理由:
+ * - 認可 (`loadVillageAndRequireCreator`) は同じだが、Body / View が独立しており
+ *   import / フィールドが膨らむため
+ * - 設定変更は Step 8f で切り出しが完了するまで進行中の作業
+ */
+@RestController
+@RequestMapping("/api/v1/villages")
+@Tag(name = "villages", description = "村")
+class VillageSettingsRestController(
+    private val villageContextLoader: VillageContextLoader,
+    private val creatorCoordinator: CreatorCoordinator,
+    private val applier: VillageSettingsUpdateApplier,
+) {
+
+    @GetMapping("/{villageId}/settings/form")
+    @Operation(
+        summary = "村設定編集フォーム取得",
+        description = "creator 専用。編集 UI で必要な現在値 + 候補値 (役職一覧 / 陣営一覧 / 募集範囲 / " +
+                "年齢制限 / 秘話可能範囲 / 発言種別) を 1 リクエストで返す。",
+    )
+    fun getEditForm(@PathVariable villageId: Int): VillageSettingsFormView {
+        val village = villageContextLoader.loadVillageAndRequireCreator(villageId)
+        return VillageSettingsFormView(village)
+    }
+
+    @PutMapping("/{villageId}/settings")
+    @Operation(
+        summary = "村設定変更",
+        description = "creator 専用。プロローグ中のみ可。オリジナルキャラチップ村では入村パスワード必須。",
+    )
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun updateSettings(
+        @PathVariable villageId: Int,
+        @Valid @RequestBody body: VillageSettingsUpdateBody,
+    ) {
+        val village = villageContextLoader.loadVillageAndRequireCreator(villageId)
+        // オリジナルキャラチップ村ではパスワード必須 (旧 Thymeleaf 実装と同じガード)
+        if (village.setting.chara.isOriginalCharachip && body.joinPassword.isNullOrBlank()) {
+            throw WolfMansionBusinessException("オリジナルキャラクターを登録する村ではパスワードは必須です")
+        }
+        val merged = applier.apply(village, body)
+        creatorCoordinator.saveSettings(merged)
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageSettingsUpdateApplier.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageSettingsUpdateApplier.kt
@@ -1,0 +1,162 @@
+package com.ort.app.api.v1.villages
+
+import com.ort.app.api.request.VillageSettingForm
+import com.ort.app.api.request.validator.SettingFormValidator
+import com.ort.app.api.request.village.VillageSettingsUpdateBody
+import com.ort.app.domain.model.camp.Camp
+import com.ort.app.domain.model.message.MessageType
+import com.ort.app.domain.model.skill.Skill
+import com.ort.app.domain.model.village.Village
+import com.ort.app.domain.model.village.setting.SayRestriction
+import com.ort.app.domain.model.village.setting.SecretSayRange
+import com.ort.app.domain.model.village.setting.VillageOrganize
+import com.ort.app.domain.model.village.setting.VillageRandomOrganize
+import com.ort.app.domain.model.village.setting.VillageTags
+import com.ort.app.domain.model.village.setting.toModel
+import com.ort.app.fw.exception.WolfMansionBusinessException
+import com.ort.dbflute.allcommon.CDef
+import org.springframework.context.MessageSource
+import org.springframework.stereotype.Component
+import org.springframework.validation.BeanPropertyBindingResult
+import java.time.LocalDateTime
+import java.util.Locale
+
+/**
+ * `VillageSettingsUpdateBody` を Village に適用するヘルパー。
+ *
+ * 旧 `CreatorController.merge` の置き換え。cross-field バリデーションは既存の
+ * `SettingFormValidator` を共有 (body → form に変換してから流し込む) し、メッセージ
+ * 解決は `MessageSource` 経由で行う。
+ *
+ * オリジナルキャラチップ村でのパスワード必須チェックは旧 Thymeleaf 実装と同じく
+ * controller 側で別途呼び出す (本クラスは「form 由来の汎用チェック + Village への反映」)。
+ */
+@Component
+class VillageSettingsUpdateApplier(
+    private val settingFormValidator: SettingFormValidator,
+    private val messageSource: MessageSource,
+) {
+
+    /**
+     * バリデーション + 反映を一度に行う。違反があれば最初のエラーを
+     * `WolfMansionBusinessException` (= 400) にして送出する。
+     */
+    fun apply(village: Village, body: VillageSettingsUpdateBody): Village {
+        val form = body.toForm()
+        validate(form)
+        return merge(village, form)
+    }
+
+    private fun validate(form: VillageSettingForm) {
+        val errors = BeanPropertyBindingResult(form, "settingsForm")
+        settingFormValidator.validate(form, errors)
+        if (!errors.hasErrors()) return
+        val first = errors.allErrors.first()
+        val message = messageSource.getMessage(first, Locale.JAPANESE)
+        throw WolfMansionBusinessException(message)
+    }
+
+    /**
+     * 旧 `CreatorController.merge` と同じロジック。
+     * Thymeleaf 撤去 (Step 9) 後に旧 controller 側もこのヘルパーに合流させる想定。
+     */
+    private fun merge(village: Village, form: VillageSettingForm): Village {
+        val startDatetime = LocalDateTime.of(
+            form.startYear!!,
+            form.startMonth!!,
+            form.startDay!!,
+            form.startHour!!,
+            form.startMinute!!,
+        )
+        val welcome =
+            if (form.welcomeRange.isNullOrBlank()) emptyList()
+            else listOf(CDef.VillageTagItem.codeOf(form.welcomeRange).toModel())
+        val age =
+            if (form.ageLimit.isNullOrBlank()) emptyList()
+            else listOf(CDef.VillageTagItem.codeOf(form.ageLimit).toModel())
+        return village.copy(
+            name = form.villageName!!,
+            days = village.days.copy(
+                list = village.days.list.map {
+                    if (it.day == 0) it.copy(dayChangeDatetime = startDatetime)
+                    else it.copy()
+                },
+            ),
+            setting = village.setting.copy(
+                chara = village.setting.chara.copy(
+                    dummyDay1Message = form.dummyDay1Message,
+                ),
+                personMin = form.startPersonMinNum!!,
+                personMax = form.personMaxNum!!,
+                dayChangeIntervalSeconds = form.dayChangeIntervalHours!! * 3600 +
+                        form.dayChangeIntervalMinutes!! * 60 +
+                        form.dayChangeIntervalSeconds!!,
+                startDatetime = startDatetime,
+                rule = village.setting.rule.copy(
+                    isOpenVote = form.openVote!!,
+                    isAvailableSameWolfAttack = form.availableSameWolfAttack!!,
+                    isOpenSkillInGrave = form.openSkillInGrave!!,
+                    isVisibleGraveSpectateMessage = form.visibleGraveSpectateMessage!!,
+                    isAvailableSpectate = form.availableSpectate!!,
+                    isAvailableSuddenlyDeath = form.availableSuddonlyDeath!!,
+                    isAvailableCommit = form.availableCommit!!,
+                    isAvailableGuardSameTarget = form.availableGuardSameTarget!!,
+                    isAvailableAction = form.availableAction!!,
+                    isRandomOrganization = form.randomOrganization!!,
+                    isReincarnationSkillAll = form.reincarnationSkillAll!!,
+                    secretSayRange = SecretSayRange(CDef.AllowedSecretSay.codeOf(form.allowedSecretSayCode!!)),
+                ),
+                organize = VillageOrganize(
+                    fixedOrganization = form.organization.orEmpty(),
+                    randomOrganization = VillageRandomOrganize(
+                        campAllocation = form.campAllocationList?.map {
+                            VillageRandomOrganize.CampAllocation(
+                                camp = Camp(CDef.Camp.codeOf(it.campCode)),
+                                min = it.minNum!!,
+                                max = it.maxNum,
+                                initAllocation = it.allocation!!,
+                                reincarnationAllocation = it.reincarnationAllocation!!,
+                            )
+                        } ?: emptyList(),
+                        skillAllocation = form.campAllocationList?.flatMap { it.skillAllocation!! }?.map {
+                            VillageRandomOrganize.SkillAllocation(
+                                skill = Skill(CDef.Skill.codeOf(it.skillCode)),
+                                min = it.minNum!!,
+                                max = it.maxNum,
+                                initAllocation = it.allocation!!,
+                                reincarnationAllocation = it.reincarnationAllocation!!,
+                            )
+                        } ?: emptyList(),
+                        wolfAllocation = form.wolfAllocation?.let {
+                            VillageRandomOrganize.WolfAllocation(
+                                min = it.minNum!!,
+                                max = it.maxNum,
+                            )
+                        },
+                    ),
+                ),
+                joinPassword = form.joinPassword,
+                sayRestriction = SayRestriction(
+                    normalSayRestriction = form.sayRestrictList!!.filter { it.restrict!! }.map {
+                        SayRestriction.NormalSayRestriction(
+                            skill = Skill(CDef.Skill.codeOf(it.skillCode)),
+                            messageType = MessageType(CDef.MessageType.通常発言),
+                            count = it.count!!,
+                            length = it.length!!,
+                        )
+                    },
+                    skillSayRestriction = (form.skillSayRestrictList!! + form.rpSayRestrictList!!)
+                        .filter { it.restrict!! }
+                        .map {
+                            SayRestriction.SkillSayRestriction(
+                                messageType = MessageType(CDef.MessageType.codeOf(it.messageTypeCode)),
+                                count = it.count!!,
+                                length = it.length!!,
+                            )
+                        },
+                ),
+                tags = VillageTags(list = welcome + age),
+            ),
+        )
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/application/coordinator/CreatorCoordinator.kt
+++ b/backend/src/main/kotlin/com/ort/app/application/coordinator/CreatorCoordinator.kt
@@ -27,39 +27,56 @@ class CreatorCoordinator(
     fun kick(villageId: Int, charaId: Int) {
         val village = villageService.findVillage(villageId)
             ?: throw WolfMansionBusinessException("village not found. id: $villageId")
+        kick(village, charaId)
+    }
+
+    /** 呼び出し側で既に village を取得済みのオーバーロード (= 二重 SELECT を避ける)。 */
+    fun kick(village: Village, charaId: Int) {
         val target = village.allParticipants(excludeDummy = true).chara(charaId)
         // 退村させる
         villageService.leave(target)
         // 退村メッセージを登録
-        messageCoordinator.registerMessage(villageId, messageDomainService.createLeaveMessage(target))
+        messageCoordinator.registerMessage(village.id, messageDomainService.createLeaveMessage(target))
     }
 
     fun say(villageId: Int, text: String, isConvertDisable: Boolean) {
         val village = villageService.findVillage(villageId)
             ?: throw WolfMansionBusinessException("village not found. id: $villageId")
+        say(village, text, isConvertDisable)
+    }
+
+    fun say(village: Village, text: String, isConvertDisable: Boolean) {
         val message = messageCoordinator.registerMessage(
-            villageId,
+            village.id,
             messageDomainService.createCreatorMessage(village, text, isConvertDisable)
         )
         // notification
-        val players = playerService.findPlayers(villageId)
+        val players = playerService.findPlayers(village.id)
         notificationService.notifyReceiveMessageToCustomerIfNeeded(village, players, message)
     }
 
     fun cancel(villageId: Int) {
         val village = villageService.findVillage(villageId)
             ?: throw WolfMansionBusinessException("village not found. id: $villageId")
+        cancel(village)
+    }
+
+    fun cancel(village: Village) {
         if (!village.canCancel()) throw WolfMansionBusinessException("プロローグ中でなければ廃村できません")
-        villageService.cancel(villageId)
+        villageService.cancel(village.id)
     }
 
     fun extendEpilogue(villageId: Int) {
         val village = villageService.findVillage(villageId)
             ?: throw WolfMansionBusinessException("village not found. id: $villageId")
+        extendEpilogue(village)
+    }
+
+    fun extendEpilogue(village: Village) {
         if (!village.canExtendEpilogue()) throw WolfMansionBusinessException("エピローグ中でなければ延長できません")
         // エピローグを1日延長する
         villageService.extendDay(
-            villageId,
+            village.id,
             village.days.latestDay().day,
             village.days.latestDay().dayChangeDatetime.plusDays(1L)
         )
@@ -68,10 +85,14 @@ class CreatorCoordinator(
     fun shortenEpilogue(villageId: Int) {
         val village = villageService.findVillage(villageId)
             ?: throw WolfMansionBusinessException("village not found. id: $villageId")
+        shortenEpilogue(village)
+    }
+
+    fun shortenEpilogue(village: Village) {
         if (!village.canShortenEpilogue()) throw WolfMansionBusinessException("エピローグ中でなければ短縮できません")
         // エピローグを1日短縮する
         villageService.shortenDay(
-            villageId,
+            village.id,
             village.days.latestDay().day,
             village.days.latestDay().dayChangeDatetime.minusDays(1L)
         )

--- a/frontend/app/features/village/detail/CreatorPanel.tsx
+++ b/frontend/app/features/village/detail/CreatorPanel.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Link } from "react-router";
 import {
   useCancelVillageMutation,
   useCreatorSayMutation,
@@ -32,6 +33,7 @@ export function CreatorPanel({ village }: { village: VillageView }) {
 
       {isPrologue && (
         <>
+          <SettingsLink villageId={village.id} />
           <KickForm village={village} />
           <CancelButton villageId={village.id} />
         </>
@@ -95,6 +97,17 @@ function CreatorSayForm({ villageId }: { villageId: number }) {
         <p className="text-xs text-rose-300">{mutation.error.message}</p>
       )}
     </form>
+  );
+}
+
+function SettingsLink({ villageId }: { villageId: number }) {
+  return (
+    <div className="border-t border-amber-700/30 pt-3 flex items-center gap-3 flex-wrap">
+      <p className="text-xs text-amber-200/80">村設定変更 (プロローグ中のみ)</p>
+      <Link to={`/villages/${villageId}/settings`} className={secondaryButtonClass}>
+        設定を編集
+      </Link>
+    </div>
   );
 }
 

--- a/frontend/app/features/village/detail/SettingsForm.tsx
+++ b/frontend/app/features/village/detail/SettingsForm.tsx
@@ -1,0 +1,732 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router";
+import { useUpdateSettingsMutation } from "./hooks";
+import type {
+  VillageSettingsFormView,
+  VillageSettingsUpdateBody,
+} from "./api";
+
+/**
+ * 村設定編集フォーム (creator 専用)。
+ *
+ * 旧 Thymeleaf の `/village/{id}/settings` 置き換え。レイアウトはフラット、
+ * デザインは Step 12/13 で詰める想定 (HANDOFF: monorepo 移行中はデザインを詰めない)。
+ *
+ * State は `VillageSettingsUpdateBody` (送信形と同型) をそのまま保持し、表示ラベルは
+ * `initial.current` (FormView の現在値、`skillName` / `messageTypeName` を持つ) から引く。
+ * cross-field バリデーションは backend 側に任せ、フロントでは Required と type のみ最低限。
+ */
+export function SettingsForm({
+  villageId,
+  initial,
+}: {
+  villageId: number;
+  initial: VillageSettingsFormView;
+}) {
+  const navigate = useNavigate();
+  const [body, setBody] = useState<VillageSettingsUpdateBody>(() =>
+    toInitialBody(initial.current),
+  );
+  const mutation = useUpdateSettingsMutation(villageId);
+
+  const optionsByCamp = useMemo(
+    () => new Map(initial.current.campAllocationList.map((c) => [c.campCode, c])),
+    [initial.current.campAllocationList],
+  );
+  const sayRestrictLabels = useMemo(
+    () => new Map(initial.current.sayRestrictList.map((r) => [r.skillCode, r.skillName])),
+    [initial.current.sayRestrictList],
+  );
+  const messageTypeLabels = useMemo(
+    () =>
+      new Map([
+        ...initial.current.skillSayRestrictList.map((r) => [r.messageTypeCode, r.messageTypeName] as const),
+        ...initial.current.rpSayRestrictList.map((r) => [r.messageTypeCode, r.messageTypeName] as const),
+      ]),
+    [initial.current.skillSayRestrictList, initial.current.rpSayRestrictList],
+  );
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    mutation.mutate(body, {
+      onSuccess: () => {
+        navigate(`/villages/${villageId}`);
+      },
+    });
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-6">
+      <BasicSection body={body} setBody={setBody} />
+      <TagSection body={body} setBody={setBody} options={initial.options} />
+      <RulesSection body={body} setBody={setBody} options={initial.options} />
+      <JoinPasswordSection body={body} setBody={setBody} passwordRequired={initial.isOriginalCharachip} />
+      <DummyMessageSection body={body} setBody={setBody} />
+      <OrganizationSection body={body} setBody={setBody} optionsByCamp={optionsByCamp} />
+      <RestrictionsSection
+        body={body}
+        setBody={setBody}
+        sayRestrictLabels={sayRestrictLabels}
+        messageTypeLabels={messageTypeLabels}
+      />
+
+      <div className="sticky bottom-0 -mx-6 px-6 py-3 bg-slate-900/95 border-t border-slate-700 flex items-center justify-between gap-4">
+        <div className="text-xs text-slate-400">
+          プロローグ中のみ変更可能。エラー時は backend のメッセージが表示されます。
+        </div>
+        <div className="flex items-center gap-3">
+          {mutation.isError && (
+            <span className="text-xs text-rose-300 max-w-md truncate" title={mutation.error.message}>
+              {mutation.error.message}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={() => navigate(`/villages/${villageId}`)}
+            className={secondaryButtonClass}
+            disabled={mutation.isPending}
+          >
+            キャンセル
+          </button>
+          <button type="submit" className={primaryButtonClass} disabled={mutation.isPending}>
+            {mutation.isPending ? "送信中..." : "保存"}
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+}
+
+// ============================================================================
+// section components
+// ============================================================================
+
+type SectionProps = {
+  body: VillageSettingsUpdateBody;
+  setBody: React.Dispatch<React.SetStateAction<VillageSettingsUpdateBody>>;
+};
+
+function BasicSection({ body, setBody }: SectionProps) {
+  return (
+    <Section title="基本">
+      <Field label="村表示名 (5〜40文字)">
+        <input
+          type="text"
+          value={body.villageName}
+          onChange={(e) => setBody((s) => ({ ...s, villageName: e.target.value }))}
+          className={inputClass}
+          minLength={5}
+          maxLength={40}
+          required
+        />
+      </Field>
+
+      <div className="grid grid-cols-2 gap-3">
+        <Field label="最少開始人数 (8〜)">
+          <RequiredNumber value={body.startPersonMinNum} onChange={(v) => setBody((s) => ({ ...s, startPersonMinNum: v }))} min={8} />
+        </Field>
+        <Field label="定員">
+          <RequiredNumber value={body.personMaxNum} onChange={(v) => setBody((s) => ({ ...s, personMaxNum: v }))} max={999} />
+        </Field>
+      </div>
+
+      <Field label="更新間隔 (時 / 分 / 秒)">
+        <div className="flex items-center gap-2">
+          <RequiredNumber value={body.dayChangeIntervalHours} onChange={(v) => setBody((s) => ({ ...s, dayChangeIntervalHours: v }))} min={0} max={72} className="w-20" />
+          <span className="text-xs text-slate-400">時</span>
+          <RequiredNumber value={body.dayChangeIntervalMinutes} onChange={(v) => setBody((s) => ({ ...s, dayChangeIntervalMinutes: v }))} min={0} max={59} className="w-20" />
+          <span className="text-xs text-slate-400">分</span>
+          <RequiredNumber value={body.dayChangeIntervalSeconds} onChange={(v) => setBody((s) => ({ ...s, dayChangeIntervalSeconds: v }))} min={0} max={59} className="w-20" />
+          <span className="text-xs text-slate-400">秒</span>
+        </div>
+      </Field>
+
+      <Field label="開始日時">
+        <div className="flex items-center gap-2 flex-wrap">
+          <RequiredNumber value={body.startYear} onChange={(v) => setBody((s) => ({ ...s, startYear: v }))} min={0} className="w-24" />
+          <span className="text-xs text-slate-400">年</span>
+          <RequiredNumber value={body.startMonth} onChange={(v) => setBody((s) => ({ ...s, startMonth: v }))} min={1} max={12} className="w-16" />
+          <span className="text-xs text-slate-400">月</span>
+          <RequiredNumber value={body.startDay} onChange={(v) => setBody((s) => ({ ...s, startDay: v }))} min={1} max={31} className="w-16" />
+          <span className="text-xs text-slate-400">日</span>
+          <RequiredNumber value={body.startHour} onChange={(v) => setBody((s) => ({ ...s, startHour: v }))} min={0} max={23} className="w-16" />
+          <span className="text-xs text-slate-400">:</span>
+          <RequiredNumber value={body.startMinute} onChange={(v) => setBody((s) => ({ ...s, startMinute: v }))} min={0} max={59} className="w-16" />
+        </div>
+      </Field>
+    </Section>
+  );
+}
+
+function TagSection({
+  body,
+  setBody,
+  options,
+}: SectionProps & { options: VillageSettingsFormView["options"] }) {
+  return (
+    <Section title="タグ">
+      <Field label="募集範囲">
+        <select
+          value={body.welcomeRange ?? ""}
+          onChange={(e) => setBody((s) => ({ ...s, welcomeRange: e.target.value || null }))}
+          className={inputClass}
+        >
+          <option value="">指定なし</option>
+          {options.welcomeRanges.map((o) => (
+            <option key={o.code} value={o.code}>{o.name}</option>
+          ))}
+        </select>
+      </Field>
+      <Field label="年齢制限">
+        <select
+          value={body.ageLimit ?? ""}
+          onChange={(e) => setBody((s) => ({ ...s, ageLimit: e.target.value || null }))}
+          className={inputClass}
+        >
+          <option value="">全年齢</option>
+          {options.ageLimits.map((o) => (
+            <option key={o.code} value={o.code}>{o.name}</option>
+          ))}
+        </select>
+      </Field>
+    </Section>
+  );
+}
+
+function RulesSection({
+  body,
+  setBody,
+  options,
+}: SectionProps & { options: VillageSettingsFormView["options"] }) {
+  return (
+    <Section title="ルール">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        <CheckRow label="記名投票" checked={body.openVote} onChange={(v) => setBody((s) => ({ ...s, openVote: v }))} />
+        <CheckRow label="見学を可能にする" checked={body.availableSpectate} onChange={(v) => setBody((s) => ({ ...s, availableSpectate: v }))} />
+        <CheckRow label="突然死あり" checked={body.availableSuddenlyDeath} onChange={(v) => setBody((s) => ({ ...s, availableSuddenlyDeath: v }))} />
+        <CheckRow label="コミット可能" checked={body.availableCommit} onChange={(v) => setBody((s) => ({ ...s, availableCommit: v }))} />
+        <CheckRow label="アクションあり" checked={body.availableAction} onChange={(v) => setBody((s) => ({ ...s, availableAction: v }))} />
+        <CheckRow label="連続襲撃あり" checked={body.availableSameWolfAttack} onChange={(v) => setBody((s) => ({ ...s, availableSameWolfAttack: v }))} />
+        <CheckRow label="連続ガードあり" checked={body.availableGuardSameTarget} onChange={(v) => setBody((s) => ({ ...s, availableGuardSameTarget: v }))} />
+        <CheckRow label="墓下役職公開" checked={body.openSkillInGrave} onChange={(v) => setBody((s) => ({ ...s, openSkillInGrave: v }))} />
+        <CheckRow label="墓下見学発言を地上から見られる" checked={body.visibleGraveSpectateMessage} onChange={(v) => setBody((s) => ({ ...s, visibleGraveSpectateMessage: v }))} />
+        <CheckRow label="転生時に全役職を候補とする" checked={body.reincarnationSkillAll} onChange={(v) => setBody((s) => ({ ...s, reincarnationSkillAll: v }))} />
+        <CheckRow label="闇鍋編成" checked={body.randomOrganization} onChange={(v) => setBody((s) => ({ ...s, randomOrganization: v }))} />
+      </div>
+      <Field label="秘話可能範囲">
+        <select
+          value={body.allowedSecretSayCode}
+          onChange={(e) => setBody((s) => ({ ...s, allowedSecretSayCode: e.target.value }))}
+          className={inputClass}
+        >
+          {options.allowedSecretSays.map((o) => (
+            <option key={o.code} value={o.code}>{o.name}</option>
+          ))}
+        </select>
+      </Field>
+    </Section>
+  );
+}
+
+function JoinPasswordSection({
+  body,
+  setBody,
+  passwordRequired,
+}: SectionProps & { passwordRequired: boolean }) {
+  return (
+    <Section title="入村パスワード">
+      <Field label={`パスワード (3〜12文字${passwordRequired ? " / オリジナル画像村は必須" : ""})`}>
+        <input
+          type="text"
+          value={body.joinPassword ?? ""}
+          onChange={(e) => setBody((s) => ({ ...s, joinPassword: e.target.value || null }))}
+          className={inputClass}
+          minLength={passwordRequired ? 3 : 0}
+          maxLength={12}
+          required={passwordRequired}
+        />
+      </Field>
+    </Section>
+  );
+}
+
+function DummyMessageSection({ body, setBody }: SectionProps) {
+  return (
+    <Section title="ダミーキャラ1日目発言">
+      <textarea
+        value={body.dummyDay1Message ?? ""}
+        onChange={(e) => setBody((s) => ({ ...s, dummyDay1Message: e.target.value || null }))}
+        rows={3}
+        maxLength={400}
+        className={inputClass}
+        placeholder="未設定なら空欄 (最大 400 文字)"
+      />
+    </Section>
+  );
+}
+
+function OrganizationSection({
+  body,
+  setBody,
+  optionsByCamp,
+}: SectionProps & {
+  optionsByCamp: Map<string, VillageSettingsFormView["current"]["campAllocationList"][number]>;
+}) {
+  if (!body.randomOrganization) {
+    return (
+      <Section title="構成 (改行区切り)">
+        <textarea
+          value={body.organization ?? ""}
+          onChange={(e) => setBody((s) => ({ ...s, organization: e.target.value }))}
+          rows={10}
+          className={`${inputClass} font-mono`}
+          placeholder="1行 = 1構成 (例: 村狼狼狼魔狐賢導狩共共霊霊霊霊霊霊)"
+        />
+      </Section>
+    );
+  }
+  const camps = body.campAllocationList ?? [];
+  const wolf = body.wolfAllocation ?? { minNum: 1, maxNum: null };
+  return (
+    <Section title="闇鍋編成">
+      <p className="text-xs text-slate-400">
+        各陣営の minNum/maxNum/allocation/reincarnationAllocation と、陣営内の役職を編集します。
+      </p>
+      {camps.map((camp, ci) => {
+        const meta = optionsByCamp.get(camp.campCode);
+        return (
+          <div key={camp.campCode ?? ci} className="border border-slate-700 rounded p-3 space-y-2">
+            <p className="text-sm text-amber-200">{meta?.campName ?? camp.campCode}</p>
+            <AllocationRow
+              minNum={camp.minNum}
+              maxNum={camp.maxNum ?? null}
+              allocation={camp.allocation}
+              reincarnationAllocation={camp.reincarnationAllocation}
+              onChange={(patch) =>
+                setBody((s) => ({
+                  ...s,
+                  campAllocationList: (s.campAllocationList ?? []).map((c, i) =>
+                    i === ci ? { ...c, ...patch } : c,
+                  ),
+                }))
+              }
+            />
+            <details>
+              <summary className="text-xs text-slate-300 cursor-pointer">役職別 ({camp.skillAllocation.length}件)</summary>
+              <div className="mt-2 space-y-1">
+                {camp.skillAllocation.map((skill, si) => {
+                  const skillMeta = meta?.skillAllocation.find((sa) => sa.skillCode === skill.skillCode);
+                  return (
+                    <div key={skill.skillCode ?? si} className="flex items-center gap-2 text-xs">
+                      <span className="w-16 shrink-0 text-slate-300">{skillMeta?.skillName ?? skill.skillCode}</span>
+                      <AllocationRow
+                        minNum={skill.minNum}
+                        maxNum={skill.maxNum ?? null}
+                        allocation={skill.allocation}
+                        reincarnationAllocation={skill.reincarnationAllocation}
+                        compact
+                        onChange={(patch) =>
+                          setBody((s) => ({
+                            ...s,
+                            campAllocationList: (s.campAllocationList ?? []).map((c, i) =>
+                              i === ci
+                                ? {
+                                    ...c,
+                                    skillAllocation: c.skillAllocation.map((sk, j) =>
+                                      j === si ? { ...sk, ...patch } : sk,
+                                    ),
+                                  }
+                                : c,
+                            ),
+                          }))
+                        }
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            </details>
+          </div>
+        );
+      })}
+      <div className="border border-slate-700 rounded p-3 space-y-2">
+        <p className="text-sm text-amber-200">人狼カウント</p>
+        <div className="flex items-center gap-2 text-xs">
+          <span className="w-16 shrink-0 text-slate-300">min/max</span>
+          <RequiredNumber
+            value={wolf.minNum}
+            onChange={(v) => setBody((s) => ({ ...s, wolfAllocation: { ...wolf, minNum: v } }))}
+            min={1}
+            max={100}
+            className="w-20"
+          />
+          <span>〜</span>
+          <OptionalNumber
+            value={wolf.maxNum ?? null}
+            onChange={(v) => setBody((s) => ({ ...s, wolfAllocation: { ...wolf, maxNum: v } }))}
+            min={1}
+            max={100}
+            className="w-20"
+          />
+        </div>
+      </div>
+    </Section>
+  );
+}
+
+function AllocationRow({
+  minNum,
+  maxNum,
+  allocation,
+  reincarnationAllocation,
+  compact,
+  onChange,
+}: {
+  minNum: number;
+  maxNum: number | null;
+  allocation: number;
+  reincarnationAllocation: number;
+  compact?: boolean;
+  onChange: (patch: {
+    minNum?: number;
+    maxNum?: number | null;
+    allocation?: number;
+    reincarnationAllocation?: number;
+  }) => void;
+}) {
+  const w = compact ? "w-14" : "w-16";
+  return (
+    <div className="flex items-center gap-2 text-xs flex-wrap">
+      <Labeled label="min">
+        <RequiredNumber value={minNum} onChange={(v) => onChange({ minNum: v })} min={0} max={100} className={w} />
+      </Labeled>
+      <Labeled label="max">
+        <OptionalNumber value={maxNum} onChange={(v) => onChange({ maxNum: v })} min={0} max={100} className={w} />
+      </Labeled>
+      <Labeled label="配分">
+        <RequiredNumber value={allocation} onChange={(v) => onChange({ allocation: v })} min={0} max={100} className={w} />
+      </Labeled>
+      <Labeled label="転生配分">
+        <RequiredNumber value={reincarnationAllocation} onChange={(v) => onChange({ reincarnationAllocation: v })} min={0} max={100} className={w} />
+      </Labeled>
+    </div>
+  );
+}
+
+function RestrictionsSection({
+  body,
+  setBody,
+  sayRestrictLabels,
+  messageTypeLabels,
+}: SectionProps & {
+  sayRestrictLabels: Map<string, string>;
+  messageTypeLabels: Map<string, string>;
+}) {
+  const sayList = body.sayRestrictList ?? [];
+  const skillSayList = body.skillSayRestrictList ?? [];
+  const rpSayList = body.rpSayRestrictList ?? [];
+  return (
+    <Section title="発言制限">
+      <details>
+        <summary className="cursor-pointer text-sm text-slate-300">通常発言: 役職別 ({sayList.length}件)</summary>
+        <div className="mt-2 space-y-1">
+          {sayList.map((r, i) => (
+            <RestrictRow
+              key={r.skillCode ?? i}
+              label={sayRestrictLabels.get(r.skillCode) ?? r.skillCode}
+              restrict={r.restrict}
+              count={r.count ?? null}
+              length={r.length ?? null}
+              onChange={(patch) =>
+                setBody((s) => ({
+                  ...s,
+                  sayRestrictList: (s.sayRestrictList ?? []).map((row, j) =>
+                    i === j ? { ...row, ...patch } : row,
+                  ),
+                }))
+              }
+            />
+          ))}
+        </div>
+      </details>
+
+      <details>
+        <summary className="cursor-pointer text-sm text-slate-300">役職発言制限 ({skillSayList.length}件)</summary>
+        <div className="mt-2 space-y-1">
+          {skillSayList.map((r, i) => (
+            <RestrictRow
+              key={r.messageTypeCode ?? i}
+              label={messageTypeLabels.get(r.messageTypeCode) ?? r.messageTypeCode}
+              restrict={r.restrict}
+              count={r.count ?? null}
+              length={r.length ?? null}
+              onChange={(patch) =>
+                setBody((s) => ({
+                  ...s,
+                  skillSayRestrictList: (s.skillSayRestrictList ?? []).map((row, j) =>
+                    i === j ? { ...row, ...patch } : row,
+                  ),
+                }))
+              }
+            />
+          ))}
+        </div>
+      </details>
+
+      <details>
+        <summary className="cursor-pointer text-sm text-slate-300">RP 発言制限 ({rpSayList.length}件)</summary>
+        <div className="mt-2 space-y-1">
+          {rpSayList.map((r, i) => (
+            <RestrictRow
+              key={r.messageTypeCode ?? i}
+              label={messageTypeLabels.get(r.messageTypeCode) ?? r.messageTypeCode}
+              restrict={r.restrict}
+              count={r.count ?? null}
+              length={r.length ?? null}
+              onChange={(patch) =>
+                setBody((s) => ({
+                  ...s,
+                  rpSayRestrictList: (s.rpSayRestrictList ?? []).map((row, j) =>
+                    i === j ? { ...row, ...patch } : row,
+                  ),
+                }))
+              }
+            />
+          ))}
+        </div>
+      </details>
+    </Section>
+  );
+}
+
+function RestrictRow({
+  label,
+  restrict,
+  count,
+  length,
+  onChange,
+}: {
+  label: string;
+  restrict: boolean;
+  count: number | null;
+  length: number | null;
+  onChange: (patch: { restrict?: boolean; count?: number | null; length?: number | null }) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <label className="flex items-center gap-1 w-40 shrink-0">
+        <input type="checkbox" checked={restrict} onChange={(e) => onChange({ restrict: e.target.checked })} />
+        <span>{label}</span>
+      </label>
+      <Labeled label="回数">
+        <OptionalNumber value={count} onChange={(v) => onChange({ count: v })} min={0} max={100} className="w-16" disabled={!restrict} />
+      </Labeled>
+      <Labeled label="文字数">
+        <OptionalNumber value={length} onChange={(v) => onChange({ length: v })} min={0} max={400} className="w-20" disabled={!restrict} />
+      </Labeled>
+    </div>
+  );
+}
+
+// ============================================================================
+// initial mapping (FormView.current -> UpdateBody)
+// ============================================================================
+
+function toInitialBody(current: VillageSettingsFormView["current"]): VillageSettingsUpdateBody {
+  return {
+    villageName: current.villageName,
+    startPersonMinNum: current.startPersonMinNum,
+    personMaxNum: current.personMaxNum,
+    dayChangeIntervalHours: current.dayChangeIntervalHours,
+    dayChangeIntervalMinutes: current.dayChangeIntervalMinutes,
+    dayChangeIntervalSeconds: current.dayChangeIntervalSeconds,
+    startYear: current.startYear,
+    startMonth: current.startMonth,
+    startDay: current.startDay,
+    startHour: current.startHour,
+    startMinute: current.startMinute,
+    welcomeRange: current.welcomeRange ?? null,
+    ageLimit: current.ageLimit ?? null,
+    openVote: current.openVote,
+    availableSameWolfAttack: current.availableSameWolfAttack,
+    openSkillInGrave: current.openSkillInGrave,
+    visibleGraveSpectateMessage: current.visibleGraveSpectateMessage,
+    allowedSecretSayCode: current.allowedSecretSayCode,
+    availableSpectate: current.availableSpectate,
+    availableSuddenlyDeath: current.availableSuddenlyDeath,
+    availableCommit: current.availableCommit,
+    availableGuardSameTarget: current.availableGuardSameTarget,
+    availableAction: current.availableAction,
+    organization: current.organization,
+    randomOrganization: current.randomOrganization,
+    reincarnationSkillAll: current.reincarnationSkillAll,
+    campAllocationList: current.campAllocationList.map((c) => ({
+      campCode: c.campCode,
+      minNum: c.minNum,
+      maxNum: c.maxNum ?? null,
+      allocation: c.allocation,
+      reincarnationAllocation: c.reincarnationAllocation,
+      skillAllocation: c.skillAllocation.map((s) => ({
+        skillCode: s.skillCode,
+        minNum: s.minNum,
+        maxNum: s.maxNum ?? null,
+        allocation: s.allocation,
+        reincarnationAllocation: s.reincarnationAllocation,
+      })),
+    })),
+    wolfAllocation: {
+      minNum: current.wolfAllocation.minNum,
+      maxNum: current.wolfAllocation.maxNum ?? null,
+    },
+    dummyDay1Message: current.dummyDay1Message ?? null,
+    joinPassword: current.joinPassword ?? null,
+    sayRestrictList: current.sayRestrictList.map((r) => ({
+      skillCode: r.skillCode,
+      restrict: r.restrict,
+      count: r.count,
+      length: r.length,
+    })),
+    skillSayRestrictList: current.skillSayRestrictList.map((r) => ({
+      messageTypeCode: r.messageTypeCode,
+      restrict: r.restrict,
+      count: r.count,
+      length: r.length,
+    })),
+    rpSayRestrictList: current.rpSayRestrictList.map((r) => ({
+      messageTypeCode: r.messageTypeCode,
+      restrict: r.restrict,
+      count: r.count,
+      length: r.length,
+    })),
+  };
+}
+
+// ============================================================================
+// shared atoms
+// ============================================================================
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4 space-y-3">
+      <h2 className="text-sm text-slate-300 font-medium">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-1 text-sm">
+      <span className="text-xs text-slate-400">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function Labeled({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span className="text-slate-500">{label}</span>
+      {children}
+    </span>
+  );
+}
+
+function CheckRow({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <label className="flex items-center gap-2 text-sm">
+      <input type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} />
+      <span>{label}</span>
+    </label>
+  );
+}
+
+/** 必須 number 入力。空欄時は 0 にフォールバック (= 後で backend が範囲検証して 400)。 */
+function RequiredNumber({
+  value,
+  onChange,
+  min,
+  max,
+  className,
+  disabled,
+}: {
+  value: number;
+  onChange: (v: number) => void;
+  min?: number;
+  max?: number;
+  className?: string;
+  disabled?: boolean;
+}) {
+  return (
+    <input
+      type="number"
+      value={value}
+      onChange={(e) => {
+        const n = Number(e.target.value);
+        onChange(Number.isFinite(n) ? n : 0);
+      }}
+      min={min}
+      max={max}
+      disabled={disabled}
+      className={`${inputClass} ${className ?? "w-24"} disabled:opacity-40`}
+    />
+  );
+}
+
+/** 任意 number 入力。空欄は null (= 制限なし) として保持。 */
+function OptionalNumber({
+  value,
+  onChange,
+  min,
+  max,
+  className,
+  disabled,
+}: {
+  value: number | null;
+  onChange: (v: number | null) => void;
+  min?: number;
+  max?: number;
+  className?: string;
+  disabled?: boolean;
+}) {
+  return (
+    <input
+      type="number"
+      value={value ?? ""}
+      onChange={(e) => {
+        const raw = e.target.value;
+        if (raw === "") {
+          onChange(null);
+          return;
+        }
+        const n = Number(raw);
+        onChange(Number.isFinite(n) ? n : null);
+      }}
+      min={min}
+      max={max}
+      disabled={disabled}
+      className={`${inputClass} ${className ?? "w-24"} disabled:opacity-40`}
+    />
+  );
+}
+
+// ============================================================================
+// styling
+// ============================================================================
+
+const inputClass =
+  "bg-slate-900 border border-slate-700 rounded px-2 py-1 text-sm text-slate-100 placeholder-slate-500 focus:outline-none focus:border-indigo-500";
+
+const primaryButtonClass =
+  "rounded bg-indigo-500 hover:bg-indigo-400 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium";
+
+const secondaryButtonClass =
+  "rounded bg-slate-700 hover:bg-slate-600 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium";

--- a/frontend/app/features/village/detail/SettingsForm.tsx
+++ b/frontend/app/features/village/detail/SettingsForm.tsx
@@ -60,7 +60,12 @@ export function SettingsForm({
       <BasicSection body={body} setBody={setBody} />
       <TagSection body={body} setBody={setBody} options={initial.options} />
       <RulesSection body={body} setBody={setBody} options={initial.options} />
-      <JoinPasswordSection body={body} setBody={setBody} passwordRequired={initial.isOriginalCharachip} />
+      <JoinPasswordSection
+        body={body}
+        setBody={setBody}
+        passwordRequired={initial.isOriginalCharachip}
+        passwordAlreadySet={initial.current.joinPasswordSet}
+      />
       <DummyMessageSection body={body} setBody={setBody} />
       <OrganizationSection body={body} setBody={setBody} optionsByCamp={optionsByCamp} />
       <RestrictionsSection
@@ -232,12 +237,19 @@ function JoinPasswordSection({
   body,
   setBody,
   passwordRequired,
-}: SectionProps & { passwordRequired: boolean }) {
+  passwordAlreadySet,
+}: SectionProps & { passwordRequired: boolean; passwordAlreadySet: boolean }) {
+  // backend は現パスワード値を返さない (ネットワーク経由の漏洩を避ける)。
+  // 既設定がある場合、空欄のまま保存するとクリア扱い (= 入村パスワード無し) になる旨を案内する。
+  const note = passwordAlreadySet
+    ? "現在: 設定済み (空欄で保存するとクリア)。変更しない場合は同じ値を再入力してください。"
+    : "現在: 未設定。";
   return (
     <Section title="入村パスワード">
       <Field label={`パスワード (3〜12文字${passwordRequired ? " / オリジナル画像村は必須" : ""})`}>
         <input
-          type="text"
+          type="password"
+          autoComplete="new-password"
           value={body.joinPassword ?? ""}
           onChange={(e) => setBody((s) => ({ ...s, joinPassword: e.target.value || null }))}
           className={inputClass}
@@ -246,6 +258,7 @@ function JoinPasswordSection({
           required={passwordRequired}
         />
       </Field>
+      <p className="text-xs text-slate-500">{note}</p>
     </Section>
   );
 }
@@ -579,7 +592,8 @@ function toInitialBody(current: VillageSettingsFormView["current"]): VillageSett
       maxNum: current.wolfAllocation.maxNum ?? null,
     },
     dummyDay1Message: current.dummyDay1Message ?? null,
-    joinPassword: current.joinPassword ?? null,
+    // 初期値は常に空欄 (backend は現パスワードを返さない)。空欄で保存するとクリア扱い。
+    joinPassword: null,
     sayRestrictList: current.sayRestrictList.map((r) => ({
       skillCode: r.skillCode,
       restrict: r.restrict,

--- a/frontend/app/features/village/detail/api.ts
+++ b/frontend/app/features/village/detail/api.ts
@@ -38,6 +38,15 @@ export type VillageCreatorSayBody = components["schemas"]["VillageCreatorSayBody
 export type VillageKickBody = components["schemas"]["VillageKickBody"];
 export type VillageAdminLeaveBody = components["schemas"]["VillageAdminLeaveBody"];
 export type VillageAdminPlayerView = components["schemas"]["VillageAdminPlayerView"];
+// SpringDoc + OpenAPI 3.1 で nullable フィールドが optional (`T | undefined`) に
+// 落ちる件 (`PlayerView` でも同じ対応) に合わせ、null も書き込めるよう深く広げる。
+// backend は undefined と null を同等に扱うので送信側でどちらでも OK。
+type WidenOptionalsDeep<T> =
+  T extends Array<infer U> ? Array<WidenOptionalsDeep<U>> :
+  T extends object ? { [K in keyof T]: undefined extends T[K] ? WidenOptionalsDeep<T[K]> | null : WidenOptionalsDeep<T[K]> } :
+  T;
+export type VillageSettingsFormView = WidenOptionalsDeep<components["schemas"]["VillageSettingsFormView"]>;
+export type VillageSettingsUpdateBody = WidenOptionalsDeep<components["schemas"]["VillageSettingsUpdateBody"]>;
 
 // ---------- fetchers ----------
 
@@ -463,6 +472,41 @@ export async function postAdminForceLeave(
   });
   if (!res.ok) {
     throw new Error(`admin leave failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+}
+
+// ---------- village settings (creator, Step 8f) ----------
+
+/**
+ * GET /api/v1/villages/{id}/settings/form — 設定編集 UI 用 (現在値 + 候補値) を返す。
+ * 未認証 / 非 creator は 400。
+ */
+export async function fetchSettingsForm(
+  villageId: number,
+  fetcher: ApiFetch = browserFetch,
+): Promise<VillageSettingsFormView> {
+  const res = await fetcher(`/api/v1/villages/${villageId}/settings/form`);
+  if (!res.ok) {
+    throw new Error(`settings form fetch failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+  return res.json();
+}
+
+/**
+ * PUT /api/v1/villages/{id}/settings — 設定を更新する。成功時 204。
+ * cross-field バリデーション失敗時は 400 + ErrorResponse.message。
+ */
+export async function putSettings(
+  villageId: number,
+  body: VillageSettingsUpdateBody,
+  fetcher: ApiFetch = browserFetch,
+): Promise<void> {
+  const res = await fetcher(`/api/v1/villages/${villageId}/settings`, {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`settings update failed: ${res.status} ${await readErrorMessage(res)}`);
   }
 }
 

--- a/frontend/app/features/village/detail/hooks.ts
+++ b/frontend/app/features/village/detail/hooks.ts
@@ -14,6 +14,7 @@ import {
   fetchFootstepCandidates,
   fetchMyself,
   fetchSelectableCharas,
+  fetchSettingsForm,
   fetchVillage,
   fetchVillageFootsteps,
   fetchVillageMessages,
@@ -35,6 +36,7 @@ import {
   putCommit,
   putFaceTypes,
   putMemo,
+  putSettings,
   type CharaView,
   type MessagesView,
   type MyselfFaceTypesView,
@@ -52,6 +54,8 @@ import {
   type VillageKickBody,
   type VillageMemoBody,
   type VillageParticipateBody,
+  type VillageSettingsFormView,
+  type VillageSettingsUpdateBody,
   type VillageView,
   type VillageVoteBody,
 } from "./api";
@@ -464,5 +468,39 @@ export function useAdminForceLeaveMutation(
   return useMutation<void, Error, VillageAdminLeaveBody>({
     mutationFn: (body) => postAdminForceLeave(villageId, body),
     onSuccess: () => invalidateAll(queryClient, villageId),
+  });
+}
+
+// ---------- Settings (Step 8f) ----------
+
+/**
+ * GET /api/v1/villages/{id}/settings/form — 設定編集 UI 用 (creator 専用)。
+ * `enabled=false` のときはクエリを発行しない (= creator でないユーザでも safe)。
+ *
+ * staleTime を長め (60秒) にしているのは編集中の form 値を polling で上書きしないため。
+ * mutation 成功時に invalidate して取り直す。
+ */
+export function useSettingsFormQuery(
+  villageId: number,
+  enabled: boolean,
+): UseQueryResult<VillageSettingsFormView> {
+  return useQuery<VillageSettingsFormView>({
+    queryKey: ["village", villageId, "settings", "form"],
+    queryFn: () => fetchSettingsForm(villageId),
+    enabled,
+    staleTime: 60_000,
+  });
+}
+
+export function useUpdateSettingsMutation(
+  villageId: number,
+): UseMutationResult<void, Error, VillageSettingsUpdateBody> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, VillageSettingsUpdateBody>({
+    mutationFn: (body) => putSettings(villageId, body),
+    onSuccess: () => {
+      // 村ヘッダ / settings form 両方を invalidate (村名や定員等 VillageView にも出ているため)
+      queryClient.invalidateQueries({ queryKey: ["village", villageId] });
+    },
   });
 }

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -5,6 +5,7 @@ export default [
   route("login", "routes/login.tsx"),
   route("villages", "routes/villages._index.tsx"),
   route("villages/:id", "routes/villages.$id.tsx"),
+  route("villages/:id/settings", "routes/villages.$id.settings.tsx"),
   route("players", "routes/players._index.tsx"),
   // NOTE: 認証不要。`isSelf=true` のときだけ編集 UI が出る (backend が viewer JWT を読んで判定)。
   route("players/:userName", "routes/players.$userName.tsx"),

--- a/frontend/app/routes/villages.$id.settings.tsx
+++ b/frontend/app/routes/villages.$id.settings.tsx
@@ -1,0 +1,82 @@
+import { Link, useNavigate } from "react-router";
+import type { Route } from "./+types/villages.$id.settings";
+import { fetchSettingsForm, fetchVillage } from "~/features/village/detail/api";
+import { useSettingsFormQuery, useVillageQuery } from "~/features/village/detail/hooks";
+import { SettingsForm } from "~/features/village/detail/SettingsForm";
+import { ssrFetch } from "~/lib/api/client";
+
+/**
+ * 村設定変更画面 (creator 専用ルート、Step 8f)。
+ *
+ * SSR loader で村と設定フォームをまとめて取りに行く。失敗時 (= 認可なし / 村なし) は
+ * loader 内で 403/404 を投げる。
+ *
+ * 進行中以降は backend 側の `assertModifySetting` で 400 になるが、UI でも先回りして
+ * フォーム表示前にステータスを判定し「現在は変更できません」を表示する。
+ */
+export function meta({ data }: Route.MetaArgs) {
+  const name = data?.village?.name ?? "村設定";
+  return [{ title: `${name} - 設定変更` }];
+}
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const villageId = Number(params.id);
+  if (!Number.isFinite(villageId)) {
+    throw new Response("invalid village id", { status: 400 });
+  }
+  const api = ssrFetch(request);
+  const village = await fetchVillage(villageId, api).catch(() => null);
+  if (!village) throw new Response("village not found", { status: 404 });
+  // 設定フォームは creator 以外 (= 未認証含む) なら 400 になる。
+  // SSR の段階で取れなければ catch して null を返し、クライアント側で「creator のみ」表示にする。
+  const settingsForm = await fetchSettingsForm(villageId, api).catch(() => null);
+  return { villageId, village, settingsForm };
+}
+
+export default function VillageSettings({ loaderData }: Route.ComponentProps) {
+  const { villageId, village: initialVillage, settingsForm: initialForm } = loaderData;
+  const navigate = useNavigate();
+
+  const villageQuery = useVillageQuery(villageId, initialVillage);
+  const village = villageQuery.data ?? initialVillage;
+  const isPrologue = village.statusCode === "IN_PREPARATION";
+
+  // creator 認可が無いと initialForm は null になる。クライアントの再 fetch も
+  // どうせ失敗するので、creator っぽいときだけ enable する (= isCreator)。
+  const settingsQuery = useSettingsFormQuery(villageId, village.isCreator);
+  const settingsForm = settingsQuery.data ?? initialForm;
+
+  return (
+    <main className="min-h-screen bg-slate-900 text-slate-100">
+      <section className="max-w-3xl mx-auto px-6 py-8 space-y-4">
+        <header className="flex items-center justify-between">
+          <h1 className="text-xl font-bold">
+            村設定変更 <span className="text-slate-400 text-sm">#{village.number} {village.name}</span>
+          </h1>
+          <Link to={`/villages/${villageId}`} className="text-sm text-slate-400 hover:text-slate-200">
+            ← 村画面
+          </Link>
+        </header>
+
+        {!settingsForm ? (
+          <p className="text-sm text-rose-300">
+            この村の設定を編集する権限がありません (creator のみ)。
+            <button
+              type="button"
+              onClick={() => navigate(`/villages/${villageId}`)}
+              className="ml-3 underline"
+            >
+              村画面に戻る
+            </button>
+          </p>
+        ) : !isPrologue ? (
+          <p className="text-sm text-amber-300">
+            プロローグ中以外は設定を変更できません (現在: {village.statusName})。
+          </p>
+        ) : (
+          <SettingsForm villageId={villageId} initial={settingsForm} />
+        )}
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
closes `.issues/7-village-settings-rest.md`
closes `.issues/8-creator-coordinator-village-redundant-select.md`

## 変更内容

### backend
- `GET /api/v1/villages/{id}/settings/form`: 編集 UI 用 (現在値 + 候補値 = 役職/陣営/募集範囲/年齢制限/秘話可能範囲/発言種別) を 1 リクエストで返す
- `PUT /api/v1/villages/{id}/settings`: 設定保存。creator 認可必須、プロローグ中のみ
- `VillageSettingsUpdateBody` (JSON 受信用 DTO) を新規。`VillageSettingForm` から
  display-only フィールドを除外。cross-field 検証は `SettingFormValidator` を
  再利用 (body→form 変換 + MessageSource でメッセージ解決 → `WolfMansionBusinessException`)
- オリジナルキャラチップ村のパスワード必須チェックも踏襲
- 旧 Thymeleaf `/village/{id}/settings` (`CreatorController`) は撤去せず残置
  (Step 9 で thymeleaf 一括撤去予定)
- **issue #8**: `CreatorCoordinator.kick / say / cancel / extendEpilogue / shortenEpilogue` に
  `Village` 引数版オーバーロードを追加し `VillageCreatorRestController` から差し替え
  (1 リクエスト中の village テーブル 2 回 SELECT を解消)。旧 `villageId: Int` 版は
  互換のため残置 (旧 Thymeleaf `CreatorController` がまだ使う)

### frontend
- `/villages/:id/settings` 新規ルート (`SettingsForm.tsx`)
- creator 認可は SSR loader で settings/form fetch を試みた結果 (null なら非 creator)。
  クライアント側 query は `village.isCreator` で enable 制御
- `CreatorPanel` に「設定を編集」リンクを追加 (プロローグ中のみ)
- フォーム構成: 基本 / タグ / ルール / パスワード / ダミー1日目 / 構成 (闇鍋編成 or 固定構成) / 発言制限
- 闇鍋編成 (陣営 + 陣営内役職) ・人狼カウント・発言制限は `<details>` で開閉可能に
- cross-field エラーは backend のメッセージをそのまま表示 (バリデーション本体は backend 側)
- nullable / optional 型は既存 player と同じパターンで `WidenOptionalsDeep` 経由で吸収

## 動作確認
- [x] backend: `./gradlew test` (BUILD SUCCESSFUL)
- [x] frontend: `pnpm typecheck && pnpm test && pnpm build` (パス)
- [ ] ユーザー手動確認依頼: 実 DB の村で `creator` ログイン → `/villages/{id}/settings` を開いて編集 → 保存 → 村画面に戻り更新が反映されていることを確認

## レビュー観点
- backend テストは追加なし (PR #21 / 既存 `VillageCreatorRestController` も同じスタンス)。
  controller テスト基盤は `V1TestSupport` にあるので、必要ならフォロー issue で追加可
- `VillageSettingsUpdateApplier.merge` は `CreatorController.merge` のコピー実装。
  step 9 (thymeleaf 撤去) で旧 controller 側を消す際に一本化する想定

🤖 Generated with [Claude Code](https://claude.com/claude-code)