### PR TITLE
Step 8g: メタ情報 REST 化 (charachip / skill / village-record) + frontend 4 ルート

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/response/chara/CharachipDetailView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/chara/CharachipDetailView.kt
@@ -1,0 +1,27 @@
+package com.ort.app.api.response.chara
+
+import com.ort.app.domain.model.chara.Charachip
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * キャラチップ詳細 (キャラ一覧 + メタ情報) を返す。
+ * `/charachips/{id}` の表示および新規村作成時のダミーキャラ選択候補に使用する想定。
+ */
+@Schema(description = "キャラチップ詳細 (キャラ一覧つき)")
+data class CharachipDetailView(
+    @field:Schema(description = "キャラチップ ID") val id: Int,
+    @field:Schema(description = "キャラチップ名") val name: String,
+    @field:Schema(description = "作者名") val designerName: String,
+    @field:Schema(description = "キャラチップ説明ページ URL (nullable)") val descriptionUrl: String?,
+    @field:Schema(description = "キャラ名変更を許可するキャラチップか") val isAvailableChangeName: Boolean,
+    @field:Schema(description = "キャラ一覧 (デフォルト画像のみ)") val charas: List<CharaView>,
+) {
+    constructor(charachip: Charachip) : this(
+        id = charachip.id,
+        name = charachip.name,
+        designerName = charachip.designer?.name ?: "",
+        descriptionUrl = charachip.descriptionUrl,
+        isAvailableChangeName = charachip.isAvailableChangeName,
+        charas = charachip.charas.list.map { CharaView(it) },
+    )
+}

--- a/backend/src/main/kotlin/com/ort/app/api/response/chara/CharachipView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/chara/CharachipView.kt
@@ -1,0 +1,29 @@
+package com.ort.app.api.response.chara
+
+import com.ort.app.domain.model.chara.Charachip
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "キャラチップ概要 (一覧表示用)")
+data class CharachipView(
+    @field:Schema(description = "キャラチップ ID") val id: Int,
+    @field:Schema(description = "キャラチップ名") val name: String,
+    @field:Schema(description = "作者名") val designerName: String,
+    @field:Schema(description = "キャラ数") val charaCount: Int,
+    @field:Schema(description = "ダミーキャラの代表画像 URL") val dummyImageUrl: String,
+    @field:Schema(description = "ダミー画像の幅 (px)") val dummyImageWidth: Int,
+    @field:Schema(description = "ダミー画像の高さ (px)") val dummyImageHeight: Int,
+    @field:Schema(description = "キャラチップ説明ページ URL (nullable)") val descriptionUrl: String?,
+    @field:Schema(description = "オリジナルキャラチップか (= プレイヤー登録による画像)") val isOriginal: Boolean,
+) {
+    constructor(charachip: Charachip, isOriginal: Boolean = false) : this(
+        id = charachip.id,
+        name = charachip.name,
+        designerName = charachip.designer?.name ?: "",
+        charaCount = charachip.charas.list.size,
+        dummyImageUrl = charachip.dummyChara().defaultImage().url,
+        dummyImageWidth = charachip.dummyChara().size.width,
+        dummyImageHeight = charachip.dummyChara().size.height,
+        descriptionUrl = charachip.descriptionUrl,
+        isOriginal = isOriginal,
+    )
+}

--- a/backend/src/main/kotlin/com/ort/app/api/response/skill/SkillCatalogView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/skill/SkillCatalogView.kt
@@ -1,0 +1,37 @@
+package com.ort.app.api.response.skill
+
+import com.ort.app.domain.model.camp.CampSkill
+import com.ort.app.domain.model.skill.SkillTag
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 役職カタログ (陣営別の役職一覧 + 役職タグ一覧)。`/skills` 一覧画面で使用。
+ *
+ * 旧 Thymeleaf 側の `SkillContent` (役職一覧表示) と `SkillListContent` (フッタの簡易カード)
+ * を統合した形。タグは絞り込みフィルタの選択肢として返す。
+ */
+@Schema(description = "役職カタログ (陣営別 + タグ一覧)")
+data class SkillCatalogView(
+    @field:Schema(description = "陣営別の役職一覧")
+    val camps: List<CampSkills>,
+    @field:Schema(description = "役職タグ一覧 (絞り込み用)")
+    val tags: List<String>,
+) {
+    constructor(campSkills: List<CampSkill>) : this(
+        camps = campSkills.map { CampSkills(it) },
+        tags = SkillTag.values().map { it.name },
+    )
+
+    @Schema(description = "陣営とその陣営に属する役職一覧")
+    data class CampSkills(
+        @field:Schema(description = "陣営コード (CDef.Camp)") val campCode: String,
+        @field:Schema(description = "陣営名") val campName: String,
+        val skills: List<SkillView>,
+    ) {
+        constructor(campSkill: CampSkill) : this(
+            campCode = campSkill.camp.code,
+            campName = campSkill.camp.name,
+            skills = campSkill.skillList.map { SkillView(it) },
+        )
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/response/village/VillageRecordsView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/village/VillageRecordsView.kt
@@ -1,0 +1,110 @@
+package com.ort.app.api.response.village
+
+import com.ort.app.domain.model.player.Players
+import com.ort.app.domain.model.village.Village
+import com.ort.app.domain.model.village.Villages
+import com.ort.app.domain.model.village.participant.VillageParticipant
+import com.ort.app.domain.model.village.participant.dead.Dead
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+/**
+ * 終了済 (エピローグ / 終了 / 廃村) 村の戦績一覧。
+ *
+ * 旧 Thymeleaf `/village-record/list` (`VillageRecordSummaryListContent`) の置き換え。
+ * 旧 API は snake_case + 文字列日付だったが、REST 化に合わせて他の REST API と統一し
+ * camelCase + `LocalDateTime` (Spring の Jackson で ISO 文字列にシリアライズ) で返す。
+ *
+ * 表記揺れリスクを抑えるため、外部連携 (Discord ボット等) が旧 snake_case を期待していたら
+ * 旧 Thymeleaf endpoint は当面残置する方針 (CLAUDE.md に従い Thymeleaf 撤去まで併存可)。
+ */
+@Schema(description = "終了村の戦績一覧")
+data class VillageRecordsView(
+    @field:Schema(description = "村レコード (新しい順)")
+    val list: List<VillageRecordSummary>,
+) {
+    constructor(villages: Villages, players: Players) : this(
+        list = villages.list.map { VillageRecordSummary(it, players) },
+    )
+
+    @Schema(description = "村 1 件の戦績")
+    data class VillageRecordSummary(
+        @field:Schema(description = "村 ID") val id: Int,
+        @field:Schema(description = "村名") val name: String,
+        @field:Schema(description = "ステータス名 (例: 終了, 廃村)") val status: String,
+        @field:Schema(description = "編成 (役職略称の連結)") val organization: String,
+        @field:Schema(description = "更新間隔 (秒)") val intervalSeconds: Int,
+        @field:Schema(description = "1 日目開始日時 (廃村なら null)") val startDatetime: LocalDateTime?,
+        @field:Schema(description = "プロローグ開始日時") val prologueDatetime: LocalDateTime,
+        @field:Schema(description = "エピローグ開始日時 (廃村なら null)") val epilogueDatetime: LocalDateTime?,
+        @field:Schema(description = "エピローグが何日目か") val epilogueDay: Int?,
+        @field:Schema(description = "勝利陣営名") val winCampName: String?,
+        @field:Schema(description = "参加者一覧 (見学含む)") val participants: List<VillageRecordParticipant>,
+    ) {
+        constructor(village: Village, players: Players) : this(
+            id = village.id,
+            name = village.name,
+            status = village.status.name,
+            organization = convertOrganization(village),
+            intervalSeconds = village.setting.dayChangeIntervalSeconds,
+            startDatetime = if (village.status.isCanceled()) null else village.setting.startDatetime,
+            prologueDatetime = village.createDatetime,
+            epilogueDatetime = if (village.status.isCanceled()) null else convertEpilogueDatetime(village),
+            epilogueDay = village.epilogueDay,
+            winCampName = village.winCamp?.name,
+            participants = village.allParticipants().list.map { VillageRecordParticipant(it, players) },
+        )
+
+        @Schema(description = "村参加者 1 件の戦績情報")
+        data class VillageRecordParticipant(
+            @field:Schema(description = "プレイヤーのユーザ名") val userName: String,
+            @field:Schema(description = "キャラ名") val characterName: String,
+            @field:Schema(description = "役職名 (1日目時点、見学なら null)") val skillName: String?,
+            @field:Schema(description = "見学か") val isSpectator: Boolean,
+            @field:Schema(description = "勝利したか (廃村などで null あり)") val isWin: Boolean?,
+            @field:Schema(description = "死亡したか") val isDead: Boolean,
+            @field:Schema(description = "死亡日") val deadDay: Int?,
+            @field:Schema(description = "死因 (\"〜死\" 表記)") val deadReason: String?,
+            @field:Schema(description = "勝敗判定陣営名") val campName: String?,
+        ) {
+            constructor(participant: VillageParticipant, players: Players) : this(
+                userName = players.list.first { it.id == participant.playerId }.name,
+                characterName = participant.charaName.name,
+                skillName = participant.skillWhen(1)?.name,
+                isSpectator = participant.isSpectator,
+                isWin = participant.isWin,
+                isDead = participant.dead.isDead,
+                deadDay = participant.dead.deadDay,
+                deadReason = extractDeadReason(participant.dead),
+                campName = participant.camp?.name,
+            )
+
+            companion object {
+                private fun extractDeadReason(dead: Dead): String? {
+                    if (!dead.isDead) return null
+                    val reason = dead.reason!!.name
+                    return if (reason.endsWith("死")) reason else "${reason}死"
+                }
+            }
+        }
+
+        companion object {
+            private fun convertOrganization(village: Village): String = when {
+                village.status.isCanceled() -> "廃村"
+                village.setting.rule.isRandomOrganization -> village.participants.list
+                    .map { it.skill!! }
+                    .sortedBy { it.toCdef().order().toInt() }
+                    .joinToString(separator = "") { it.shortName }
+                else -> village.setting.organize.fixedOrganization
+                    .replace("\r\n", "\n").split("\n")
+                    .firstOrNull { it.length == village.participants.count }
+                    ?: ""
+            }
+
+            private fun convertEpilogueDatetime(village: Village): LocalDateTime? {
+                val epilogueDay = village.epilogueDay ?: return null
+                return village.days.list.firstOrNull { it.day == epilogueDay - 1 }?.dayChangeDatetime
+            }
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/response/village/VillageRecordsView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/village/VillageRecordsView.kt
@@ -68,7 +68,10 @@ data class VillageRecordsView(
             @field:Schema(description = "勝敗判定陣営名") val campName: String?,
         ) {
             constructor(participant: VillageParticipant, players: Players) : this(
-                userName = players.list.first { it.id == participant.playerId }.name,
+                // `playerService.findPlayers(villageIdList)` は isGone=false の村プレイヤーのみ取得するため、
+                // 途中退村プレイヤー (= isGone=true) は players に含まれない可能性がある。
+                // 該当プレイヤーが見つからない場合は表示用フォールバック "(退会)" を返す。
+                userName = players.list.firstOrNull { it.id == participant.playerId }?.name ?: "(退会)",
                 characterName = participant.charaName.name,
                 skillName = participant.skillWhen(1)?.name,
                 isSpectator = participant.isSpectator,
@@ -81,9 +84,13 @@ data class VillageRecordsView(
 
             companion object {
                 private fun extractDeadReason(dead: Dead): String? {
-                    if (!dead.isDead) return null
-                    val reason = dead.reason!!.name
-                    return if (reason.endsWith("死")) reason else "${reason}死"
+                    // `dead.isDead == true` のとき `dead.reason` が常に非 null であることは
+                    // ドメインモデル上の不変だが、コンパイラはスマートキャストできないので
+                    // `?.let` で明示的に扱う。
+                    return dead.reason?.let {
+                        val name = it.name
+                        if (name.endsWith("死")) name else "${name}死"
+                    }
                 }
             }
         }
@@ -92,7 +99,9 @@ data class VillageRecordsView(
             private fun convertOrganization(village: Village): String = when {
                 village.status.isCanceled() -> "廃村"
                 village.setting.rule.isRandomOrganization -> village.participants.list
-                    .map { it.skill!! }
+                    // 廃村でないと skill は基本非 null だが、データ不整合時の NPE を避けるため
+                    // `mapNotNull` で safe にフィルタする (廃村は↑で別分岐)
+                    .mapNotNull { it.skill }
                     .sortedBy { it.toCdef().order().toInt() }
                     .joinToString(separator = "") { it.shortName }
                 else -> village.setting.organize.fixedOrganization
@@ -101,6 +110,13 @@ data class VillageRecordsView(
                     ?: ""
             }
 
+            /**
+             * エピローグ突入日時 = `(epilogueDay - 1)` の `dayChangeDatetime` (=その日の終了時刻
+             * = 次の日 = エピローグ初日の開始時刻)。
+             * 例えば epilogueDay=4 (4日目がエピローグ) なら day=3 の dayChangeDatetime。
+             * epilogueDay=1 (= 1日目がエピローグ、極端なケース) なら day=0 (プロローグ) の
+             * dayChangeDatetime が返り、これはプロローグ終了 = day 1 開始時刻なので意味的に正しい。
+             */
             private fun convertEpilogueDatetime(village: Village): LocalDateTime? {
                 val epilogueDay = village.epilogueDay ?: return null
                 return village.days.list.firstOrNull { it.day == epilogueDay - 1 }?.dayChangeDatetime

--- a/backend/src/main/kotlin/com/ort/app/api/v1/charachips/CharachipRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/charachips/CharachipRestController.kt
@@ -1,0 +1,52 @@
+package com.ort.app.api.v1.charachips
+
+import com.ort.app.api.response.chara.CharachipDetailView
+import com.ort.app.api.response.chara.CharachipView
+import com.ort.app.application.service.CharaService
+import com.ort.app.fw.exception.WolfMansionRecordNotFoundException
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * キャラチップ / キャラの参照 REST API。
+ *
+ * 旧 Thymeleaf `CharaController` (`/chara-group`, `/chara-group/{id}`) の置き換え。
+ * フロントエンドの「キャラチップ一覧 / 詳細」画面、および新規村作成 (Step 8h) でのダミーキャラ
+ * 選択候補取得に使う。
+ *
+ * オリジナルキャラチップ (`isOriginal=true`) はプレイヤーが登録した画像セットで、
+ * 認可されたユーザのみが見えるべき。現状は read-only / 公開済みのみを返す前提で
+ * `isOriginal=false` 固定で実装する (オリジナルキャラチップの管理機能は Step 8h 以降)。
+ */
+@RestController
+@RequestMapping("/api/v1/charachips")
+@Tag(name = "charachips", description = "キャラチップ / キャラ")
+class CharachipRestController(
+    private val charaService: CharaService,
+) {
+
+    @GetMapping
+    @Operation(
+        summary = "キャラチップ一覧",
+        description = "公式キャラチップ (= プレイヤー登録によるオリジナルでないもの) を全件返す。",
+    )
+    fun list(): List<CharachipView> {
+        return charaService.findCharachips().list.map { CharachipView(it) }
+    }
+
+    @GetMapping("/{charachipId}")
+    @Operation(
+        summary = "キャラチップ詳細",
+        description = "指定キャラチップに属するキャラ一覧 (デフォルト画像のみ) と作者・説明 URL を返す。" +
+                "オリジナルキャラチップは現時点では公開しないので `isOriginal=false` 固定で問い合わせる。",
+    )
+    fun detail(@PathVariable charachipId: Int): CharachipDetailView {
+        val charachip = charaService.findCharachip(charachipId, isOriginal = false)
+            ?: throw WolfMansionRecordNotFoundException("charachip not found. id=$charachipId")
+        return CharachipDetailView(charachip)
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/v1/skills/SkillRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/skills/SkillRestController.kt
@@ -1,0 +1,88 @@
+package com.ort.app.api.v1.skills
+
+import com.ort.app.api.response.skill.SkillCatalogView
+import com.ort.app.application.service.CampService
+import com.ort.app.application.service.VillageService
+import com.ort.app.domain.model.skill.Skill
+import com.ort.app.domain.model.skill.SkillTag
+import com.ort.app.domain.model.skill.Skills
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 役職カタログの参照 REST API。
+ *
+ * 旧 Thymeleaf `SkillController` (`/skill`, `/skill-list`) と
+ * `IndexController.skillList` (`/skill/list`) の置き換え。
+ *
+ * - `GET /api/v1/skills`: 全役職を陣営別 + タグ一覧つきで返す (カタログ表示用)
+ * - `GET /api/v1/skills/search`: タグ / キーワード / 村 ID で絞り込んだ役職コード一覧を返す
+ *   (旧 `/skill-list` 互換: 役職検索フィルタ用)
+ */
+@RestController
+@RequestMapping("/api/v1/skills")
+@Tag(name = "skills", description = "役職カタログ")
+class SkillRestController(
+    private val campService: CampService,
+    private val villageService: VillageService,
+) {
+
+    @GetMapping
+    @Operation(
+        summary = "役職カタログ",
+        description = "陣営別の役職一覧 + タグ一覧 (絞り込みフィルタ用) を返す。",
+    )
+    fun catalog(): SkillCatalogView {
+        return SkillCatalogView(campService.findCampSkills())
+    }
+
+    @GetMapping("/search")
+    @Operation(
+        summary = "役職検索 (絞り込み)",
+        description = "tags / name / villageId による絞り込み結果の役職コード一覧を返す (lowercase)。" +
+                "旧 `/skill-list` 互換。tags はカンマ区切り。villageId 指定時は固定構成村の場合のみ" +
+                "その村に出る役職に絞り込む (闇鍋村は絞り込まず全件返す)。",
+    )
+    fun search(
+        @Parameter(description = "カンマ区切りタグ (SkillTag enum 名)") @RequestParam(required = false) tags: String?,
+        @Parameter(description = "役職名部分一致") @RequestParam(required = false) name: String?,
+        @Parameter(description = "村 ID (固定構成村のみ絞り込み対象、闇鍋村は無視)") @RequestParam(required = false) villageId: Int?,
+    ): List<String> {
+        val tagSkills: List<Skill> =
+            if (tags.isNullOrBlank()) Skills.all().list
+            else SkillTag.of(tags.split(",")).flatMap { it.getSkillList() }.distinct()
+        val byVillage = villageId
+            ?.let { filterByVillageSkill(tagSkills, it) }
+            ?: tagSkills
+        val byName = if (name.isNullOrBlank()) byVillage
+        else byVillage.filter { it.name.contains(name) }
+        return byName.map { it.code.lowercase() }
+    }
+
+    private fun filterByVillageSkill(skills: List<Skill>, villageId: Int): List<Skill> {
+        val village = villageService.findVillage(villageId) ?: return skills
+        // 闇鍋は非対応 (= 絞り込まずに全件返す、旧実装踏襲)
+        if (village.setting.rule.isRandomOrganization) return skills
+        return when {
+            village.status.isPrologue() || village.status.isCanceled() -> {
+                skills.filter {
+                    village.setting.organize.allRequestableSkillList().any { s -> it.code == s.code }
+                }
+            }
+            else -> {
+                val organizationSkillCodes = village.setting.organize.fixedOrganization
+                    .replace("\r\n", "\n").split("\n")
+                    .firstOrNull { it.length == village.participants.count }
+                    ?.map { Skill.byShortName(it.toString())!!.code }
+                    ?.distinct()
+                    ?: return skills
+                skills.filter { organizationSkillCodes.contains(it.code) }
+            }
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/v1/skills/SkillRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/skills/SkillRestController.kt
@@ -75,10 +75,13 @@ class SkillRestController(
                 }
             }
             else -> {
+                // `fixedOrganization` の 1 文字が役職 shortName に一致しない場合
+                // (設定不備 / 旧データ等) は該当役職をスキップして絞り込みを継続。
+                // 行自体が見つからない (参加人数に合う構成が無い) ときも絞り込みせず全件返す。
                 val organizationSkillCodes = village.setting.organize.fixedOrganization
                     .replace("\r\n", "\n").split("\n")
                     .firstOrNull { it.length == village.participants.count }
-                    ?.map { Skill.byShortName(it.toString())!!.code }
+                    ?.mapNotNull { Skill.byShortName(it.toString())?.code }
                     ?.distinct()
                     ?: return skills
                 skills.filter { organizationSkillCodes.contains(it.code) }

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageRecordRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageRecordRestController.kt
@@ -1,0 +1,71 @@
+package com.ort.app.api.v1.villages
+
+import com.ort.app.api.response.village.VillageRecordsView
+import com.ort.app.application.service.PlayerService
+import com.ort.app.application.service.VillageService
+import com.ort.app.domain.model.village.VillageQuery
+import com.ort.app.domain.model.village.VillageStatus
+import com.ort.dbflute.allcommon.CDef
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 終了済村の戦績一覧 REST API。
+ *
+ * 旧 Thymeleaf `IndexController` (`/village-record/list`, `/village-record/latest-vid`)
+ * の置き換え。エピローグ / 終了 / 廃村 の村のみを対象。
+ *
+ * 旧 API は snake_case + 文字列日時で外部連携 (Discord ボット等) が依存している
+ * 可能性があるため、Thymeleaf 撤去 (Step 9) まで旧 endpoint は残置する方針。
+ * 新 endpoint は他の REST API と整合的に camelCase + ISO 日時で返す。
+ */
+@RestController
+@RequestMapping("/api/v1/village-records")
+@Tag(name = "village-records", description = "終了村の戦績")
+class VillageRecordRestController(
+    private val villageService: VillageService,
+    private val playerService: PlayerService,
+) {
+
+    private val finishedStatuses = listOf(
+        VillageStatus(CDef.VillageStatus.エピローグ),
+        VillageStatus(CDef.VillageStatus.終了),
+        VillageStatus(CDef.VillageStatus.廃村),
+    )
+
+    @GetMapping
+    @Operation(
+        summary = "終了済 村戦績一覧",
+        description = "エピローグ / 終了 / 廃村 の村を新しい順に返す。`vid` で対象村 ID を絞り込み可能。",
+    )
+    fun list(
+        @Parameter(description = "対象村 ID (繰り返し指定可、未指定で全件)") @RequestParam(required = false) vid: List<Int>?,
+    ): VillageRecordsView {
+        val villages = villageService.findVillages(
+            query = VillageQuery(
+                statuses = finishedStatuses,
+                ids = vid ?: emptyList(),
+            ),
+        )
+        val reversed = villages.copy(list = villages.list.reversed())
+        val players = playerService.findPlayers(villageIdList = reversed.list.map { it.id })
+        return VillageRecordsView(reversed, players)
+    }
+
+    @GetMapping("/latest-vid")
+    @Operation(
+        summary = "最新の終了済村 ID",
+        description = "エピローグ / 終了 / 廃村 の村のうち最新 (= 最大 ID) のものを返す。",
+    )
+    fun latestVid(): LatestVidView {
+        return LatestVidView(vid = villageService.findLatestVillageId(finishedStatuses))
+    }
+
+    @io.swagger.v3.oas.annotations.media.Schema(description = "最新終了済村 ID")
+    data class LatestVidView(val vid: Int)
+}

--- a/frontend/app/features/meta/api.ts
+++ b/frontend/app/features/meta/api.ts
@@ -1,0 +1,85 @@
+/**
+ * メタ情報 (キャラチップ / 役職カタログ / 終了村戦績) の型 + fetch 関数。
+ * 型は SpringDoc → `pnpm gen:api` で生成した `~/lib/api/generated.ts` を参照する。
+ *
+ * 認可不要 (read-only)。`browserFetch` / `ssrFetch` どちらでも使える。
+ */
+
+import type { components } from "~/lib/api/generated";
+import { browserFetch, type ApiFetch } from "~/lib/api/client";
+
+type Schemas = components["schemas"];
+
+// nullable な optional フィールドを `T | null` に広げて、SSR JSON で null が来ても受けられるよう
+// 既存パターン (`features/player/api.ts`) と揃える。
+type WidenOptionalsDeep<T> =
+  T extends Array<infer U> ? Array<WidenOptionalsDeep<U>> :
+  T extends object ? { [K in keyof T]: undefined extends T[K] ? WidenOptionalsDeep<T[K]> | null : WidenOptionalsDeep<T[K]> } :
+  T;
+
+export type CharachipView = Schemas["CharachipView"];
+export type CharachipDetailView = WidenOptionalsDeep<Schemas["CharachipDetailView"]>;
+export type SkillCatalogView = Schemas["SkillCatalogView"];
+export type VillageRecordsView = WidenOptionalsDeep<Schemas["VillageRecordsView"]>;
+export type VillageRecordSummary = VillageRecordsView["list"][number];
+
+// ---------- charachips ----------
+
+export async function fetchCharachips(
+  fetcher: ApiFetch = browserFetch,
+): Promise<CharachipView[]> {
+  const res = await fetcher(`/api/v1/charachips`);
+  if (!res.ok) throw new Error(`charachips fetch failed: ${res.status}`);
+  return res.json();
+}
+
+export async function fetchCharachipDetail(
+  charachipId: number,
+  fetcher: ApiFetch = browserFetch,
+): Promise<CharachipDetailView> {
+  const res = await fetcher(`/api/v1/charachips/${charachipId}`);
+  if (!res.ok) throw new Error(`charachip detail fetch failed: ${res.status}`);
+  return res.json();
+}
+
+// ---------- skills ----------
+
+export async function fetchSkillCatalog(
+  fetcher: ApiFetch = browserFetch,
+): Promise<SkillCatalogView> {
+  const res = await fetcher(`/api/v1/skills`);
+  if (!res.ok) throw new Error(`skill catalog fetch failed: ${res.status}`);
+  return res.json();
+}
+
+/**
+ * `GET /api/v1/skills/search` — tags / name / villageId による絞り込み結果の役職コード (lowercase) を返す。
+ * 旧 `/skill-list` 互換。tags はカンマ区切り。
+ */
+export async function searchSkills(
+  params: { tags?: string; name?: string; villageId?: number },
+  fetcher: ApiFetch = browserFetch,
+): Promise<string[]> {
+  const qs = new URLSearchParams();
+  if (params.tags) qs.set("tags", params.tags);
+  if (params.name) qs.set("name", params.name);
+  if (params.villageId != null) qs.set("villageId", String(params.villageId));
+  const suffix = qs.toString() ? `?${qs.toString()}` : "";
+  const res = await fetcher(`/api/v1/skills/search${suffix}`);
+  if (!res.ok) throw new Error(`skill search failed: ${res.status}`);
+  return res.json();
+}
+
+// ---------- village records ----------
+
+export async function fetchVillageRecords(
+  params: { vid?: number[] } = {},
+  fetcher: ApiFetch = browserFetch,
+): Promise<VillageRecordsView> {
+  const qs = new URLSearchParams();
+  (params.vid ?? []).forEach((id) => qs.append("vid", String(id)));
+  const suffix = qs.toString() ? `?${qs.toString()}` : "";
+  const res = await fetcher(`/api/v1/village-records${suffix}`);
+  if (!res.ok) throw new Error(`village-records fetch failed: ${res.status}`);
+  return res.json();
+}

--- a/frontend/app/features/meta/hooks.ts
+++ b/frontend/app/features/meta/hooks.ts
@@ -1,0 +1,80 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import {
+  fetchCharachipDetail,
+  fetchCharachips,
+  fetchSkillCatalog,
+  fetchVillageRecords,
+  searchSkills,
+  type CharachipDetailView,
+  type CharachipView,
+  type SkillCatalogView,
+  type VillageRecordsView,
+} from "./api";
+
+// メタ情報は変動が少ないので staleTime を長めに (10 分)。明示的な refetch でのみ更新される。
+const META_STALE_MS = 10 * 60_000;
+
+export function useCharachipsQuery(
+  initialData?: CharachipView[],
+): UseQueryResult<CharachipView[]> {
+  return useQuery<CharachipView[]>({
+    queryKey: ["charachips"],
+    queryFn: () => fetchCharachips(),
+    initialData,
+    initialDataUpdatedAt: initialData ? Date.now() : undefined,
+    staleTime: META_STALE_MS,
+  });
+}
+
+export function useCharachipDetailQuery(
+  charachipId: number,
+  initialData?: CharachipDetailView,
+): UseQueryResult<CharachipDetailView> {
+  return useQuery<CharachipDetailView>({
+    queryKey: ["charachips", charachipId],
+    queryFn: () => fetchCharachipDetail(charachipId),
+    initialData,
+    initialDataUpdatedAt: initialData ? Date.now() : undefined,
+    staleTime: META_STALE_MS,
+  });
+}
+
+export function useSkillCatalogQuery(
+  initialData?: SkillCatalogView,
+): UseQueryResult<SkillCatalogView> {
+  return useQuery<SkillCatalogView>({
+    queryKey: ["skills", "catalog"],
+    queryFn: () => fetchSkillCatalog(),
+    initialData,
+    initialDataUpdatedAt: initialData ? Date.now() : undefined,
+    staleTime: META_STALE_MS,
+  });
+}
+
+/**
+ * 検索条件 (tags / name / villageId) が変わったら自動的に再 fetch する。
+ * 検索フィルタ操作はインタラクティブなので staleTime は短め (30秒)。
+ */
+export function useSkillSearchQuery(
+  params: { tags?: string; name?: string; villageId?: number },
+  enabled: boolean,
+): UseQueryResult<string[]> {
+  return useQuery<string[]>({
+    queryKey: ["skills", "search", params.tags ?? "", params.name ?? "", params.villageId ?? null],
+    queryFn: () => searchSkills(params),
+    enabled,
+    staleTime: 30_000,
+  });
+}
+
+export function useVillageRecordsQuery(
+  initialData?: VillageRecordsView,
+): UseQueryResult<VillageRecordsView> {
+  return useQuery<VillageRecordsView>({
+    queryKey: ["village-records"],
+    queryFn: () => fetchVillageRecords(),
+    initialData,
+    initialDataUpdatedAt: initialData ? Date.now() : undefined,
+    staleTime: META_STALE_MS,
+  });
+}

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -9,6 +9,10 @@ export default [
   route("players", "routes/players._index.tsx"),
   // NOTE: 認証不要。`isSelf=true` のときだけ編集 UI が出る (backend が viewer JWT を読んで判定)。
   route("players/:userName", "routes/players.$userName.tsx"),
+  route("charachips", "routes/charachips._index.tsx"),
+  route("charachips/:id", "routes/charachips.$id.tsx"),
+  route("skills", "routes/skills.tsx"),
+  route("village-records", "routes/village-records.tsx"),
   // 認証必須エリア
   layout("routes/_auth.tsx", [
     route("me", "routes/me.tsx"),

--- a/frontend/app/routes/charachips.$id.tsx
+++ b/frontend/app/routes/charachips.$id.tsx
@@ -1,0 +1,78 @@
+import { Link } from "react-router";
+import type { Route } from "./+types/charachips.$id";
+import { fetchCharachipDetail } from "~/features/meta/api";
+import { useCharachipDetailQuery } from "~/features/meta/hooks";
+import { ssrFetch } from "~/lib/api/client";
+
+export function meta({ data }: Route.MetaArgs) {
+  const name = data?.charachip?.name ?? "キャラチップ";
+  return [{ title: `${name} - wolf-mansion` }];
+}
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const id = Number(params.id);
+  if (!Number.isFinite(id)) throw new Response("invalid charachip id", { status: 400 });
+  const api = ssrFetch(request);
+  const charachip = await fetchCharachipDetail(id, api).catch(() => null);
+  if (!charachip) throw new Response("charachip not found", { status: 404 });
+  return { id, charachip };
+}
+
+export default function CharachipDetail({ loaderData }: Route.ComponentProps) {
+  const { id, charachip: initial } = loaderData;
+  const query = useCharachipDetailQuery(id, initial);
+  const charachip = query.data ?? initial;
+
+  return (
+    <main className="min-h-screen bg-slate-900 text-slate-100">
+      <section className="max-w-4xl mx-auto px-6 py-10 space-y-6">
+        <header className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold">{charachip.name}</h1>
+            <p className="text-xs text-slate-400">
+              作: {charachip.designerName}
+              {charachip.descriptionUrl && (
+                <>
+                  {" / "}
+                  <a
+                    href={charachip.descriptionUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline hover:text-indigo-300"
+                  >
+                    説明ページ
+                  </a>
+                </>
+              )}
+            </p>
+            <p className="text-xs text-slate-500">
+              キャラ名変更: {charachip.isAvailableChangeName ? "可" : "不可"}
+            </p>
+          </div>
+          <Link to="/charachips" className="text-sm text-slate-400 hover:text-slate-200">
+            ← キャラチップ一覧
+          </Link>
+        </header>
+
+        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+          {charachip.charas.map((c) => (
+            <li
+              key={c.id}
+              className="rounded-xl bg-slate-800/40 border border-slate-700 p-3 flex flex-col items-center gap-2"
+            >
+              <img
+                src={c.defaultImageUrl}
+                width={c.imageWidth}
+                height={c.imageHeight}
+                alt={c.name}
+                className="bg-slate-900/60 rounded"
+              />
+              <p className="text-sm text-center truncate w-full">{c.name}</p>
+              <p className="text-xs text-slate-400">[{c.shortName}]</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/frontend/app/routes/charachips._index.tsx
+++ b/frontend/app/routes/charachips._index.tsx
@@ -1,0 +1,62 @@
+import { Link } from "react-router";
+import type { Route } from "./+types/charachips._index";
+import { fetchCharachips, type CharachipView } from "~/features/meta/api";
+import { useCharachipsQuery } from "~/features/meta/hooks";
+import { ssrFetch } from "~/lib/api/client";
+
+export function meta(_: Route.MetaArgs) {
+  return [{ title: "キャラチップ一覧 - wolf-mansion" }];
+}
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const api = ssrFetch(request);
+  // SSR で取れなければ空配列でフォールバック (DB ダウン等の防御)
+  const charachips = await fetchCharachips(api).catch(() => [] as CharachipView[]);
+  return { charachips };
+}
+
+export default function CharachipsIndex({ loaderData }: Route.ComponentProps) {
+  const query = useCharachipsQuery(loaderData.charachips);
+  const list = query.data ?? loaderData.charachips;
+
+  return (
+    <main className="min-h-screen bg-slate-900 text-slate-100">
+      <section className="max-w-4xl mx-auto px-6 py-10 space-y-6">
+        <header className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold">キャラチップ一覧</h1>
+          <Link to="/" className="text-sm text-slate-400 hover:text-slate-200">
+            ← トップへ
+          </Link>
+        </header>
+
+        {list.length === 0 ? (
+          <p className="text-sm text-slate-400">キャラチップが見つかりません。</p>
+        ) : (
+          <ul className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {list.map((c) => (
+              <li key={c.id}>
+                <Link
+                  to={`/charachips/${c.id}`}
+                  className="flex items-center gap-3 rounded-xl bg-slate-800/40 border border-slate-700 p-3 hover:border-indigo-400 transition"
+                >
+                  <img
+                    src={c.dummyImageUrl}
+                    width={c.dummyImageWidth}
+                    height={c.dummyImageHeight}
+                    alt={c.name}
+                    className="bg-slate-900/60 rounded"
+                  />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-base font-medium truncate">{c.name}</p>
+                    <p className="text-xs text-slate-400 truncate">{c.designerName}</p>
+                    <p className="text-xs text-slate-500">{c.charaCount} キャラ</p>
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -47,7 +47,7 @@ export default function Home({ loaderData }: Route.ComponentProps) {
           <p className="text-slate-300">人狼ゲーム</p>
         </header>
 
-        <div className="flex gap-3 justify-center">
+        <div className="flex gap-3 justify-center flex-wrap">
           <Link
             to="/villages"
             className="rounded-md bg-indigo-500 hover:bg-indigo-400 px-5 py-2 font-semibold transition"
@@ -65,6 +65,19 @@ export default function Home({ loaderData }: Route.ComponentProps) {
             className="rounded-md border border-slate-600 hover:border-slate-400 px-5 py-2 font-semibold transition"
           >
             ログイン
+          </Link>
+        </div>
+        <div className="flex gap-3 justify-center flex-wrap text-sm">
+          <Link to="/charachips" className="text-slate-300 hover:text-indigo-300 underline-offset-4 hover:underline">
+            キャラチップ一覧
+          </Link>
+          <span className="text-slate-600">/</span>
+          <Link to="/skills" className="text-slate-300 hover:text-indigo-300 underline-offset-4 hover:underline">
+            役職一覧
+          </Link>
+          <span className="text-slate-600">/</span>
+          <Link to="/village-records" className="text-slate-300 hover:text-indigo-300 underline-offset-4 hover:underline">
+            終了村一覧
           </Link>
         </div>
 

--- a/frontend/app/routes/skills.tsx
+++ b/frontend/app/routes/skills.tsx
@@ -1,0 +1,134 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router";
+import type { Route } from "./+types/skills";
+import { fetchSkillCatalog, type SkillCatalogView } from "~/features/meta/api";
+import { useSkillCatalogQuery, useSkillSearchQuery } from "~/features/meta/hooks";
+import { ssrFetch } from "~/lib/api/client";
+
+export function meta(_: Route.MetaArgs) {
+  return [{ title: "役職一覧 - wolf-mansion" }];
+}
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const api = ssrFetch(request);
+  const catalog = await fetchSkillCatalog(api).catch(() => null);
+  return { catalog };
+}
+
+export default function SkillsPage({ loaderData }: Route.ComponentProps) {
+  const fallback: SkillCatalogView = { camps: [], tags: [] };
+  const initial = loaderData.catalog ?? fallback;
+  const query = useSkillCatalogQuery(initial);
+  const catalog = query.data ?? initial;
+
+  // 絞り込みフィルタ (タグ複数選択 + 名前部分一致)
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [keyword, setKeyword] = useState("");
+  const searchParams = useMemo(
+    () => ({
+      tags: selectedTags.length === 0 ? undefined : selectedTags.join(","),
+      name: keyword.trim() || undefined,
+    }),
+    [selectedTags, keyword],
+  );
+  const hasFilter = selectedTags.length > 0 || keyword.trim() !== "";
+  const search = useSkillSearchQuery(searchParams, hasFilter);
+  const matchedCodes = new Set((search.data ?? []).map((c) => c.toLowerCase()));
+
+  function toggleTag(tag: string) {
+    setSelectedTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-900 text-slate-100">
+      <section className="max-w-4xl mx-auto px-6 py-10 space-y-6">
+        <header className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold">役職一覧</h1>
+          <Link to="/" className="text-sm text-slate-400 hover:text-slate-200">
+            ← トップへ
+          </Link>
+        </header>
+
+        <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4 space-y-3">
+          <h2 className="text-sm text-slate-300">絞り込み</h2>
+          <label className="block text-xs text-slate-400">
+            名前
+            <input
+              type="text"
+              value={keyword}
+              onChange={(e) => setKeyword(e.target.value)}
+              placeholder="部分一致 (例: 占い)"
+              className="mt-1 w-full bg-slate-900 border border-slate-700 rounded px-2 py-1 text-sm text-slate-100 placeholder-slate-500 focus:outline-none focus:border-indigo-500"
+            />
+          </label>
+          {catalog.tags.length > 0 && (
+            <div className="space-y-1">
+              <p className="text-xs text-slate-400">タグ (複数選択可、OR 条件)</p>
+              <div className="flex flex-wrap gap-1">
+                {catalog.tags.map((tag) => {
+                  const active = selectedTags.includes(tag);
+                  return (
+                    <button
+                      key={tag}
+                      type="button"
+                      onClick={() => toggleTag(tag)}
+                      className={
+                        "rounded-full px-2.5 py-0.5 text-xs border transition " +
+                        (active
+                          ? "bg-indigo-500/30 border-indigo-400 text-indigo-100"
+                          : "border-slate-600 text-slate-300 hover:border-slate-400")
+                      }
+                    >
+                      {tag}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+          {hasFilter && (
+            <p className="text-xs text-slate-500">
+              {search.isLoading
+                ? "絞り込み中..."
+                : `該当 ${matchedCodes.size} 件`}
+            </p>
+          )}
+        </section>
+
+        <div className="space-y-6">
+          {catalog.camps.map((camp) => {
+            const skills = hasFilter
+              ? camp.skills.filter((s) => matchedCodes.has(s.code.toLowerCase()))
+              : camp.skills;
+            if (hasFilter && skills.length === 0) return null;
+            return (
+              <section
+                key={camp.campCode}
+                className="rounded-xl bg-slate-800/40 border border-slate-700 p-4"
+              >
+                <h3 className="text-sm font-medium text-amber-200 mb-3">
+                  {camp.campName} ({skills.length})
+                </h3>
+                <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2">
+                  {skills.map((s) => (
+                    <li
+                      key={s.code}
+                      className="border border-slate-700 rounded px-2 py-1 text-sm flex items-center gap-2"
+                    >
+                      <span className="font-mono text-xs text-slate-400 w-5 shrink-0">
+                        {s.shortName}
+                      </span>
+                      <span className="truncate">{s.name}</span>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            );
+          })}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/frontend/app/routes/village-records.tsx
+++ b/frontend/app/routes/village-records.tsx
@@ -1,0 +1,101 @@
+import { Link } from "react-router";
+import type { Route } from "./+types/village-records";
+import { fetchVillageRecords, type VillageRecordSummary } from "~/features/meta/api";
+import { useVillageRecordsQuery } from "~/features/meta/hooks";
+import { ssrFetch } from "~/lib/api/client";
+
+export function meta(_: Route.MetaArgs) {
+  return [{ title: "終了村一覧 - wolf-mansion" }];
+}
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const api = ssrFetch(request);
+  const records = await fetchVillageRecords({}, api).catch(() => ({ list: [] }));
+  return { records };
+}
+
+export default function VillageRecords({ loaderData }: Route.ComponentProps) {
+  const query = useVillageRecordsQuery(loaderData.records);
+  const view = query.data ?? loaderData.records;
+
+  return (
+    <main className="min-h-screen bg-slate-900 text-slate-100">
+      <section className="max-w-4xl mx-auto px-6 py-10 space-y-6">
+        <header className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold">終了村一覧</h1>
+          <Link to="/" className="text-sm text-slate-400 hover:text-slate-200">
+            ← トップへ
+          </Link>
+        </header>
+
+        {view.list.length === 0 ? (
+          <p className="text-sm text-slate-400">終了した村がまだありません。</p>
+        ) : (
+          <ul className="space-y-3">
+            {view.list.map((v) => (
+              <RecordRow key={v.id} village={v} />
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}
+
+function RecordRow({ village }: { village: VillageRecordSummary }) {
+  return (
+    <li className="rounded-xl bg-slate-800/40 border border-slate-700 p-4 space-y-2">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-baseline gap-2 min-w-0">
+          <span className="font-mono text-slate-500 text-sm shrink-0">
+            #{String(village.id).padStart(4, "0")}
+          </span>
+          <Link to={`/villages/${village.id}`} className="text-base font-medium hover:text-indigo-300 truncate">
+            {village.name}
+          </Link>
+        </div>
+        <span className="text-xs text-slate-400 shrink-0">{village.status}</span>
+      </div>
+      <div className="flex flex-wrap items-center gap-3 text-xs text-slate-400">
+        <span className="font-mono">{village.organization}</span>
+        {village.winCampName && <span className="text-amber-300">勝利: {village.winCampName}</span>}
+        {village.startDatetime && (
+          <span>開始: {formatDateTime(village.startDatetime)}</span>
+        )}
+        {village.epilogueDatetime && (
+          <span>EP: {formatDateTime(village.epilogueDatetime)} ({village.epilogueDay}日目)</span>
+        )}
+      </div>
+      <details className="text-xs">
+        <summary className="cursor-pointer text-slate-300">参加者 ({village.participants.length}名)</summary>
+        <ul className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-1">
+          {village.participants.map((p, i) => (
+            <li key={`${village.id}-${i}-${p.userName}-${p.characterName}`} className="flex items-center gap-2">
+              <span className="text-slate-500 w-24 truncate">{p.userName}</span>
+              <span className="truncate">{p.characterName}</span>
+              {p.skillName && <span className="text-indigo-300 text-[10px]">[{p.skillName}]</span>}
+              {p.isSpectator && <span className="text-slate-400 text-[10px]">見学</span>}
+              {p.isDead && (
+                <span className="text-rose-300 text-[10px]">
+                  {p.deadDay}d {p.deadReason ?? ""}
+                </span>
+              )}
+              {p.isWin === true && <span className="text-amber-300 text-[10px]">勝</span>}
+            </li>
+          ))}
+        </ul>
+      </details>
+    </li>
+  );
+}
+
+function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const yy = String(d.getFullYear()).slice(-2);
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mi = String(d.getMinutes()).padStart(2, "0");
+  return `${yy}/${mm}/${dd} ${hh}:${mi}`;
+}


### PR DESCRIPTION
## 変更内容

Step 8 残りのうち read-only メタ情報ページを REST 化 + 専用フロントエンドルートを追加。
新規村作成 (creator) は範囲が広いので Step 8h として独立 PR にする。

### backend (3 controllers / 4 view DTOs)
- `GET /api/v1/charachips`: 公式キャラチップ一覧 (`CharachipView`)
- `GET /api/v1/charachips/{id}`: キャラチップ詳細 + キャラ一覧 (`CharachipDetailView`)
- `GET /api/v1/skills`: 役職カタログ (陣営別 + タグ一覧、`SkillCatalogView`)
- `GET /api/v1/skills/search`: 役職コード絞り込み (旧 `/skill-list` 互換、tags/name/villageId)
- `GET /api/v1/village-records?vid=...`: 終了済村戦績一覧 (`VillageRecordsView`)
- `GET /api/v1/village-records/latest-vid`: 最新終了済村 ID
- 旧 Thymeleaf endpoints (`/chara-group`, `/skill`, `/skill-list`, `/village-record/list`,
  `/village-record/latest-vid`, `/skill/list`) は **当面残置**: Discord ボット等の外部連携が
  旧 snake_case schema (`VillageRecord` w/ `participant_list` 等) に依存している可能性が
  あるため、Step 9 (Thymeleaf 撤去) で一括削除する
- 旧 `VillageRecordListContent.VillageRecord` と新 schema が衝突するため、新側は
  `VillageRecordSummary` / `VillageRecordParticipant` という別名で命名

### frontend (4 新ルート + 共通 feature module)
- `/charachips` — 一覧 (カード)
- `/charachips/:id` — 詳細 (キャラグリッド)
- `/skills` — カタログ + タグ複数選択 + 名前部分一致フィルタ
- `/village-records` — 終了村一覧 (参加者は `<details>` で展開可)
- `features/meta/{api,hooks}.ts` を新設、staleTime 10 分 (メタ情報は変動少ない)
- トップページ (`/`) にメタ情報 3 リンクを追加

## 動作確認
- [x] backend: `./gradlew test` (BUILD SUCCESSFUL)
- [x] frontend: `pnpm typecheck && pnpm test && pnpm build` (パス)
- [ ] ユーザー手動確認依頼: 実 DB で `/charachips`, `/charachips/{id}`, `/skills`,
      `/village-records` の 4 ページを開いて表示確認

## レビュー観点
- 新 view DTO が camelCase + ISO 日時 (旧 snake_case schema との両立)
- 旧 endpoint 残置の判断 (外部連携リスクを避けるため、Step 9 で一括撤去)
- `/skills/search` の `villageId` パラメータは旧実装と同じく闇鍋村では絞り込まず全件返す
  (将来仕様変更したい場合は別 issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)