### PR TITLE
Step 8h: 新規村作成 REST 化 (creator, JSON / non-original)

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/request/village/NewVillageCreateBody.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/request/village/NewVillageCreateBody.kt
@@ -1,0 +1,266 @@
+package com.ort.app.api.request.village
+
+import com.ort.app.api.request.NewVillageForm
+import com.ort.app.api.request.setting.MessageTypeSayRestrictForm
+import com.ort.app.api.request.setting.RandomOrganizationCampForm
+import com.ort.app.api.request.setting.RandomOrganizationSkillForm
+import com.ort.app.api.request.setting.RandomOrganizationWolfForm
+import com.ort.app.api.request.setting.SkillSayRestrictForm
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+
+/**
+ * 新規村作成 (POST /api/v1/villages) リクエスト body (JSON)。
+ *
+ * 旧 `NewVillageForm` (Thymeleaf form) の JSON 受信用スリム版。
+ * 設定変更 (`VillageSettingsUpdateBody`) と多くのフィールドが共通だが、新規村作成固有の
+ * フィールド (役職希望可否 / プロデューサー機能 / キャラチップ選択 / ダミーキャラ情報) を含む。
+ * `VillageSettingsUpdateBody` の nested DTO (CampAllocationBody / SkillAllocationBody /
+ * WolfAllocationBody / SkillSayRestrictBody / MessageTypeSayRestrictBody) を再利用する。
+ *
+ * オリジナルキャラチップ村 (`shouldOriginalImage=true`) は multipart 画像アップロードが
+ * 必要なため、本 JSON endpoint では非対応 (= controller 層で 501 を返す)。
+ * 入村フロー (Step 8a) でも同じ理由で original charachip は 501 にしている。
+ */
+@Schema(description = "新規村作成リクエスト body (creator)")
+data class NewVillageCreateBody(
+    @field:Schema(description = "村表示名 (5〜40文字)")
+    @field:NotNull
+    @field:Size(min = 5, max = 40)
+    val villageName: String?,
+
+    @field:Schema(description = "最少開始人数 (8〜999)")
+    @field:NotNull
+    @field:Min(8)
+    @field:Max(999)
+    val startPersonMinNum: Int?,
+
+    @field:Schema(description = "定員 (8〜999)")
+    @field:NotNull
+    @field:Min(8)
+    @field:Max(999)
+    val personMaxNum: Int?,
+
+    @field:Schema(description = "更新間隔: 時間 (0-72)")
+    @field:NotNull @field:Min(0) @field:Max(72)
+    val dayChangeIntervalHours: Int?,
+
+    @field:Schema(description = "更新間隔: 分 (0-59)")
+    @field:NotNull @field:Min(0) @field:Max(59)
+    val dayChangeIntervalMinutes: Int?,
+
+    @field:Schema(description = "更新間隔: 秒 (0-59)")
+    @field:NotNull @field:Min(0) @field:Max(59)
+    val dayChangeIntervalSeconds: Int?,
+
+    @field:Schema(description = "開始年")
+    @field:NotNull @field:Min(0)
+    val startYear: Int?,
+
+    @field:Schema(description = "開始月 (1-12)")
+    @field:NotNull @field:Min(1) @field:Max(12)
+    val startMonth: Int?,
+
+    @field:Schema(description = "開始日 (1-31)")
+    @field:NotNull @field:Min(1) @field:Max(31)
+    val startDay: Int?,
+
+    @field:Schema(description = "開始時 (0-23)")
+    @field:NotNull @field:Min(0) @field:Max(23)
+    val startHour: Int?,
+
+    @field:Schema(description = "開始分 (0-59)")
+    @field:NotNull @field:Min(0) @field:Max(59)
+    val startMinute: Int?,
+
+    @field:Schema(description = "募集範囲タグ (ANYONE_WELCOME / RELATIVES_ONLY)")
+    val welcomeRange: String?,
+
+    @field:Schema(description = "年齢制限タグ (R15 / R18)")
+    val ageLimit: String?,
+
+    @field:Schema(description = "記名投票か")
+    @field:NotNull val openVote: Boolean?,
+    @field:Schema(description = "役職希望を有効にするか")
+    @field:NotNull val possibleSkillRequest: Boolean?,
+    @field:Schema(description = "連続襲撃ありか")
+    @field:NotNull val availableSameWolfAttack: Boolean?,
+    @field:Schema(description = "墓下役職公開ありか")
+    @field:NotNull val openSkillInGrave: Boolean?,
+    @field:Schema(description = "墓下見学発言を地上から見られるか")
+    @field:NotNull val visibleGraveSpectateMessage: Boolean?,
+    @field:Schema(description = "見学可能か")
+    @field:NotNull val availableSpectate: Boolean?,
+    @field:Schema(description = "村建てがプロデューサー機能を持つか")
+    @field:NotNull val creatorIsProducer: Boolean?,
+    @field:Schema(description = "突然死ありか")
+    @field:NotNull val availableSuddenlyDeath: Boolean?,
+    @field:Schema(description = "コミット可能か")
+    @field:NotNull val availableCommit: Boolean?,
+    @field:Schema(description = "連続ガードありか")
+    @field:NotNull val availableGuardSameTarget: Boolean?,
+    @field:Schema(description = "アクションありか")
+    @field:NotNull val availableAction: Boolean?,
+    @field:Schema(description = "闇鍋編成か")
+    @field:NotNull val randomOrganization: Boolean?,
+    @field:Schema(description = "転生時に全役職を候補とするか")
+    @field:NotNull val reincarnationSkillAll: Boolean?,
+
+    @field:Schema(description = "秘話可能範囲 (CDef.AllowedSecretSay code)")
+    @field:NotNull val allowedSecretSayCode: String?,
+
+    @field:Schema(description = "オリジナル画像を使用するか。true は現状未対応 (501)。")
+    @field:NotNull val shouldOriginalImage: Boolean?,
+
+    @field:Schema(description = "公式キャラチップ ID 一覧 (shouldOriginalImage=false のとき必須)")
+    val characterSetId: List<Int>?,
+
+    @field:Schema(description = "ダミーキャラ ID (shouldOriginalImage=false のとき必須)")
+    val dummyCharaId: Int?,
+
+    @field:Schema(description = "ダミーキャラ表示名 (1〜40文字)")
+    @field:NotNull
+    @field:Size(min = 1, max = 40)
+    val dummyCharaName: String?,
+
+    @field:Schema(description = "ダミーキャラ略称 (1文字)")
+    @field:NotNull
+    @field:Size(min = 1, max = 1)
+    val dummyCharaShortName: String?,
+
+    @field:Schema(description = "ダミーキャラ入村発言 (1〜400文字)")
+    @field:NotNull
+    @field:Size(min = 1, max = 400)
+    val dummyJoinMessage: String?,
+
+    @field:Schema(description = "ダミーキャラ1日目発言 (任意、最大400文字)")
+    @field:Size(max = 400)
+    val dummyDay1Message: String?,
+
+    @field:Schema(description = "構成 (改行区切り、闇鍋でないときに参照)")
+    val organization: String?,
+
+    @field:Schema(description = "闇鍋編成詳細")
+    @field:Valid
+    val campAllocationList: List<VillageSettingsUpdateBody.CampAllocationBody>?,
+
+    @field:Schema(description = "闇鍋編成: 人狼カウント配分")
+    @field:Valid
+    val wolfAllocation: VillageSettingsUpdateBody.WolfAllocationBody?,
+
+    @field:Schema(description = "入村パスワード (3〜12文字、未設定なら null/空)")
+    val joinPassword: String?,
+
+    @field:Schema(description = "通常発言の役職別制限一覧 (全役職分)")
+    @field:NotNull
+    @field:Valid
+    val sayRestrictList: List<VillageSettingsUpdateBody.SkillSayRestrictBody>?,
+
+    @field:Schema(description = "役職発言制限一覧 (人狼の囁き等)")
+    @field:NotNull
+    @field:Valid
+    val skillSayRestrictList: List<VillageSettingsUpdateBody.MessageTypeSayRestrictBody>?,
+
+    @field:Schema(description = "RP 発言制限一覧 (アクション等)")
+    @field:NotNull
+    @field:Valid
+    val rpSayRestrictList: List<VillageSettingsUpdateBody.MessageTypeSayRestrictBody>?,
+) {
+    /**
+     * 旧 `NewVillageForm` に変換する。`NewVillageFormValidator` を共有するため。
+     * 表示用フィールド (campName / skillName / messageTypeName) は空。
+     */
+    fun toForm(): NewVillageForm = NewVillageForm(
+        villageName = villageName,
+        startPersonMinNum = startPersonMinNum,
+        personMaxNum = personMaxNum,
+        dayChangeIntervalHours = dayChangeIntervalHours,
+        dayChangeIntervalMinutes = dayChangeIntervalMinutes,
+        dayChangeIntervalSeconds = dayChangeIntervalSeconds,
+        startYear = startYear,
+        startMonth = startMonth,
+        startDay = startDay,
+        startHour = startHour,
+        startMinute = startMinute,
+        welcomeRange = welcomeRange,
+        ageLimit = ageLimit,
+        openVote = openVote,
+        possibleSkillRequest = possibleSkillRequest,
+        availableSameWolfAttack = availableSameWolfAttack,
+        openSkillInGrave = openSkillInGrave,
+        visibleGraveSpectateMessage = visibleGraveSpectateMessage,
+        shouldOriginalImage = shouldOriginalImage,
+        characterSetId = characterSetId,
+        dummyCharaId = dummyCharaId,
+        dummyCharaImageFile = null,
+        dummyCharaName = dummyCharaName,
+        dummyCharaShortName = dummyCharaShortName,
+        dummyJoinMessage = dummyJoinMessage,
+        dummyDay1Message = dummyDay1Message,
+        joinPassword = joinPassword,
+        availableSpectate = availableSpectate,
+        creatorIsProducer = creatorIsProducer,
+        availableSuddonlyDeath = availableSuddenlyDeath,
+        availableCommit = availableCommit,
+        availableGuardSameTarget = availableGuardSameTarget,
+        availableAction = availableAction,
+        organization = organization,
+        randomOrganization = randomOrganization,
+        reincarnationSkillAll = reincarnationSkillAll,
+        campAllocationList = campAllocationList?.map { c ->
+            RandomOrganizationCampForm(
+                campCode = c.campCode,
+                campName = null,
+                minNum = c.minNum,
+                maxNum = c.maxNum,
+                allocation = c.allocation,
+                reincarnationAllocation = c.reincarnationAllocation,
+                skillAllocation = c.skillAllocation?.map { s ->
+                    RandomOrganizationSkillForm(
+                        skillCode = s.skillCode,
+                        skillName = null,
+                        minNum = s.minNum,
+                        maxNum = s.maxNum,
+                        allocation = s.allocation,
+                        reincarnationAllocation = s.reincarnationAllocation,
+                    )
+                },
+            )
+        },
+        wolfAllocation = wolfAllocation?.let {
+            RandomOrganizationWolfForm(minNum = it.minNum, maxNum = it.maxNum)
+        },
+        allowedSecretSayCode = allowedSecretSayCode,
+        sayRestrictList = sayRestrictList?.map { r ->
+            SkillSayRestrictForm(
+                skillName = null,
+                skillCode = r.skillCode,
+                restrict = r.restrict,
+                count = r.count,
+                length = r.length,
+            )
+        },
+        skillSayRestrictList = skillSayRestrictList?.map { r ->
+            MessageTypeSayRestrictForm(
+                messageTypeName = null,
+                messageTypeCode = r.messageTypeCode,
+                restrict = r.restrict,
+                count = r.count,
+                length = r.length,
+            )
+        },
+        rpSayRestrictList = rpSayRestrictList?.map { r ->
+            MessageTypeSayRestrictForm(
+                messageTypeName = null,
+                messageTypeCode = r.messageTypeCode,
+                restrict = r.restrict,
+                count = r.count,
+                length = r.length,
+            )
+        },
+    )
+}

--- a/backend/src/main/kotlin/com/ort/app/api/response/village/NewVillageFormView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/village/NewVillageFormView.kt
@@ -1,0 +1,247 @@
+package com.ort.app.api.response.village
+
+import com.ort.app.api.response.chara.CharachipView
+import com.ort.app.domain.model.chara.Charachips
+import com.ort.app.domain.model.skill.Skills
+import com.ort.app.domain.model.village.setting.VillageOrganize
+import com.ort.dbflute.allcommon.CDef
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+/**
+ * 新規村作成画面 (GET /api/v1/new-village/form-defaults) のレスポンス。
+ *
+ * - `canCreate`: 認証ユーザが村建てできる状態か (= 進行中の自分の村が無いか)
+ * - `defaults`: 初期 form 値 (`NewVillageForm.initialize()` と同等)
+ * - `options`: 候補値 (公式キャラチップ / 役職一覧 / 陣営一覧 / タグ / 秘話可能範囲 / 発言種別)
+ *
+ * フロントエンドはこの 1 リクエストで作成フォームを初期描画できる。
+ *
+ * `canCreate=false` のときも options は埋めて返す (UI の説明表示用)。
+ * 未認証ユーザは backend 側で 400 ("ログインが必要です") にする。
+ */
+@Schema(description = "新規村作成フォーム初期値 (creator)")
+data class NewVillageFormView(
+    @field:Schema(description = "認証ユーザが現時点で村建て可能か")
+    val canCreate: Boolean,
+    @field:Schema(description = "認証ユーザ名 (デバッグ補助 / canCreate の根拠表示用)")
+    val userName: String,
+    @field:Schema(description = "フォーム初期値")
+    val defaults: NewVillageDefaults,
+    @field:Schema(description = "候補値")
+    val options: NewVillageOptions,
+) {
+
+    @Schema(description = "新規村作成 form の初期値")
+    data class NewVillageDefaults(
+        val villageName: String,
+        val startPersonMinNum: Int,
+        val personMaxNum: Int,
+        val dayChangeIntervalHours: Int,
+        val dayChangeIntervalMinutes: Int,
+        val dayChangeIntervalSeconds: Int,
+        val startYear: Int,
+        val startMonth: Int,
+        val startDay: Int,
+        val startHour: Int,
+        val startMinute: Int,
+        val welcomeRange: String?,
+        val ageLimit: String?,
+        val openVote: Boolean,
+        val possibleSkillRequest: Boolean,
+        val availableSameWolfAttack: Boolean,
+        val openSkillInGrave: Boolean,
+        val visibleGraveSpectateMessage: Boolean,
+        val availableSpectate: Boolean,
+        val creatorIsProducer: Boolean,
+        val availableSuddenlyDeath: Boolean,
+        val availableCommit: Boolean,
+        val availableGuardSameTarget: Boolean,
+        val availableAction: Boolean,
+        val randomOrganization: Boolean,
+        val reincarnationSkillAll: Boolean,
+        val allowedSecretSayCode: String,
+        val shouldOriginalImage: Boolean,
+        val characterSetId: List<Int>,
+        val dummyCharaName: String,
+        val dummyCharaShortName: String,
+        val dummyJoinMessage: String,
+        val dummyDay1Message: String?,
+        val organization: String,
+        val campAllocationList: List<VillageSettingsFormView.CampAllocation>,
+        val wolfAllocation: VillageSettingsFormView.WolfAllocation,
+        val joinPassword: String?,
+        val sayRestrictList: List<VillageSettingsFormView.SkillSayRestrict>,
+        val skillSayRestrictList: List<VillageSettingsFormView.MessageTypeSayRestrict>,
+        val rpSayRestrictList: List<VillageSettingsFormView.MessageTypeSayRestrict>,
+    ) {
+        companion object {
+            /**
+             * 旧 `NewVillageForm.initialize()` と同等のデフォルト値を返す。
+             * 開始日時は 7日後 0:00 (現地時刻)。
+             */
+            fun create(): NewVillageDefaults {
+                val startDate = LocalDate.now().plusDays(7L)
+                return NewVillageDefaults(
+                    villageName = "",
+                    startPersonMinNum = 8,
+                    personMaxNum = 20,
+                    dayChangeIntervalHours = 24,
+                    dayChangeIntervalMinutes = 0,
+                    dayChangeIntervalSeconds = 0,
+                    startYear = startDate.year,
+                    startMonth = startDate.monthValue,
+                    startDay = startDate.dayOfMonth,
+                    startHour = 0,
+                    startMinute = 0,
+                    welcomeRange = null,
+                    ageLimit = null,
+                    openVote = true,
+                    possibleSkillRequest = true,
+                    availableSameWolfAttack = true,
+                    openSkillInGrave = false,
+                    visibleGraveSpectateMessage = false,
+                    availableSpectate = false,
+                    creatorIsProducer = false,
+                    availableSuddenlyDeath = false,
+                    availableCommit = false,
+                    availableGuardSameTarget = true,
+                    availableAction = false,
+                    randomOrganization = false,
+                    reincarnationSkillAll = false,
+                    allowedSecretSayCode = CDef.AllowedSecretSay.なし.code(),
+                    shouldOriginalImage = false,
+                    characterSetId = listOf(1),
+                    dummyCharaName = "楽天家 ゲルト",
+                    dummyCharaShortName = "楽",
+                    dummyJoinMessage = "",
+                    dummyDay1Message = null,
+                    organization = VillageOrganize.defaultFixedOrganization,
+                    campAllocationList = defaultCampAllocations(),
+                    wolfAllocation = VillageSettingsFormView.WolfAllocation(minNum = 1, maxNum = null),
+                    joinPassword = null,
+                    sayRestrictList = defaultSayRestrictList(),
+                    skillSayRestrictList = defaultMessageTypeRestrictList(
+                        listOf(
+                            CDef.MessageType.人狼の囁き,
+                            CDef.MessageType.共鳴発言,
+                            CDef.MessageType.恋人発言,
+                            CDef.MessageType.念話,
+                        ),
+                    ),
+                    rpSayRestrictList = defaultMessageTypeRestrictList(listOf(CDef.MessageType.アクション)),
+                )
+            }
+
+            private fun defaultCampAllocations(): List<VillageSettingsFormView.CampAllocation> {
+                return listOf(
+                    CDef.Camp.村人陣営,
+                    CDef.Camp.人狼陣営,
+                    CDef.Camp.狐陣営,
+                    CDef.Camp.恋人陣営,
+                    CDef.Camp.愉快犯陣営,
+                ).map { cdefCamp ->
+                    val skills = Skills.all().filterNotSomeone().filterByCamp(cdefCamp).list
+                    VillageSettingsFormView.CampAllocation(
+                        campCode = cdefCamp.code(),
+                        campName = cdefCamp.alias(),
+                        minNum = 0,
+                        maxNum = null,
+                        allocation = 50,
+                        reincarnationAllocation = 50,
+                        skillAllocation = skills.map { s ->
+                            VillageSettingsFormView.SkillAllocation(
+                                skillCode = s.code,
+                                skillName = s.name,
+                                minNum = if (s.toCdef() == CDef.Skill.村人) 1 else 0,
+                                maxNum = if (s.isRequestable()) null else 0,
+                                allocation = 50,
+                                reincarnationAllocation = if (s.isRevivable()) 50 else 0,
+                            )
+                        },
+                    )
+                }
+            }
+
+            private fun defaultSayRestrictList(): List<VillageSettingsFormView.SkillSayRestrict> {
+                return Skills.all().filterNotSomeone().list.map { s ->
+                    VillageSettingsFormView.SkillSayRestrict(
+                        skillCode = s.code,
+                        skillName = s.name,
+                        restrict = false,
+                        count = 20,
+                        length = 400,
+                    )
+                }
+            }
+
+            private fun defaultMessageTypeRestrictList(
+                types: List<CDef.MessageType>,
+            ): List<VillageSettingsFormView.MessageTypeSayRestrict> {
+                return types.map { mt ->
+                    VillageSettingsFormView.MessageTypeSayRestrict(
+                        messageTypeCode = mt.code(),
+                        messageTypeName = mt.alias(),
+                        restrict = false,
+                        count = 20,
+                        length = 400,
+                    )
+                }
+            }
+        }
+    }
+
+    @Schema(description = "編集 UI で出す候補値一覧 + キャラチップ")
+    data class NewVillageOptions(
+        @field:Schema(description = "公式キャラチップ一覧 (オリジナル選択時は使わない)")
+        val charachips: List<CharachipView>,
+        @field:Schema(description = "募集範囲候補")
+        val welcomeRanges: List<VillageSettingsFormView.CodeName>,
+        @field:Schema(description = "年齢制限候補")
+        val ageLimits: List<VillageSettingsFormView.CodeName>,
+        @field:Schema(description = "秘話可能範囲候補")
+        val allowedSecretSays: List<VillageSettingsFormView.CodeName>,
+        @field:Schema(description = "陣営一覧 (闇鍋編成 UI 用)")
+        val camps: List<VillageSettingsFormView.CodeName>,
+        @field:Schema(description = "発言種別: 役職発言制限の対象一覧")
+        val skillMessageTypes: List<VillageSettingsFormView.CodeName>,
+        @field:Schema(description = "発言種別: RP 発言制限の対象一覧")
+        val rpMessageTypes: List<VillageSettingsFormView.CodeName>,
+        @field:Schema(description = "全役職一覧 (おまかせ除く)。通常発言制限の対象。")
+        val skills: List<VillageSettingsFormView.CodeName>,
+    ) {
+        constructor(charachips: Charachips) : this(
+            charachips = charachips.list.map { CharachipView(it) },
+            welcomeRanges = listOf(
+                VillageSettingsFormView.CodeName(CDef.VillageTagItem.誰歓.code(), CDef.VillageTagItem.誰歓.alias()),
+                VillageSettingsFormView.CodeName(CDef.VillageTagItem.身内.code(), CDef.VillageTagItem.身内.alias()),
+            ),
+            ageLimits = listOf(
+                VillageSettingsFormView.CodeName(CDef.VillageTagItem.R15.code(), CDef.VillageTagItem.R15.alias()),
+                VillageSettingsFormView.CodeName(CDef.VillageTagItem.R18.code(), CDef.VillageTagItem.R18.alias()),
+            ),
+            allowedSecretSays = CDef.AllowedSecretSay.listAll().map {
+                VillageSettingsFormView.CodeName(it.code(), it.alias())
+            },
+            camps = listOf(
+                CDef.Camp.村人陣営,
+                CDef.Camp.人狼陣営,
+                CDef.Camp.狐陣営,
+                CDef.Camp.恋人陣営,
+                CDef.Camp.愉快犯陣営,
+            ).map { VillageSettingsFormView.CodeName(it.code(), it.alias()) },
+            skillMessageTypes = listOf(
+                CDef.MessageType.人狼の囁き,
+                CDef.MessageType.共鳴発言,
+                CDef.MessageType.恋人発言,
+                CDef.MessageType.念話,
+            ).map { VillageSettingsFormView.CodeName(it.code(), it.alias()) },
+            rpMessageTypes = listOf(CDef.MessageType.アクション).map {
+                VillageSettingsFormView.CodeName(it.code(), it.alias())
+            },
+            skills = Skills.all().filterNotSomeone().list.map {
+                VillageSettingsFormView.CodeName(it.code, it.name)
+            },
+        )
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/NewVillageCreateApplier.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/NewVillageCreateApplier.kt
@@ -1,0 +1,49 @@
+package com.ort.app.api.v1.villages
+
+import com.ort.app.api.request.NewVillageForm
+import com.ort.app.api.request.validator.NewVillageFormValidator
+import com.ort.app.api.request.village.NewVillageCreateBody
+import com.ort.app.domain.model.player.Player
+import com.ort.app.domain.model.village.Village
+import com.ort.app.fw.exception.WolfMansionBusinessException
+import org.springframework.context.MessageSource
+import org.springframework.stereotype.Component
+import org.springframework.validation.BeanPropertyBindingResult
+import java.util.Locale
+
+/**
+ * `NewVillageCreateBody` を Village に変換するヘルパー。
+ *
+ * cross-field バリデーションは既存の `NewVillageFormValidator` を共有
+ * (body → form 変換 + `MessageSource` でメッセージ解決 → `WolfMansionBusinessException`)。
+ * Step 8f の `VillageSettingsUpdateApplier` と同じパターン。
+ *
+ * Bean Validation 段階のフィールド単体チェックは `@Valid @RequestBody` で自動実行される
+ * ため、本クラスではクロスフィールドのみを扱う。
+ */
+@Component
+class NewVillageCreateApplier(
+    private val newVillageFormValidator: NewVillageFormValidator,
+    private val messageSource: MessageSource,
+) {
+
+    /**
+     * バリデーション + Village 変換を一度に行う。違反があれば最初のエラーを
+     * `WolfMansionBusinessException` (= 400) で送出する。
+     */
+    fun toVillage(body: NewVillageCreateBody, creator: Player): Village {
+        val form = body.toForm()
+        form.initialize() // null 値があると validator が NPE するので NewVillageForm の挙動に合わせて補完
+        validate(form)
+        return form.toVillage(creator)
+    }
+
+    private fun validate(form: NewVillageForm) {
+        val errors = BeanPropertyBindingResult(form, "villageForm")
+        newVillageFormValidator.validate(form, errors)
+        if (!errors.hasErrors()) return
+        val first = errors.allErrors.first()
+        val message = messageSource.getMessage(first, Locale.JAPANESE)
+        throw WolfMansionBusinessException(message)
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/NewVillageRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/NewVillageRestController.kt
@@ -5,7 +5,6 @@ import com.ort.app.api.response.village.NewVillageFormView
 import com.ort.app.application.coordinator.VillageCoordinator
 import com.ort.app.application.service.CharaService
 import com.ort.app.application.service.PlayerService
-import com.ort.app.domain.model.player.canCreateVillage
 import com.ort.app.fw.exception.WolfMansionBusinessException
 import com.ort.app.fw.exception.WolfMansionNotImplementedException
 import com.ort.app.fw.util.WolfMansionUserInfoUtil
@@ -55,11 +54,13 @@ class NewVillageRestController(
     fun formDefaults(): NewVillageFormView {
         val userName = WolfMansionUserInfoUtil.getUserInfo()?.username
             ?: throw WolfMansionBusinessException("ログインが必要です")
+        // JWT は持っているが player レコードが見つからない (= 退会済み等) は本来起きないが、
+        // 起きた場合は canCreate=false で誤魔化さず 400 で原因を明示する。
         val player = playerService.findPlayer(userName)
-        val canCreate = player.canCreateVillage()
+            ?: throw WolfMansionBusinessException("プレイヤー情報が見つかりません")
         val charachips = charaService.findCharachips()
         return NewVillageFormView(
-            canCreate = canCreate,
+            canCreate = player.isAvailableCreateVillage(),
             userName = userName,
             defaults = NewVillageFormView.NewVillageDefaults.create(),
             options = NewVillageFormView.NewVillageOptions(charachips),
@@ -82,7 +83,7 @@ class NewVillageRestController(
             ?: throw WolfMansionBusinessException("ログインが必要です")
         val player = playerService.findPlayer(userName)
             ?: throw WolfMansionBusinessException("プレイヤー情報が見つかりません")
-        if (!player.canCreateVillage()) {
+        if (!player.isAvailableCreateVillage()) {
             throw WolfMansionBusinessException("村建てした村の決着がつくまでは村を建てられません。")
         }
         // オリジナル画像登録は multipart が必要。本 endpoint では受け付けない。
@@ -100,6 +101,12 @@ class NewVillageRestController(
         val charachips = charaService.findCharachips(characterSetId, false)
         if (charachips.list.size != characterSetId.size) {
             throw WolfMansionBusinessException("指定したキャラチップが見つかりません")
+        }
+        // dummyCharaId が選択したキャラチップ群のいずれかに属していることを検証
+        // (任意の charaId で別チップのキャラをダミーにできないようにする)
+        val dummyInScope = charachips.list.any { chip -> chip.charas.list.any { it.id == dummyCharaId } }
+        if (!dummyInScope) {
+            throw WolfMansionBusinessException("ダミーキャラは選択したキャラチップから選んでください")
         }
         villageCoordinator.assertCreateVillage(player, body.personMaxNum!!, charachips, isOriginal = false)
         val paramVillage = applier.toVillage(body, player)

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/NewVillageRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/NewVillageRestController.kt
@@ -1,0 +1,121 @@
+package com.ort.app.api.v1.villages
+
+import com.ort.app.api.request.village.NewVillageCreateBody
+import com.ort.app.api.response.village.NewVillageFormView
+import com.ort.app.application.coordinator.VillageCoordinator
+import com.ort.app.application.service.CharaService
+import com.ort.app.application.service.PlayerService
+import com.ort.app.domain.model.player.canCreateVillage
+import com.ort.app.fw.exception.WolfMansionBusinessException
+import com.ort.app.fw.exception.WolfMansionNotImplementedException
+import com.ort.app.fw.util.WolfMansionUserInfoUtil
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 新規村作成 (creator) の REST API。
+ *
+ * 旧 Thymeleaf `NewVillageController` (`/new-village`, `/new-village/confirm`,
+ * `/new-village/create`, `/new-village/divert/...`) の置き換え。
+ *
+ * - `GET /api/v1/new-village/form-defaults`: 初期 form 値 + 候補値 + canCreate を返す
+ * - `POST /api/v1/villages`: 新規村作成 (JSON-only、`shouldOriginalImage=true` は 501)
+ *
+ * **意図的にスコープ外** (Step 8h):
+ * - オリジナルキャラチップ村 (`shouldOriginalImage=true`): multipart 画像アップロードが必要。
+ *   入村フロー (Step 8a) も同じ理由で 501 にしている。後続 step で multipart endpoint を追加予定。
+ * - 既存村からの設定流用 (旧 `/new-village/divert/{id}`): UX 補助機能のため後続 step に持ち越し。
+ *   フロントから `villages/{id}/settings/form` 相当を借りるか、専用 endpoint を追加する。
+ * - 確認画面: SPA 側で `<dialog>` ベースの確認 UI に置き換え (server preview endpoint 不要)。
+ */
+@RestController
+@RequestMapping("/api/v1")
+@Tag(name = "villages", description = "村")
+class NewVillageRestController(
+    private val villageCoordinator: VillageCoordinator,
+    private val playerService: PlayerService,
+    private val charaService: CharaService,
+    private val applier: NewVillageCreateApplier,
+) {
+
+    @GetMapping("/new-village/form-defaults")
+    @Operation(
+        summary = "新規村作成フォーム初期値",
+        description = "認証ユーザの canCreate 判定 + フォーム初期値 + 候補値 (公式キャラチップ / 役職 / 陣営 / タグ / 秘話可能範囲 / 発言種別) を 1 リクエストで返す。未認証は 400。",
+    )
+    fun formDefaults(): NewVillageFormView {
+        val userName = WolfMansionUserInfoUtil.getUserInfo()?.username
+            ?: throw WolfMansionBusinessException("ログインが必要です")
+        val player = playerService.findPlayer(userName)
+        val canCreate = player.canCreateVillage()
+        val charachips = charaService.findCharachips()
+        return NewVillageFormView(
+            canCreate = canCreate,
+            userName = userName,
+            defaults = NewVillageFormView.NewVillageDefaults.create(),
+            options = NewVillageFormView.NewVillageOptions(charachips),
+        )
+    }
+
+    @PostMapping("/villages")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(
+        summary = "新規村作成",
+        description = "新規村を作成して 201 + 作成された村 ID を返す。" +
+                "creator 認可 (= `player.canCreateVillage()`) を満たさない場合は 400。" +
+                "オリジナルキャラチップ村 (`shouldOriginalImage=true`) は本 endpoint では非対応で 501 を返す。" +
+                "cross-field バリデーションは旧 `NewVillageFormValidator` を共有。",
+    )
+    fun create(
+        @Valid @RequestBody body: NewVillageCreateBody,
+    ): CreatedVillageView {
+        val userName = WolfMansionUserInfoUtil.getUserInfo()?.username
+            ?: throw WolfMansionBusinessException("ログインが必要です")
+        val player = playerService.findPlayer(userName)
+            ?: throw WolfMansionBusinessException("プレイヤー情報が見つかりません")
+        if (!player.canCreateVillage()) {
+            throw WolfMansionBusinessException("村建てした村の決着がつくまでは村を建てられません。")
+        }
+        // オリジナル画像登録は multipart が必要。本 endpoint では受け付けない。
+        if (body.shouldOriginalImage == true) {
+            throw WolfMansionNotImplementedException(
+                "オリジナル画像を使用する村の作成はこの API では未対応です。",
+            )
+        }
+        // 公式キャラチップ村は characterSetId / dummyCharaId が必須
+        val characterSetId = body.characterSetId
+        val dummyCharaId = body.dummyCharaId
+        if (characterSetId.isNullOrEmpty() || dummyCharaId == null) {
+            throw WolfMansionBusinessException("キャラチップとダミーキャラを選択してください")
+        }
+        val charachips = charaService.findCharachips(characterSetId, false)
+        if (charachips.list.size != characterSetId.size) {
+            throw WolfMansionBusinessException("指定したキャラチップが見つかりません")
+        }
+        villageCoordinator.assertCreateVillage(player, body.personMaxNum!!, charachips, isOriginal = false)
+        val paramVillage = applier.toVillage(body, player)
+        val village = villageCoordinator.registerVillage(
+            paramVillage = paramVillage,
+            dummyCharaName = body.dummyCharaName!!,
+            dummyCharaShortName = body.dummyCharaShortName!!,
+            dummyCharaImage = null,
+            joinMessage = body.dummyJoinMessage!!,
+            day1Message = body.dummyDay1Message,
+        )
+        return CreatedVillageView(id = village.id)
+    }
+
+    @Schema(description = "作成された村の識別子")
+    data class CreatedVillageView(
+        @field:Schema(description = "村 ID") val id: Int,
+    )
+}

--- a/frontend/app/features/village/new/NewVillageForm.tsx
+++ b/frontend/app/features/village/new/NewVillageForm.tsx
@@ -26,23 +26,29 @@ export function NewVillageForm({ initial }: { initial: NewVillageFormView }) {
   // 選択中キャラチップに含まれるキャラ一覧 (ダミーキャラ選択肢)
   const characterSetId = body.characterSetId ?? [];
   const [charaListByChip, setCharaListByChip] = useState<Map<number, CharachipDetailView>>(new Map());
-  // 既に取得済の charachip id を覚えておく (再 fetch 防止 + 取得中フラグなしで簡素化)
+  // in-flight な charachip id (再 fetch 抑止用)。fetch 完了 / 失敗のどちらでも
+  // 必ず delete して、unmount → 再 mount でも取得し直せるようにする。
   const fetchingRef = useRef<Set<number>>(new Set());
   useEffect(() => {
     let cancelled = false;
     characterSetId.forEach((id) => {
       if (charaListByChip.has(id) || fetchingRef.current.has(id)) return;
       fetchingRef.current.add(id);
-      fetchCharachipDetail(id).then((detail) => {
-        if (cancelled) return;
-        setCharaListByChip((prev) => {
-          const next = new Map(prev);
-          next.set(id, detail);
-          return next;
+      fetchCharachipDetail(id)
+        .then((detail) => {
+          if (cancelled) return;
+          setCharaListByChip((prev) => {
+            const next = new Map(prev);
+            next.set(id, detail);
+            return next;
+          });
+        })
+        .catch(() => {
+          // 取得失敗時は黙って何もしない (UI 上は「キャラ選択肢なし」)
+        })
+        .finally(() => {
+          fetchingRef.current.delete(id);
         });
-      }).catch(() => {
-        // 取得失敗時は黙って何もしない (UI 上は「キャラ選択肢なし」)
-      });
     });
     return () => {
       cancelled = true;
@@ -94,6 +100,7 @@ export function NewVillageForm({ initial }: { initial: NewVillageFormView }) {
           setBody={setBody}
           options={initial.options}
           allCharas={allCharas}
+          charaListByChip={charaListByChip}
         />
         <DummyCharaSection body={body} setBody={setBody} />
         <TagSection body={body} setBody={setBody} options={initial.options} />
@@ -204,9 +211,11 @@ function CharaSection({
   setBody,
   options,
   allCharas,
+  charaListByChip,
 }: SectionProps & {
   options: NewVillageFormView["options"];
   allCharas: CharachipDetailView["charas"];
+  charaListByChip: Map<number, CharachipDetailView>;
 }) {
   const characterSetId = body.characterSetId ?? [];
 
@@ -216,8 +225,12 @@ function CharaSection({
       if (checked) ids.add(chipId);
       else ids.delete(chipId);
       const nextIds = Array.from(ids).sort((a, b) => a - b);
-      // 選択解除した chip にダミーキャラが含まれていた場合は dummyCharaId を null に
-      const dummyStillValid = s.dummyCharaId != null && nextIds.length > 0;
+      // 残ったキャラチップ群に dummyCharaId が含まれていなければ null にリセットする。
+      // (一旦選んだダミーキャラのチップを外すケース)
+      const remainingCharaIds = new Set(
+        nextIds.flatMap((id) => charaListByChip.get(id)?.charas.map((c) => c.id) ?? []),
+      );
+      const dummyStillValid = s.dummyCharaId != null && remainingCharaIds.has(s.dummyCharaId);
       return { ...s, characterSetId: nextIds, dummyCharaId: dummyStillValid ? s.dummyCharaId : null };
     });
   }

--- a/frontend/app/features/village/new/NewVillageForm.tsx
+++ b/frontend/app/features/village/new/NewVillageForm.tsx
@@ -1,0 +1,929 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router";
+import { useCreateVillageMutation } from "./hooks";
+import type { NewVillageCreateBody, NewVillageFormView } from "./api";
+import { fetchCharachipDetail, type CharachipDetailView } from "~/features/meta/api";
+
+/**
+ * 新規村作成フォーム (creator 専用)。
+ *
+ * 旧 Thymeleaf `/new-village` 置き換え。設定変更 (`SettingsForm`) と多くの構造を共有しつつ、
+ * 新規村作成固有のフィールド (キャラチップ選択 / ダミーキャラ情報 / 役職希望可否 / プロデューサー機能)
+ * を追加。
+ *
+ * 確認画面は SPA 内 `<dialog>` ベース (旧 `/new-village/confirm` は不要)。
+ * オリジナルキャラチップ村 (`shouldOriginalImage=true`) は backend が 501 を返すので
+ * UI でも初期 false / 切り替え不可。後続 step で multipart 対応する予定。
+ *
+ * cross-field バリデーションは backend に任せ、フロントでは Required と type のみ最低限。
+ */
+export function NewVillageForm({ initial }: { initial: NewVillageFormView }) {
+  const navigate = useNavigate();
+  const [body, setBody] = useState<NewVillageCreateBody>(() => toInitialBody(initial.defaults));
+  const mutation = useCreateVillageMutation();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  // 選択中キャラチップに含まれるキャラ一覧 (ダミーキャラ選択肢)
+  const characterSetId = body.characterSetId ?? [];
+  const [charaListByChip, setCharaListByChip] = useState<Map<number, CharachipDetailView>>(new Map());
+  // 既に取得済の charachip id を覚えておく (再 fetch 防止 + 取得中フラグなしで簡素化)
+  const fetchingRef = useRef<Set<number>>(new Set());
+  useEffect(() => {
+    let cancelled = false;
+    characterSetId.forEach((id) => {
+      if (charaListByChip.has(id) || fetchingRef.current.has(id)) return;
+      fetchingRef.current.add(id);
+      fetchCharachipDetail(id).then((detail) => {
+        if (cancelled) return;
+        setCharaListByChip((prev) => {
+          const next = new Map(prev);
+          next.set(id, detail);
+          return next;
+        });
+      }).catch(() => {
+        // 取得失敗時は黙って何もしない (UI 上は「キャラ選択肢なし」)
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [characterSetId, charaListByChip]);
+
+  const allCharas = useMemo(
+    () => characterSetId.flatMap((id) => charaListByChip.get(id)?.charas ?? []),
+    [characterSetId, charaListByChip],
+  );
+
+  const sayRestrictLabels = useMemo(
+    () => new Map(initial.defaults.sayRestrictList.map((r) => [r.skillCode, r.skillName])),
+    [initial.defaults.sayRestrictList],
+  );
+  const messageTypeLabels = useMemo(
+    () =>
+      new Map([
+        ...initial.defaults.skillSayRestrictList.map((r) => [r.messageTypeCode, r.messageTypeName] as const),
+        ...initial.defaults.rpSayRestrictList.map((r) => [r.messageTypeCode, r.messageTypeName] as const),
+      ]),
+    [initial.defaults.skillSayRestrictList, initial.defaults.rpSayRestrictList],
+  );
+  const optionsByCamp = useMemo(
+    () => new Map(initial.defaults.campAllocationList.map((c) => [c.campCode, c])),
+    [initial.defaults.campAllocationList],
+  );
+
+  function openConfirm(e: React.FormEvent) {
+    e.preventDefault();
+    setConfirmOpen(true);
+  }
+
+  function submit() {
+    mutation.mutate(body, {
+      onSuccess: (res) => {
+        setConfirmOpen(false);
+        navigate(`/villages/${res.id}`);
+      },
+    });
+  }
+
+  return (
+    <>
+      <form onSubmit={openConfirm} className="space-y-6">
+        <BasicSection body={body} setBody={setBody} />
+        <CharaSection
+          body={body}
+          setBody={setBody}
+          options={initial.options}
+          allCharas={allCharas}
+        />
+        <DummyCharaSection body={body} setBody={setBody} />
+        <TagSection body={body} setBody={setBody} options={initial.options} />
+        <RulesSection body={body} setBody={setBody} options={initial.options} />
+        <JoinPasswordSection body={body} setBody={setBody} />
+        <OrganizationSection body={body} setBody={setBody} optionsByCamp={optionsByCamp} />
+        <RestrictionsSection
+          body={body}
+          setBody={setBody}
+          sayRestrictLabels={sayRestrictLabels}
+          messageTypeLabels={messageTypeLabels}
+        />
+
+        <div className="sticky bottom-0 -mx-6 px-6 py-3 bg-slate-900/95 border-t border-slate-700 flex items-center justify-between gap-4">
+          <div className="text-xs text-slate-400">
+            検証エラーは backend のメッセージが表示されます。
+          </div>
+          <div className="flex items-center gap-3">
+            {mutation.isError && (
+              <span className="text-xs text-rose-300 max-w-md truncate" title={mutation.error.message}>
+                {mutation.error.message}
+              </span>
+            )}
+            <button type="submit" className={primaryButtonClass} disabled={mutation.isPending}>
+              {mutation.isPending ? "送信中..." : "内容を確認"}
+            </button>
+          </div>
+        </div>
+      </form>
+
+      {confirmOpen && (
+        <ConfirmDialog
+          body={body}
+          allCharas={allCharas}
+          onCancel={() => setConfirmOpen(false)}
+          onSubmit={submit}
+          isPending={mutation.isPending}
+          error={mutation.isError ? mutation.error.message : null}
+        />
+      )}
+    </>
+  );
+}
+
+// ============================================================================
+// section components
+// ============================================================================
+
+type SectionProps = {
+  body: NewVillageCreateBody;
+  setBody: React.Dispatch<React.SetStateAction<NewVillageCreateBody>>;
+};
+
+function BasicSection({ body, setBody }: SectionProps) {
+  return (
+    <Section title="基本">
+      <Field label="村表示名 (5〜40文字)">
+        <input
+          type="text"
+          value={body.villageName ?? ""}
+          onChange={(e) => setBody((s) => ({ ...s, villageName: e.target.value }))}
+          className={inputClass}
+          minLength={5}
+          maxLength={40}
+          required
+        />
+      </Field>
+
+      <div className="grid grid-cols-2 gap-3">
+        <Field label="最少開始人数 (8〜)">
+          <RequiredNumber value={body.startPersonMinNum} onChange={(v) => setBody((s) => ({ ...s, startPersonMinNum: v }))} min={8} />
+        </Field>
+        <Field label="定員 (8〜999)">
+          <RequiredNumber value={body.personMaxNum} onChange={(v) => setBody((s) => ({ ...s, personMaxNum: v }))} min={8} max={999} />
+        </Field>
+      </div>
+
+      <Field label="更新間隔 (時 / 分 / 秒)">
+        <div className="flex items-center gap-2">
+          <RequiredNumber value={body.dayChangeIntervalHours} onChange={(v) => setBody((s) => ({ ...s, dayChangeIntervalHours: v }))} min={0} max={72} className="w-20" />
+          <span className="text-xs text-slate-400">時</span>
+          <RequiredNumber value={body.dayChangeIntervalMinutes} onChange={(v) => setBody((s) => ({ ...s, dayChangeIntervalMinutes: v }))} min={0} max={59} className="w-20" />
+          <span className="text-xs text-slate-400">分</span>
+          <RequiredNumber value={body.dayChangeIntervalSeconds} onChange={(v) => setBody((s) => ({ ...s, dayChangeIntervalSeconds: v }))} min={0} max={59} className="w-20" />
+          <span className="text-xs text-slate-400">秒</span>
+        </div>
+      </Field>
+
+      <Field label="開始日時 (現在より7日後を初期値、最大14日後まで)">
+        <div className="flex items-center gap-2 flex-wrap">
+          <RequiredNumber value={body.startYear} onChange={(v) => setBody((s) => ({ ...s, startYear: v }))} min={0} className="w-24" />
+          <span className="text-xs text-slate-400">年</span>
+          <RequiredNumber value={body.startMonth} onChange={(v) => setBody((s) => ({ ...s, startMonth: v }))} min={1} max={12} className="w-16" />
+          <span className="text-xs text-slate-400">月</span>
+          <RequiredNumber value={body.startDay} onChange={(v) => setBody((s) => ({ ...s, startDay: v }))} min={1} max={31} className="w-16" />
+          <span className="text-xs text-slate-400">日</span>
+          <RequiredNumber value={body.startHour} onChange={(v) => setBody((s) => ({ ...s, startHour: v }))} min={0} max={23} className="w-16" />
+          <span className="text-xs text-slate-400">:</span>
+          <RequiredNumber value={body.startMinute} onChange={(v) => setBody((s) => ({ ...s, startMinute: v }))} min={0} max={59} className="w-16" />
+        </div>
+      </Field>
+    </Section>
+  );
+}
+
+function CharaSection({
+  body,
+  setBody,
+  options,
+  allCharas,
+}: SectionProps & {
+  options: NewVillageFormView["options"];
+  allCharas: CharachipDetailView["charas"];
+}) {
+  const characterSetId = body.characterSetId ?? [];
+
+  function toggleChip(chipId: number, checked: boolean) {
+    setBody((s) => {
+      const ids = new Set(s.characterSetId ?? []);
+      if (checked) ids.add(chipId);
+      else ids.delete(chipId);
+      const nextIds = Array.from(ids).sort((a, b) => a - b);
+      // 選択解除した chip にダミーキャラが含まれていた場合は dummyCharaId を null に
+      const dummyStillValid = s.dummyCharaId != null && nextIds.length > 0;
+      return { ...s, characterSetId: nextIds, dummyCharaId: dummyStillValid ? s.dummyCharaId : null };
+    });
+  }
+
+  return (
+    <Section title="キャラクター設定">
+      <Field label="キャラチップ (複数選択可)">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-1">
+          {options.charachips.map((c) => {
+            const checked = characterSetId.includes(c.id);
+            return (
+              <label key={c.id} className="flex items-center gap-2 text-sm border border-slate-700 rounded px-2 py-1.5">
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={(e) => toggleChip(c.id, e.target.checked)}
+                />
+                <img src={c.dummyImageUrl} width={c.dummyImageWidth} height={c.dummyImageHeight} alt={c.name} className="bg-slate-900/60 rounded" />
+                <div className="flex-1 min-w-0">
+                  <span className="block truncate">{c.name}</span>
+                  <span className="block text-xs text-slate-400 truncate">{c.designerName} / {c.charaCount}キャラ</span>
+                </div>
+              </label>
+            );
+          })}
+        </div>
+      </Field>
+
+      <Field label="ダミーキャラ (選択キャラチップ内から)">
+        <select
+          value={body.dummyCharaId ?? ""}
+          onChange={(e) => setBody((s) => ({ ...s, dummyCharaId: e.target.value ? Number(e.target.value) : null }))}
+          className={inputClass}
+          required
+        >
+          <option value="">選択してください</option>
+          {allCharas.map((c) => (
+            <option key={c.id} value={c.id}>{c.name} [{c.shortName}]</option>
+          ))}
+        </select>
+      </Field>
+    </Section>
+  );
+}
+
+function DummyCharaSection({ body, setBody }: SectionProps) {
+  return (
+    <Section title="ダミーキャラの自己紹介">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <Field label="ダミーキャラ表示名 (1〜40文字)">
+          <input
+            type="text"
+            value={body.dummyCharaName ?? ""}
+            onChange={(e) => setBody((s) => ({ ...s, dummyCharaName: e.target.value }))}
+            className={inputClass}
+            minLength={1}
+            maxLength={40}
+            required
+          />
+        </Field>
+        <Field label="略称 (1文字)">
+          <input
+            type="text"
+            value={body.dummyCharaShortName ?? ""}
+            onChange={(e) => setBody((s) => ({ ...s, dummyCharaShortName: e.target.value }))}
+            className={inputClass}
+            minLength={1}
+            maxLength={1}
+            required
+          />
+        </Field>
+      </div>
+      <Field label="入村発言 (1〜400文字、必須)">
+        <textarea
+          value={body.dummyJoinMessage ?? ""}
+          onChange={(e) => setBody((s) => ({ ...s, dummyJoinMessage: e.target.value }))}
+          rows={3}
+          maxLength={400}
+          className={inputClass}
+          required
+        />
+      </Field>
+      <Field label="1日目発言 (任意、最大400文字)">
+        <textarea
+          value={body.dummyDay1Message ?? ""}
+          onChange={(e) => setBody((s) => ({ ...s, dummyDay1Message: e.target.value || null }))}
+          rows={3}
+          maxLength={400}
+          className={inputClass}
+        />
+      </Field>
+    </Section>
+  );
+}
+
+function TagSection({
+  body,
+  setBody,
+  options,
+}: SectionProps & { options: NewVillageFormView["options"] }) {
+  return (
+    <Section title="タグ">
+      <Field label="募集範囲">
+        <select
+          value={body.welcomeRange ?? ""}
+          onChange={(e) => setBody((s) => ({ ...s, welcomeRange: e.target.value || null }))}
+          className={inputClass}
+        >
+          <option value="">指定なし</option>
+          {options.welcomeRanges.map((o) => (
+            <option key={o.code} value={o.code}>{o.name}</option>
+          ))}
+        </select>
+      </Field>
+      <Field label="年齢制限">
+        <select
+          value={body.ageLimit ?? ""}
+          onChange={(e) => setBody((s) => ({ ...s, ageLimit: e.target.value || null }))}
+          className={inputClass}
+        >
+          <option value="">全年齢</option>
+          {options.ageLimits.map((o) => (
+            <option key={o.code} value={o.code}>{o.name}</option>
+          ))}
+        </select>
+      </Field>
+    </Section>
+  );
+}
+
+function RulesSection({
+  body,
+  setBody,
+  options,
+}: SectionProps & { options: NewVillageFormView["options"] }) {
+  return (
+    <Section title="ルール">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        <CheckRow label="記名投票" checked={body.openVote ?? false} onChange={(v) => setBody((s) => ({ ...s, openVote: v }))} />
+        <CheckRow label="役職希望を有効にする" checked={body.possibleSkillRequest ?? false} onChange={(v) => setBody((s) => ({ ...s, possibleSkillRequest: v }))} />
+        <CheckRow label="見学を可能にする" checked={body.availableSpectate ?? false} onChange={(v) => setBody((s) => ({ ...s, availableSpectate: v }))} />
+        <CheckRow label="村建てがプロデューサー機能を持つ" checked={body.creatorIsProducer ?? false} onChange={(v) => setBody((s) => ({ ...s, creatorIsProducer: v }))} />
+        <CheckRow label="突然死あり" checked={body.availableSuddenlyDeath ?? false} onChange={(v) => setBody((s) => ({ ...s, availableSuddenlyDeath: v }))} />
+        <CheckRow label="コミット可能" checked={body.availableCommit ?? false} onChange={(v) => setBody((s) => ({ ...s, availableCommit: v }))} />
+        <CheckRow label="アクションあり" checked={body.availableAction ?? false} onChange={(v) => setBody((s) => ({ ...s, availableAction: v }))} />
+        <CheckRow label="連続襲撃あり" checked={body.availableSameWolfAttack ?? false} onChange={(v) => setBody((s) => ({ ...s, availableSameWolfAttack: v }))} />
+        <CheckRow label="連続ガードあり" checked={body.availableGuardSameTarget ?? false} onChange={(v) => setBody((s) => ({ ...s, availableGuardSameTarget: v }))} />
+        <CheckRow label="墓下役職公開" checked={body.openSkillInGrave ?? false} onChange={(v) => setBody((s) => ({ ...s, openSkillInGrave: v }))} />
+        <CheckRow label="墓下見学発言を地上から見られる" checked={body.visibleGraveSpectateMessage ?? false} onChange={(v) => setBody((s) => ({ ...s, visibleGraveSpectateMessage: v }))} />
+        <CheckRow label="転生時に全役職を候補とする" checked={body.reincarnationSkillAll ?? false} onChange={(v) => setBody((s) => ({ ...s, reincarnationSkillAll: v }))} />
+        <CheckRow label="闇鍋編成" checked={body.randomOrganization ?? false} onChange={(v) => setBody((s) => ({ ...s, randomOrganization: v }))} />
+      </div>
+      <Field label="秘話可能範囲">
+        <select
+          value={body.allowedSecretSayCode ?? ""}
+          onChange={(e) => setBody((s) => ({ ...s, allowedSecretSayCode: e.target.value }))}
+          className={inputClass}
+        >
+          {options.allowedSecretSays.map((o) => (
+            <option key={o.code} value={o.code}>{o.name}</option>
+          ))}
+        </select>
+      </Field>
+    </Section>
+  );
+}
+
+function JoinPasswordSection({ body, setBody }: SectionProps) {
+  return (
+    <Section title="入村パスワード (任意)">
+      <Field label="3〜12文字、未設定ならパスワード不要">
+        <input
+          type="password"
+          autoComplete="new-password"
+          value={body.joinPassword ?? ""}
+          onChange={(e) => setBody((s) => ({ ...s, joinPassword: e.target.value || null }))}
+          className={inputClass}
+          maxLength={12}
+        />
+      </Field>
+    </Section>
+  );
+}
+
+function OrganizationSection({
+  body,
+  setBody,
+  optionsByCamp,
+}: SectionProps & {
+  optionsByCamp: Map<string, NewVillageFormView["defaults"]["campAllocationList"][number]>;
+}) {
+  if (!body.randomOrganization) {
+    return (
+      <Section title="構成 (改行区切り、固定編成)">
+        <textarea
+          value={body.organization ?? ""}
+          onChange={(e) => setBody((s) => ({ ...s, organization: e.target.value }))}
+          rows={10}
+          className={`${inputClass} font-mono`}
+          placeholder="1行 = 1構成 (例: 村狼狼狼魔狐賢導狩共共霊霊霊霊霊霊)"
+        />
+      </Section>
+    );
+  }
+  const camps = body.campAllocationList ?? [];
+  const wolf = body.wolfAllocation ?? { minNum: 1, maxNum: null };
+  return (
+    <Section title="闇鍋編成">
+      <p className="text-xs text-slate-400">
+        各陣営の min/max/allocation/reincarnationAllocation と陣営内の役職を編集します。
+      </p>
+      {camps.map((camp, ci) => {
+        const meta = optionsByCamp.get(camp.campCode);
+        return (
+          <div key={camp.campCode ?? ci} className="border border-slate-700 rounded p-3 space-y-2">
+            <p className="text-sm text-amber-200">{meta?.campName ?? camp.campCode}</p>
+            <AllocationRow
+              minNum={camp.minNum}
+              maxNum={camp.maxNum ?? null}
+              allocation={camp.allocation}
+              reincarnationAllocation={camp.reincarnationAllocation}
+              onChange={(patch) =>
+                setBody((s) => ({
+                  ...s,
+                  campAllocationList: (s.campAllocationList ?? []).map((c, i) =>
+                    i === ci ? { ...c, ...patch } : c,
+                  ),
+                }))
+              }
+            />
+            <details>
+              <summary className="text-xs text-slate-300 cursor-pointer">役職別 ({camp.skillAllocation.length}件)</summary>
+              <div className="mt-2 space-y-1">
+                {camp.skillAllocation.map((skill, si) => {
+                  const skillMeta = meta?.skillAllocation.find((sa) => sa.skillCode === skill.skillCode);
+                  return (
+                    <div key={skill.skillCode ?? si} className="flex items-center gap-2 text-xs">
+                      <span className="w-16 shrink-0 text-slate-300">{skillMeta?.skillName ?? skill.skillCode}</span>
+                      <AllocationRow
+                        minNum={skill.minNum}
+                        maxNum={skill.maxNum ?? null}
+                        allocation={skill.allocation}
+                        reincarnationAllocation={skill.reincarnationAllocation}
+                        compact
+                        onChange={(patch) =>
+                          setBody((s) => ({
+                            ...s,
+                            campAllocationList: (s.campAllocationList ?? []).map((c, i) =>
+                              i === ci
+                                ? {
+                                    ...c,
+                                    skillAllocation: c.skillAllocation.map((sk, j) =>
+                                      j === si ? { ...sk, ...patch } : sk,
+                                    ),
+                                  }
+                                : c,
+                            ),
+                          }))
+                        }
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            </details>
+          </div>
+        );
+      })}
+      <div className="border border-slate-700 rounded p-3 space-y-2">
+        <p className="text-sm text-amber-200">人狼カウント</p>
+        <div className="flex items-center gap-2 text-xs">
+          <span className="w-16 shrink-0 text-slate-300">min/max</span>
+          <RequiredNumber
+            value={wolf.minNum}
+            onChange={(v) => setBody((s) => ({ ...s, wolfAllocation: { ...wolf, minNum: v } }))}
+            min={1}
+            max={100}
+            className="w-20"
+          />
+          <span>〜</span>
+          <OptionalNumber
+            value={wolf.maxNum ?? null}
+            onChange={(v) => setBody((s) => ({ ...s, wolfAllocation: { ...wolf, maxNum: v } }))}
+            min={1}
+            max={100}
+            className="w-20"
+          />
+        </div>
+      </div>
+    </Section>
+  );
+}
+
+function AllocationRow({
+  minNum,
+  maxNum,
+  allocation,
+  reincarnationAllocation,
+  compact,
+  onChange,
+}: {
+  minNum: number;
+  maxNum: number | null;
+  allocation: number;
+  reincarnationAllocation: number;
+  compact?: boolean;
+  onChange: (patch: {
+    minNum?: number;
+    maxNum?: number | null;
+    allocation?: number;
+    reincarnationAllocation?: number;
+  }) => void;
+}) {
+  const w = compact ? "w-14" : "w-16";
+  return (
+    <div className="flex items-center gap-2 text-xs flex-wrap">
+      <Labeled label="min">
+        <RequiredNumber value={minNum} onChange={(v) => onChange({ minNum: v })} min={0} max={100} className={w} />
+      </Labeled>
+      <Labeled label="max">
+        <OptionalNumber value={maxNum} onChange={(v) => onChange({ maxNum: v })} min={0} max={100} className={w} />
+      </Labeled>
+      <Labeled label="配分">
+        <RequiredNumber value={allocation} onChange={(v) => onChange({ allocation: v })} min={0} max={100} className={w} />
+      </Labeled>
+      <Labeled label="転生配分">
+        <RequiredNumber value={reincarnationAllocation} onChange={(v) => onChange({ reincarnationAllocation: v })} min={0} max={100} className={w} />
+      </Labeled>
+    </div>
+  );
+}
+
+function RestrictionsSection({
+  body,
+  setBody,
+  sayRestrictLabels,
+  messageTypeLabels,
+}: SectionProps & {
+  sayRestrictLabels: Map<string, string>;
+  messageTypeLabels: Map<string, string>;
+}) {
+  const sayList = body.sayRestrictList ?? [];
+  const skillSayList = body.skillSayRestrictList ?? [];
+  const rpSayList = body.rpSayRestrictList ?? [];
+  return (
+    <Section title="発言制限">
+      <details>
+        <summary className="cursor-pointer text-sm text-slate-300">通常発言: 役職別 ({sayList.length}件)</summary>
+        <div className="mt-2 space-y-1">
+          {sayList.map((r, i) => (
+            <RestrictRow
+              key={r.skillCode ?? i}
+              label={sayRestrictLabels.get(r.skillCode) ?? r.skillCode}
+              restrict={r.restrict}
+              count={r.count ?? null}
+              length={r.length ?? null}
+              onChange={(patch) =>
+                setBody((s) => ({
+                  ...s,
+                  sayRestrictList: (s.sayRestrictList ?? []).map((row, j) => (i === j ? { ...row, ...patch } : row)),
+                }))
+              }
+            />
+          ))}
+        </div>
+      </details>
+
+      <details>
+        <summary className="cursor-pointer text-sm text-slate-300">役職発言制限 ({skillSayList.length}件)</summary>
+        <div className="mt-2 space-y-1">
+          {skillSayList.map((r, i) => (
+            <RestrictRow
+              key={r.messageTypeCode ?? i}
+              label={messageTypeLabels.get(r.messageTypeCode) ?? r.messageTypeCode}
+              restrict={r.restrict}
+              count={r.count ?? null}
+              length={r.length ?? null}
+              onChange={(patch) =>
+                setBody((s) => ({
+                  ...s,
+                  skillSayRestrictList: (s.skillSayRestrictList ?? []).map((row, j) => (i === j ? { ...row, ...patch } : row)),
+                }))
+              }
+            />
+          ))}
+        </div>
+      </details>
+
+      <details>
+        <summary className="cursor-pointer text-sm text-slate-300">RP 発言制限 ({rpSayList.length}件)</summary>
+        <div className="mt-2 space-y-1">
+          {rpSayList.map((r, i) => (
+            <RestrictRow
+              key={r.messageTypeCode ?? i}
+              label={messageTypeLabels.get(r.messageTypeCode) ?? r.messageTypeCode}
+              restrict={r.restrict}
+              count={r.count ?? null}
+              length={r.length ?? null}
+              onChange={(patch) =>
+                setBody((s) => ({
+                  ...s,
+                  rpSayRestrictList: (s.rpSayRestrictList ?? []).map((row, j) => (i === j ? { ...row, ...patch } : row)),
+                }))
+              }
+            />
+          ))}
+        </div>
+      </details>
+    </Section>
+  );
+}
+
+function RestrictRow({
+  label,
+  restrict,
+  count,
+  length,
+  onChange,
+}: {
+  label: string;
+  restrict: boolean;
+  count: number | null;
+  length: number | null;
+  onChange: (patch: { restrict?: boolean; count?: number | null; length?: number | null }) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <label className="flex items-center gap-1 w-40 shrink-0">
+        <input type="checkbox" checked={restrict} onChange={(e) => onChange({ restrict: e.target.checked })} />
+        <span>{label}</span>
+      </label>
+      <Labeled label="回数">
+        <OptionalNumber value={count} onChange={(v) => onChange({ count: v })} min={0} max={100} className="w-16" disabled={!restrict} />
+      </Labeled>
+      <Labeled label="文字数">
+        <OptionalNumber value={length} onChange={(v) => onChange({ length: v })} min={0} max={400} className="w-20" disabled={!restrict} />
+      </Labeled>
+    </div>
+  );
+}
+
+// ============================================================================
+// confirm dialog
+// ============================================================================
+
+function ConfirmDialog({
+  body,
+  allCharas,
+  onCancel,
+  onSubmit,
+  isPending,
+  error,
+}: {
+  body: NewVillageCreateBody;
+  allCharas: CharachipDetailView["charas"];
+  onCancel: () => void;
+  onSubmit: () => void;
+  isPending: boolean;
+  error: string | null;
+}) {
+  const dummyChara = allCharas.find((c) => c.id === body.dummyCharaId);
+  const startStr = `${body.startYear}/${pad2(body.startMonth ?? 0)}/${pad2(body.startDay ?? 0)} ${pad2(body.startHour ?? 0)}:${pad2(body.startMinute ?? 0)}`;
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center p-4 z-50">
+      <div className="max-w-md w-full bg-slate-900 border border-slate-700 rounded-xl p-5 space-y-4 max-h-[90vh] overflow-y-auto">
+        <h2 className="text-lg font-semibold">この内容で村を建てます</h2>
+        <dl className="text-sm space-y-1.5">
+          <Row k="村名" v={body.villageName ?? ""} />
+          <Row k="人数" v={`${body.startPersonMinNum} 〜 ${body.personMaxNum}`} />
+          <Row k="開始日時" v={startStr} />
+          <Row k="更新間隔" v={`${body.dayChangeIntervalHours}h ${body.dayChangeIntervalMinutes}m ${body.dayChangeIntervalSeconds}s`} />
+          <Row k="編成" v={body.randomOrganization ? "闇鍋編成" : "固定編成"} />
+          <Row k="ダミーキャラ" v={dummyChara ? `${dummyChara.name} (${dummyChara.shortName})` : `${body.dummyCharaName} (${body.dummyCharaShortName})`} />
+          <Row k="表示名" v={body.dummyCharaName ?? ""} />
+        </dl>
+        <p className="text-xs text-slate-400">
+          作成後はプロローグ画面に遷移します。設定は村建てメニュー → 設定変更で後から調整可能です。
+        </p>
+        {error && <p className="text-xs text-rose-300">{error}</p>}
+        <div className="flex items-center justify-end gap-3">
+          <button type="button" onClick={onCancel} className={secondaryButtonClass} disabled={isPending}>
+            戻る
+          </button>
+          <button type="button" onClick={onSubmit} className={primaryButtonClass} disabled={isPending}>
+            {isPending ? "作成中..." : "村を建てる"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Row({ k, v }: { k: string; v: string }) {
+  return (
+    <div className="flex items-baseline gap-3 border-b border-slate-700/40 pb-1">
+      <dt className="text-xs text-slate-400 w-24 shrink-0">{k}</dt>
+      <dd className="text-sm flex-1 break-words">{v || "(未設定)"}</dd>
+    </div>
+  );
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+// ============================================================================
+// initial mapping
+// ============================================================================
+
+function toInitialBody(defaults: NewVillageFormView["defaults"]): NewVillageCreateBody {
+  return {
+    villageName: defaults.villageName,
+    startPersonMinNum: defaults.startPersonMinNum,
+    personMaxNum: defaults.personMaxNum,
+    dayChangeIntervalHours: defaults.dayChangeIntervalHours,
+    dayChangeIntervalMinutes: defaults.dayChangeIntervalMinutes,
+    dayChangeIntervalSeconds: defaults.dayChangeIntervalSeconds,
+    startYear: defaults.startYear,
+    startMonth: defaults.startMonth,
+    startDay: defaults.startDay,
+    startHour: defaults.startHour,
+    startMinute: defaults.startMinute,
+    welcomeRange: defaults.welcomeRange ?? null,
+    ageLimit: defaults.ageLimit ?? null,
+    openVote: defaults.openVote,
+    possibleSkillRequest: defaults.possibleSkillRequest,
+    availableSameWolfAttack: defaults.availableSameWolfAttack,
+    openSkillInGrave: defaults.openSkillInGrave,
+    visibleGraveSpectateMessage: defaults.visibleGraveSpectateMessage,
+    availableSpectate: defaults.availableSpectate,
+    creatorIsProducer: defaults.creatorIsProducer,
+    availableSuddenlyDeath: defaults.availableSuddenlyDeath,
+    availableCommit: defaults.availableCommit,
+    availableGuardSameTarget: defaults.availableGuardSameTarget,
+    availableAction: defaults.availableAction,
+    randomOrganization: defaults.randomOrganization,
+    reincarnationSkillAll: defaults.reincarnationSkillAll,
+    allowedSecretSayCode: defaults.allowedSecretSayCode,
+    shouldOriginalImage: defaults.shouldOriginalImage,
+    characterSetId: defaults.characterSetId,
+    dummyCharaId: null,
+    dummyCharaName: defaults.dummyCharaName,
+    dummyCharaShortName: defaults.dummyCharaShortName,
+    dummyJoinMessage: defaults.dummyJoinMessage,
+    dummyDay1Message: defaults.dummyDay1Message ?? null,
+    organization: defaults.organization,
+    campAllocationList: defaults.campAllocationList.map((c) => ({
+      campCode: c.campCode,
+      minNum: c.minNum,
+      maxNum: c.maxNum ?? null,
+      allocation: c.allocation,
+      reincarnationAllocation: c.reincarnationAllocation,
+      skillAllocation: c.skillAllocation.map((s) => ({
+        skillCode: s.skillCode,
+        minNum: s.minNum,
+        maxNum: s.maxNum ?? null,
+        allocation: s.allocation,
+        reincarnationAllocation: s.reincarnationAllocation,
+      })),
+    })),
+    wolfAllocation: {
+      minNum: defaults.wolfAllocation.minNum,
+      maxNum: defaults.wolfAllocation.maxNum ?? null,
+    },
+    joinPassword: defaults.joinPassword ?? null,
+    sayRestrictList: defaults.sayRestrictList.map((r) => ({
+      skillCode: r.skillCode,
+      restrict: r.restrict,
+      count: r.count,
+      length: r.length,
+    })),
+    skillSayRestrictList: defaults.skillSayRestrictList.map((r) => ({
+      messageTypeCode: r.messageTypeCode,
+      restrict: r.restrict,
+      count: r.count,
+      length: r.length,
+    })),
+    rpSayRestrictList: defaults.rpSayRestrictList.map((r) => ({
+      messageTypeCode: r.messageTypeCode,
+      restrict: r.restrict,
+      count: r.count,
+      length: r.length,
+    })),
+  };
+}
+
+// ============================================================================
+// atoms
+// ============================================================================
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4 space-y-3">
+      <h2 className="text-sm text-slate-300 font-medium">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-1 text-sm">
+      <span className="text-xs text-slate-400">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function Labeled({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span className="text-slate-500">{label}</span>
+      {children}
+    </span>
+  );
+}
+
+function CheckRow({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <label className="flex items-center gap-2 text-sm">
+      <input type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} />
+      <span>{label}</span>
+    </label>
+  );
+}
+
+function RequiredNumber({
+  value,
+  onChange,
+  min,
+  max,
+  className,
+  disabled,
+}: {
+  value: number;
+  onChange: (v: number) => void;
+  min?: number;
+  max?: number;
+  className?: string;
+  disabled?: boolean;
+}) {
+  return (
+    <input
+      type="number"
+      value={value}
+      onChange={(e) => {
+        const n = Number(e.target.value);
+        onChange(Number.isFinite(n) ? n : 0);
+      }}
+      min={min}
+      max={max}
+      disabled={disabled}
+      className={`${inputClass} ${className ?? "w-24"} disabled:opacity-40`}
+    />
+  );
+}
+
+function OptionalNumber({
+  value,
+  onChange,
+  min,
+  max,
+  className,
+  disabled,
+}: {
+  value: number | null;
+  onChange: (v: number | null) => void;
+  min?: number;
+  max?: number;
+  className?: string;
+  disabled?: boolean;
+}) {
+  return (
+    <input
+      type="number"
+      value={value ?? ""}
+      onChange={(e) => {
+        const raw = e.target.value;
+        if (raw === "") {
+          onChange(null);
+          return;
+        }
+        const n = Number(raw);
+        onChange(Number.isFinite(n) ? n : null);
+      }}
+      min={min}
+      max={max}
+      disabled={disabled}
+      className={`${inputClass} ${className ?? "w-24"} disabled:opacity-40`}
+    />
+  );
+}
+
+const inputClass =
+  "bg-slate-900 border border-slate-700 rounded px-2 py-1 text-sm text-slate-100 placeholder-slate-500 focus:outline-none focus:border-indigo-500";
+
+const primaryButtonClass =
+  "rounded bg-indigo-500 hover:bg-indigo-400 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium";
+
+const secondaryButtonClass =
+  "rounded bg-slate-700 hover:bg-slate-600 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium";

--- a/frontend/app/features/village/new/api.ts
+++ b/frontend/app/features/village/new/api.ts
@@ -1,0 +1,56 @@
+/**
+ * 新規村作成 (creator) の型と fetch 関数。
+ * 旧 Thymeleaf `/new-village` 系の置き換え。
+ */
+
+import type { components } from "~/lib/api/generated";
+import { browserFetch, type ApiFetch } from "~/lib/api/client";
+
+type Schemas = components["schemas"];
+
+// nullable optional フィールドを `T | null` に深く広げる (既存パターン)
+type WidenOptionalsDeep<T> =
+  T extends Array<infer U> ? Array<WidenOptionalsDeep<U>> :
+  T extends object ? { [K in keyof T]: undefined extends T[K] ? WidenOptionalsDeep<T[K]> | null : WidenOptionalsDeep<T[K]> } :
+  T;
+
+export type NewVillageFormView = WidenOptionalsDeep<Schemas["NewVillageFormView"]>;
+export type NewVillageCreateBody = WidenOptionalsDeep<Schemas["NewVillageCreateBody"]>;
+export type CreatedVillageView = Schemas["CreatedVillageView"];
+
+async function readErrorMessage(res: Response): Promise<string> {
+  const errBody = await res.text();
+  try {
+    const parsed = JSON.parse(errBody) as { message?: string };
+    if (parsed.message) return parsed.message;
+  } catch {
+    // not JSON
+  }
+  return errBody;
+}
+
+/** GET /api/v1/new-village/form-defaults — 未認証は 400。 */
+export async function fetchNewVillageDefaults(
+  fetcher: ApiFetch = browserFetch,
+): Promise<NewVillageFormView> {
+  const res = await fetcher(`/api/v1/new-village/form-defaults`);
+  if (!res.ok) {
+    throw new Error(`new-village defaults failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+  return res.json();
+}
+
+/** POST /api/v1/villages — 新規村作成。201 で `{ id }` を返す。 */
+export async function postNewVillage(
+  body: NewVillageCreateBody,
+  fetcher: ApiFetch = browserFetch,
+): Promise<CreatedVillageView> {
+  const res = await fetcher(`/api/v1/villages`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`new-village create failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+  return res.json();
+}

--- a/frontend/app/features/village/new/hooks.ts
+++ b/frontend/app/features/village/new/hooks.ts
@@ -1,0 +1,43 @@
+import {
+  useMutation,
+  useQuery,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import {
+  fetchNewVillageDefaults,
+  postNewVillage,
+  type CreatedVillageView,
+  type NewVillageCreateBody,
+  type NewVillageFormView,
+} from "./api";
+
+/**
+ * 認証必須エンドポイント。未認証時は backend が 400 を返すため、`enabled` で抑止して
+ * 認証済みのときだけ fetch する想定。
+ */
+export function useNewVillageDefaultsQuery(
+  enabled: boolean,
+  initialData?: NewVillageFormView,
+): UseQueryResult<NewVillageFormView> {
+  return useQuery<NewVillageFormView>({
+    queryKey: ["new-village", "defaults"],
+    queryFn: () => fetchNewVillageDefaults(),
+    enabled,
+    initialData,
+    initialDataUpdatedAt: initialData ? Date.now() : undefined,
+    // canCreate (= 進行中の自分の村が無いか) は他のフローで変わる可能性があるので
+    // staleTime は短め (5分)。レイアウト崩れより最新性を優先。
+    staleTime: 5 * 60_000,
+  });
+}
+
+export function useCreateVillageMutation(): UseMutationResult<
+  CreatedVillageView,
+  Error,
+  NewVillageCreateBody
+> {
+  return useMutation<CreatedVillageView, Error, NewVillageCreateBody>({
+    mutationFn: (body) => postNewVillage(body),
+  });
+}

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -16,5 +16,6 @@ export default [
   // 認証必須エリア
   layout("routes/_auth.tsx", [
     route("me", "routes/me.tsx"),
+    route("new-village", "routes/new-village.tsx"),
   ]),
 ] satisfies RouteConfig;

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -61,6 +61,12 @@ export default function Home({ loaderData }: Route.ComponentProps) {
             プレイヤー一覧
           </Link>
           <Link
+            to="/new-village"
+            className="rounded-md border border-slate-600 hover:border-slate-400 px-5 py-2 font-semibold transition"
+          >
+            村を建てる
+          </Link>
+          <Link
             to="/login"
             className="rounded-md border border-slate-600 hover:border-slate-400 px-5 py-2 font-semibold transition"
           >

--- a/frontend/app/routes/new-village.tsx
+++ b/frontend/app/routes/new-village.tsx
@@ -1,0 +1,61 @@
+import { Link } from "react-router";
+import type { Route } from "./+types/new-village";
+import { fetchNewVillageDefaults } from "~/features/village/new/api";
+import { useNewVillageDefaultsQuery } from "~/features/village/new/hooks";
+import { NewVillageForm } from "~/features/village/new/NewVillageForm";
+import { ssrFetch } from "~/lib/api/client";
+
+export function meta(_: Route.MetaArgs) {
+  return [{ title: "村を建てる - wolf-mansion" }];
+}
+
+/**
+ * 新規村作成画面 (creator 専用、Step 8h)。
+ *
+ * SSR loader で `/api/v1/new-village/form-defaults` を呼ぶ。未認証 / 村建て不可なら
+ * loader が null を返し、UI 側で「ログインしてください」「現在は村建てできません」を表示。
+ *
+ * オリジナルキャラチップ村は backend で 501 になるので、UI でも `shouldOriginalImage` は
+ * 固定 false (= 切り替えセクションを出していない)。
+ */
+export async function loader({ request }: Route.LoaderArgs) {
+  const api = ssrFetch(request);
+  const defaults = await fetchNewVillageDefaults(api).catch(() => null);
+  return { defaults };
+}
+
+export default function NewVillagePage({ loaderData }: Route.ComponentProps) {
+  const initialDefaults = loaderData.defaults;
+  // SSR で取れなかった (= 未認証 or 一時エラー) ときも、クライアントで再 fetch を試みる。
+  const query = useNewVillageDefaultsQuery(true, initialDefaults ?? undefined);
+  const data = query.data ?? initialDefaults;
+
+  return (
+    <main className="min-h-screen bg-slate-900 text-slate-100">
+      <section className="max-w-3xl mx-auto px-6 py-8 space-y-4">
+        <header className="flex items-center justify-between">
+          <h1 className="text-xl font-bold">村を建てる</h1>
+          <Link to="/" className="text-sm text-slate-400 hover:text-slate-200">
+            ← トップへ
+          </Link>
+        </header>
+
+        {!data ? (
+          <p className="text-sm text-rose-300">
+            ログインが必要です。
+            <Link to="/login" className="ml-2 underline">
+              ログイン
+            </Link>
+          </p>
+        ) : !data.canCreate ? (
+          <p className="text-sm text-amber-300">
+            現在は村を建てられません。直前に建てた村の決着がついていないか、参加実績が条件を
+            満たしていない可能性があります。
+          </p>
+        ) : (
+          <NewVillageForm initial={data} />
+        )}
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## 変更内容

### backend
- `GET /api/v1/new-village/form-defaults`: 認証ユーザの canCreate 判定 + フォーム初期値
  + 候補値 (公式キャラチップ / 役職 / 陣営 / タグ / 秘話可能範囲 / 発言種別) を 1 リクエストで返す
- `POST /api/v1/villages`: 新規村作成、201 で `{ id }` を返す
- `NewVillageCreateBody` を新規 (旧 \`NewVillageForm\` の JSON 受信版、display-only 除外)。
  nested DTO は Step 8f の \`VillageSettingsUpdateBody\` を再利用
- `NewVillageCreateApplier` で \`NewVillageFormValidator\` を `BeanPropertyBindingResult` + `MessageSource`
  経由で共有 (Step 8f の \`VillageSettingsUpdateApplier\` と同じパターン)
- **意図的スコープ外**:
  - オリジナルキャラチップ村 (`shouldOriginalImage=true`): multipart 画像アップロード必須のため 501 (Step 8a と同じ方針)
  - divert (既存村から流用): UX 補助機能のため後続 step に持ち越し
- schema 命名衝突回避: `NewVillageFormView.NewVillageDefaults` / `NewVillageOptions` で命名
  (`VillageSettingsFormView.CurrentSettings` / `Options` と被るため)

### frontend
- 新ルート `/new-village` (認証ガード `_auth.tsx` 配下)
- SSR loader が `form-defaults` を取得、未認証 / canCreate=false で適切に分岐表示
- `NewVillageForm.tsx`: 設定変更フォームと同構造 + キャラチップ複数選択 + ダミーキャラ ID 選択 +
  ダミーキャラ自己紹介 + プロデューサー機能 + 役職希望
- 確認 dialog 内で送信ボタン (旧 \`/new-village/confirm\` の置き換え)
- ダミーキャラ選択肢は選択中キャラチップから `/charachips/{id}` を並列 fetch して構築
- トップページ (`/`) に「村を建てる」リンクを追加 (ページ内でログイン / canCreate ガード)
- パスワードは `type=password` + `autoComplete=new-password` (Step 8f と同じ方針)

## 動作確認
- [x] backend: `./gradlew test` (BUILD SUCCESSFUL)
- [x] frontend: `pnpm typecheck && pnpm test && pnpm build` (パス)
- [ ] ユーザー手動確認依頼: 実 DB の test player (`canCreate=true` の人) で
      `/new-village` を開いて構成入力 → 「内容を確認」 → ダイアログで「村を建てる」 →
      新規村のプロローグ画面に遷移することを確認

## レビュー観点
- `NewVillageCreateBody` の field 構造が `VillageSettingsUpdateBody` を踏襲しつつ creator 固有
  フィールド (possibleSkillRequest / creatorIsProducer / shouldOriginalImage / characterSetId /
  dummyCharaId / dummyCharaName / dummyCharaShortName / dummyJoinMessage) を追加
- `NewVillageCreateApplier.toVillage` は `form.initialize()` を呼んでから validator 起動
  (旧 `NewVillageForm` validator が一部 null 値を前提にしているため。再発防止コメント記載)
- 旧 Thymeleaf `NewVillageController` は当面残置 (Step 9 で一括撤去予定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)