### PR TITLE
fix: myself 未参加時を 204 No Content に変更 (#2)

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/response/myself/MyselfView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/myself/MyselfView.kt
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  * 自分視点の参加者情報 (隠蔽なし)。
  *
  * 自分の情報は隠蔽不要なので、村全体ビュー (VillageView) とは別 endpoint で返す。
- * 未参加 (user は居るが参加していない / 未ログイン) の場合はそもそも 200 で `null` を返す想定。
+ * 未参加 (user は居るが参加していない / 未ログイン) の場合は 204 No Content を返す想定。
  */
 @Schema(description = "自分視点の参加者情報 (隠蔽なし)")
 data class MyselfView(

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
@@ -142,14 +142,14 @@ class VillageDetailRestController(
     @GetMapping("/{villageId}/myself")
     @Operation(
         summary = "自分視点の参加者情報",
-        description = "ログイン中ユーザがこの村に参加していれば 200 + body、未参加なら 200 + null。" +
+        description = "ログイン中ユーザがこの村に参加していれば 200 + body、未参加なら 204 No Content。" +
                 "当日の能力 / 投票 / コミット状態と役職別の入力仕様を含む。",
     )
     fun myself(
         @PathVariable villageId: Int,
-    ): ResponseEntity<MyselfView?> {
+    ): ResponseEntity<MyselfView> {
         val ctx = loadContext(villageId)
-        val myself = ctx.myself ?: return ResponseEntity.ok(null)
+        val myself = ctx.myself ?: return ResponseEntity.noContent().build()
         val situation = villageCoordinator.findParticipantSituation(
             village = ctx.village,
             username = ctx.user?.username,

--- a/backend/src/test/kotlin/com/ort/app/api/v1/villages/VillageDetailRestControllerTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/api/v1/villages/VillageDetailRestControllerTest.kt
@@ -33,6 +33,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.hamcrest.Matchers.greaterThan
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
@@ -157,6 +158,20 @@ class VillageDetailRestControllerTest {
             .andExpect(jsonPath("$.list[0].roomNumbers").value("04,05"))
             .andExpect(jsonPath("$.list[0].registerChara.id").value(ownerCharaId))
             .andExpect(jsonPath("$.list[0].chara.id").value(ownerCharaId))
+    }
+
+    // ---------- GET /{id}/myself ----------
+
+    @Test
+    fun `GET _api_v1_villages_id_myself 未認証なら 204 No Content`() {
+        val village = createPrologueVillage().copy(id = 4)
+        whenever(villageService.findVillage(eq(4), any())).thenReturn(village)
+        whenever(charaService.findCharachips(any(), any())).thenReturn(buildCharachips(village))
+
+        mockMvc.perform(get("/api/v1/villages/4/myself"))
+            .andExpect(status().isNoContent)
+            // 204 は body を持たない
+            .andExpect(content().string(""))
     }
 
     // ---------- ヘルパー ----------

--- a/backend/src/test/kotlin/com/ort/app/api/v1/villages/VillageDetailRestControllerTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/api/v1/villages/VillageDetailRestControllerTest.kt
@@ -170,8 +170,8 @@ class VillageDetailRestControllerTest {
 
         mockMvc.perform(get("/api/v1/villages/4/myself"))
             .andExpect(status().isNoContent)
-            // 204 は body を持たない
-            .andExpect(content().string(""))
+            // 204 は空 body を期待する (ByteArray 比較で厳密に検証)
+            .andExpect(content().bytes(ByteArray(0)))
     }
 
     // ---------- ヘルパー ----------

--- a/frontend/app/features/village/detail/api.ts
+++ b/frontend/app/features/village/detail/api.ts
@@ -128,10 +128,8 @@ export async function fetchMyself(
 ): Promise<MyselfView | null> {
   const res = await fetcher(`/api/v1/villages/${villageId}/myself`);
   if (!res.ok) throw new Error(`myself fetch failed: ${res.status}`);
-  // backend は未参加時に 200 + body=null を返す
-  const text = await res.text();
-  if (!text || text === "null") return null;
-  return JSON.parse(text) as MyselfView;
+  if (res.status === 204) return null;
+  return (await res.json()) as MyselfView;
 }
 
 /**

--- a/frontend/app/features/village/detail/api.ts
+++ b/frontend/app/features/village/detail/api.ts
@@ -128,6 +128,7 @@ export async function fetchMyself(
 ): Promise<MyselfView | null> {
   const res = await fetcher(`/api/v1/villages/${villageId}/myself`);
   if (!res.ok) throw new Error(`myself fetch failed: ${res.status}`);
+  // backend contract: 参加者なし = 204、参加者あり = 200 + body。他の 2xx は返さない。
   if (res.status === 204) return null;
   return (await res.json()) as MyselfView;
 }


### PR DESCRIPTION
closes .issues/2-myself-empty-body-content-type.md

## 変更内容

`GET /api/v1/villages/{id}/myself` が未参加時に返していた `200 + body=null` を **204 No Content** に変更。

- backend: `VillageDetailRestController.myself` の戻り型を `ResponseEntity<MyselfView?>` から `ResponseEntity<MyselfView>` に変更、未参加時は `noContent().build()` を返す
- frontend: `fetchMyself` を `res.text()` + `"null"` 文字列判定の力技から `res.status === 204 ? null : await res.json()` のシンプル分岐に変更
- test: 未認証時に `/myself` が 204 + 空 body を返すケースを `VillageDetailRestControllerTest` に追加
- doc: `MyselfView` の KDoc と `@Operation` description を 204 文面に更新

## 背景

`ResponseEntity.ok(null)` は Spring の `MappingJackson2HttpMessageConverter` で Content-Type が付くケースと付かないケースが content negotiation 次第で揺れる。frontend が `res.json()` を無条件に呼べないため "null" 文字列判定で対応していた。`.issues/2` で追跡。

## 動作確認

- [x] backend: `./gradlew test --tests VillageDetailRestControllerTest` (6 tests, 全 pass、新規 myself 204 テストを含む)
- [x] frontend: `pnpm typecheck` / `pnpm test` (11 tests pass) / `pnpm build`
- [ ] **ユーザー手動確認依頼**:
  - 未ログイン状態で `/villages/:id` を開き、myself クエリが 204 を受けてエラーなく描画されること
  - 自分が参加していない村を開いて同様に確認
  - 自分が参加している村を開き、能力 / 投票 / コミット系の myself 依存 UI が従来通り動作すること

## スコープ外

- 参加者あり (200 + body) ケースのテストは `ParticipantSituation` の 9 sub-situation を全 mock する維持コストが高いため省略。Step 8b 〜 8h で手動 e2e 確認済み
- `frontend/app/lib/api/generated.ts` は gitignore 対象。次回 `pnpm gen:api` で OpenAPI から自動再生成される (今回の変更は backend OpenAPI 経由で反映される)