### PR TITLE
refactor: myself endpoint 用に findMyselfActionSituation を分離 (#5)

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/response/myself/MyselfView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/myself/MyselfView.kt
@@ -1,7 +1,12 @@
 package com.ort.app.api.response.myself
 
 import com.ort.app.api.response.skill.SkillView
+import com.ort.app.domain.model.situation.MyselfActionSituation
 import com.ort.app.domain.model.situation.ParticipantSituation
+import com.ort.app.domain.model.situation.participant.ParticipantAbilitySituation
+import com.ort.app.domain.model.situation.participant.ParticipantCommitSituation
+import com.ort.app.domain.model.situation.participant.ParticipantRpSituation
+import com.ort.app.domain.model.situation.participant.ParticipantVoteSituation
 import com.ort.app.domain.model.village.participant.VillageParticipant
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -47,6 +52,28 @@ data class MyselfView(
     val rp: MyselfRpView,
 ) {
     constructor(myself: VillageParticipant, situation: ParticipantSituation) : this(
+        myself = myself,
+        commitSituation = situation.commit,
+        voteSituation = situation.vote,
+        abilitySituation = situation.ability,
+        rpSituation = situation.rp,
+    )
+
+    constructor(myself: VillageParticipant, situation: MyselfActionSituation) : this(
+        myself = myself,
+        commitSituation = situation.commit,
+        voteSituation = situation.vote,
+        abilitySituation = situation.ability,
+        rpSituation = situation.rp,
+    )
+
+    private constructor(
+        myself: VillageParticipant,
+        commitSituation: ParticipantCommitSituation,
+        voteSituation: ParticipantVoteSituation,
+        abilitySituation: ParticipantAbilitySituation,
+        rpSituation: ParticipantRpSituation,
+    ) : this(
         id = myself.id,
         charaId = myself.charaId,
         name = myself.name(),
@@ -59,9 +86,9 @@ data class MyselfView(
         isWin = myself.isWin,
         skill = myself.skill?.let { SkillView(it) },
         campCode = myself.camp?.code,
-        commit = MyselfCommitView(situation.commit),
-        vote = MyselfVoteView(situation.vote),
-        ability = MyselfAbilityView(situation.ability),
-        rp = MyselfRpView(situation.rp),
+        commit = MyselfCommitView(commitSituation),
+        vote = MyselfVoteView(voteSituation),
+        ability = MyselfAbilityView(abilitySituation),
+        rp = MyselfRpView(rpSituation),
     )
 }

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
@@ -150,9 +150,8 @@ class VillageDetailRestController(
     ): ResponseEntity<MyselfView> {
         val ctx = loadContext(villageId)
         val myself = ctx.myself ?: return ResponseEntity.noContent().build()
-        val situation = villageCoordinator.findParticipantSituation(
+        val situation = villageCoordinator.findMyselfActionSituation(
             village = ctx.village,
-            username = ctx.user?.username,
             myself = myself,
             votes = voteService.findVotes(ctx.village.id),
             abilities = abilityService.findAbilities(ctx.village.id),

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
@@ -19,7 +19,7 @@ import com.ort.app.application.service.VoteApplicationService
 import com.ort.app.domain.model.chara.Chara
 import com.ort.app.domain.model.chara.Charachips
 import com.ort.app.domain.model.message.MessageQuery
-import com.ort.app.domain.model.player.Player
+import com.ort.app.domain.model.player.Players
 import com.ort.app.domain.model.village.Village
 import com.ort.app.domain.model.village.participant.VillageParticipant
 import com.ort.app.domain.service.SpoilerDomainService
@@ -62,7 +62,8 @@ class VillageDetailRestController(
         @PathVariable villageId: Int,
     ): VillageView {
         val ctx = loadContext(villageId)
-        val participants = buildParticipants(ctx)
+        val players = playerService.findPlayers(ctx.village.id)
+        val participants = buildParticipants(ctx, players)
         // 旧 Thymeleaf 系 (`CreatorController`) と新 REST creator endpoints の認可判定
         // (`VillageContextLoader.loadVillageAndRequireCreator`) はどちらも
         // `CreatorCoordinator.isCreator` を使う = Player ID=1 (管理者) は全村 creator 扱い。
@@ -100,7 +101,8 @@ class VillageDetailRestController(
             isPaging = false,
             isDispLatest = true,
         )
-        val messages = messageService.findMeesages(ctx.village, ctx.myself, ctx.player, query)
+        val viewerPlayer = ctx.user?.let { playerService.findPlayer(it.username) }
+        val messages = messageService.findMeesages(ctx.village, ctx.myself, viewerPlayer, query)
         return MessagesView(messages)
     }
 
@@ -162,22 +164,29 @@ class VillageDetailRestController(
         return ResponseEntity.ok(MyselfView(myself, situation))
     }
 
+    /**
+     * 4 endpoint で共通して必要な最小コンテキストだけを構築する。
+     * 全 endpoint で必須でない以下は呼び出し側で必要なときだけ fetch する:
+     * - `playerService.findPlayer(username)` (viewer の Player、`messages` のみ)
+     * - `playerService.findPlayers(villageId)` (村の全プレイヤー、`get`/`buildParticipants` のみ)
+     */
     private fun loadContext(villageId: Int): VillageDetailContext {
         val village = villageService.findVillage(villageId, excludeGone = false)
             ?: throw WolfMansionRecordNotFoundException("village not found. id=$villageId")
         val user = WolfMansionUserInfoUtil.getUserInfo()
-        val player = user?.let { playerService.findPlayer(it.username) }
         val myself = user?.let { villageService.findVillageParticipant(village.id, it.username) }
         val charachips = village.setting.chara.let {
             charaService.findCharachips(it.charachipIds, it.isOriginalCharachip)
         }
-        val players = playerService.findPlayers(village.id)
-        return VillageDetailContext(village, user, player, myself, charachips, players)
+        return VillageDetailContext(village, user, myself, charachips)
     }
 
-    private fun buildParticipants(ctx: VillageDetailContext): VillageParticipantsView {
+    private fun buildParticipants(
+        ctx: VillageDetailContext,
+        players: Players,
+    ): VillageParticipantsView {
         val charaById = ctx.charachips.charas().list.associateBy { it.id }
-        val playerById = ctx.players.list.associateBy { it.id }
+        val playerById = players.list.associateBy { it.id }
         val isSpoilerOpen = spoilerDomainService.isViewableSpoilerContent(ctx.village, ctx.myself)
         val sorted = ctx.village.allParticipants().sortedByRoomNumber().list
         val views = sorted.mapNotNull { participant ->
@@ -235,9 +244,7 @@ class VillageDetailRestController(
     private data class VillageDetailContext(
         val village: Village,
         val user: com.ort.app.fw.security.UserInfo?,
-        val player: Player?,
         val myself: VillageParticipant?,
         val charachips: Charachips,
-        val players: com.ort.app.domain.model.player.Players,
     )
 }

--- a/backend/src/main/kotlin/com/ort/app/application/coordinator/VillageCoordinator.kt
+++ b/backend/src/main/kotlin/com/ort/app/application/coordinator/VillageCoordinator.kt
@@ -17,6 +17,7 @@ import com.ort.app.domain.model.commit.Commit
 import com.ort.app.domain.model.footstep.Footsteps
 import com.ort.app.domain.model.message.Message
 import com.ort.app.domain.model.player.Player
+import com.ort.app.domain.model.situation.MyselfActionSituation
 import com.ort.app.domain.model.situation.ParticipantSituation
 import com.ort.app.domain.model.situation.VillageSituation
 import com.ort.app.domain.model.situation.village.VillageParticipantLiveSituation
@@ -406,6 +407,41 @@ class VillageCoordinator(
             vote = voteDomainService.convertToParticipantSituation(village, myself, votes),
             admin = adminDomainService.convertToSituation(village, myself),
             creator = creatorDomainService.convertToSituation(village, player)
+        )
+    }
+
+    /**
+     * REST `/myself` 専用の軽量版。commit / vote / ability / rp の 4 サブ situation だけを構築し、
+     * `findParticipantSituation` が必要としていた以下の重い処理を行わない:
+     * - `playerService.findPlayer(username)` (myself 用)
+     * - `messageService.findParticipantDayMessageCount(...)` (say 用の発言数集計)
+     * - `playerService.findPlayer(creator)` (say の creatorPlayerId 用)
+     * - participate / skillRequest / say / admin / creator の各 sub-situation 構築
+     *
+     * 旧 Thymeleaf 系 (`VillageControllerHelper`) は引き続き `findParticipantSituation` を使う。
+     */
+    fun findMyselfActionSituation(
+        village: Village,
+        myself: VillageParticipant,
+        votes: Votes,
+        abilities: Abilities,
+        footsteps: Footsteps,
+        charachips: Charachips,
+        day: Int,
+    ): MyselfActionSituation {
+        val commits = commitService.findCommits(village.id)
+        return MyselfActionSituation(
+            commit = commitDomainService.convertToSituation(village, myself, commits),
+            vote = voteDomainService.convertToParticipantSituation(village, myself, votes),
+            ability = abilityDomainService.convertToParticipantSituation(
+                village,
+                myself,
+                abilities,
+                votes,
+                footsteps,
+                day
+            ),
+            rp = rpDomainService.convertToSituation(village, myself, charachips, day),
         )
     }
 

--- a/backend/src/main/kotlin/com/ort/app/domain/model/situation/MyselfActionSituation.kt
+++ b/backend/src/main/kotlin/com/ort/app/domain/model/situation/MyselfActionSituation.kt
@@ -1,0 +1,13 @@
+package com.ort.app.domain.model.situation
+
+import com.ort.app.domain.model.situation.participant.ParticipantAbilitySituation
+import com.ort.app.domain.model.situation.participant.ParticipantCommitSituation
+import com.ort.app.domain.model.situation.participant.ParticipantRpSituation
+import com.ort.app.domain.model.situation.participant.ParticipantVoteSituation
+
+data class MyselfActionSituation(
+    val commit: ParticipantCommitSituation,
+    val vote: ParticipantVoteSituation,
+    val ability: ParticipantAbilitySituation,
+    val rp: ParticipantRpSituation,
+)


### PR DESCRIPTION
closes .issues/5-myself-find-participant-situation-heavy.md

## 変更内容

`GET /api/v1/villages/{villageId}/myself` が `VillageCoordinator.findParticipantSituation`
を呼んでおり、myself UI として必要な 4 サブ situation (commit / vote / ability / rp) 以外の
participate / skillRequest / say / admin / creator まで構築していた件を改善。

- `VillageCoordinator.findMyselfActionSituation(...)` を新設 (commit / vote / ability / rp のみ)。
  内部で `commitService.findCommits(villageId)` の 1 クエリだけ追加で発行し、以下を呼ばない:
  - `playerService.findPlayer(username)` (myself 用 player fetch)
  - `messageService.findParticipantDayMessageCount(...)` (say 用、発言数集計)
  - `playerService.findPlayer(creator)` (say の creatorPlayerId 用)
- `MyselfActionSituation` を `com.ort.app.domain.model.situation` に追加
- `MyselfView` に `(VillageParticipant, MyselfActionSituation)` の secondary constructor を追加。
  既存の `(VillageParticipant, ParticipantSituation)` 経路 (旧 Thymeleaf) も同じ private constructor に集約
- `VillageDetailRestController.myself` を新軽量版に差し替え

旧 Thymeleaf 系 (`VillageControllerHelper`) は引き続き `findParticipantSituation` を使用 (Step 9 で撤去予定)。

### 関連 nit (issue #5 後半) も同時解消

`VillageDetailRestController.loadContext` が `playerService.findPlayer(username)` を呼び、
`findParticipantSituation` 内でも独立に同じ player を再 fetch していた件は、
軽量版が player を必要としないため myself 経路から自然に消える。

### 互換性

`MyselfView` の JSON shape は無変更 (constructor 追加のみ)。frontend は変更不要。
OpenAPI 再生成も不要。

## 動作確認

- [x] `./gradlew compileKotlin classes` (warning は既存のみ、本変更由来なし)
- [x] `./gradlew test`
- [ ] ユーザー手動確認依頼:
  - ログイン状態で参加中の村画面を開き、myself UI (能力 / 投票 / コミット / RP) が
    従来どおり動作することを確認
  - 未参加の村で myself が 204 No Content を返すこと