### PR TITLE
Step 8i: オリジナルキャラチップ村作成 + 入村 (multipart)

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/request/village/NewVillageCreateBody.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/request/village/NewVillageCreateBody.kt
@@ -14,7 +14,7 @@ import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 
 /**
- * 新規村作成 (POST /api/v1/villages) リクエスト body (JSON)。
+ * 新規村作成 (POST /api/v1/villages) リクエスト body。
  *
  * 旧 `NewVillageForm` (Thymeleaf form) の JSON 受信用スリム版。
  * 設定変更 (`VillageSettingsUpdateBody`) と多くのフィールドが共通だが、新規村作成固有の
@@ -22,9 +22,10 @@ import jakarta.validation.constraints.Size
  * `VillageSettingsUpdateBody` の nested DTO (CampAllocationBody / SkillAllocationBody /
  * WolfAllocationBody / SkillSayRestrictBody / MessageTypeSayRestrictBody) を再利用する。
  *
- * オリジナルキャラチップ村 (`shouldOriginalImage=true`) は multipart 画像アップロードが
- * 必要なため、本 JSON endpoint では非対応 (= controller 層で 501 を返す)。
- * 入村フロー (Step 8a) でも同じ理由で original charachip は 501 にしている。
+ * `shouldOriginalImage=true` (オリジナルキャラチップ村) の場合は multipart endpoint
+ * (`POST /api/v1/villages`, `consumes=multipart/form-data`) で `body` part として送られ、
+ * 同時に `dummyCharaImage` (画像 file part) を要求する。JSON endpoint に
+ * `shouldOriginalImage=true` を送ると 400 (multipart endpoint へ案内)。
  */
 @Schema(description = "新規村作成リクエスト body (creator)")
 data class NewVillageCreateBody(
@@ -113,7 +114,7 @@ data class NewVillageCreateBody(
     @field:Schema(description = "秘話可能範囲 (CDef.AllowedSecretSay code)")
     @field:NotNull val allowedSecretSayCode: String?,
 
-    @field:Schema(description = "オリジナル画像を使用するか。true は現状未対応 (501)。")
+    @field:Schema(description = "オリジナル画像を使用するか。true の場合は multipart endpoint (`dummyCharaImage` part 必須) を使用する。")
     @field:NotNull val shouldOriginalImage: Boolean?,
 
     @field:Schema(description = "公式キャラチップ ID 一覧 (shouldOriginalImage=false のとき必須)")

--- a/backend/src/main/kotlin/com/ort/app/api/request/village/VillageParticipateBody.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/request/village/VillageParticipateBody.kt
@@ -8,15 +8,15 @@ import jakarta.validation.constraints.Size
 /**
  * 入村リクエスト。
  *
- * 現状はキャラチップ制の村のみサポート。オリジナルキャラチップ
- * (`village.setting.chara.isOriginalCharachip == true`) で `charaImageFile` を伴う
- * 入村フローは別 endpoint (multipart) として将来追加する想定で、本 DTO では未対応。
+ * 非オリジナル村 (公式キャラチップ) は JSON endpoint `POST /participate` で `charaId` 必須。
+ * オリジナルキャラチップ村は multipart endpoint `POST /participate` (`consumes=multipart/form-data`)
+ * で `body` (この DTO の JSON) と `charaImage` (画像) を送る。multipart 経路では `charaId=null` で
+ * 構わない (chara は backend で動的に作成される)。
  */
 @Schema(description = "入村リクエスト")
 data class VillageParticipateBody(
-    @field:NotNull
-    @field:Schema(description = "選択するキャラ ID")
-    val charaId: Int,
+    @field:Schema(description = "選択するキャラ ID (非オリジナル村で必須、オリジナル村では null)")
+    val charaId: Int? = null,
     @field:NotNull
     @field:NotBlank
     @field:Size(min = 1, max = 40)

--- a/backend/src/main/kotlin/com/ort/app/api/v1/support/ImageUploadValidator.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/support/ImageUploadValidator.kt
@@ -1,0 +1,43 @@
+package com.ort.app.api.v1.support
+
+import com.ort.app.fw.exception.WolfMansionBusinessException
+import org.springframework.web.multipart.MultipartFile
+
+/**
+ * REST 層でアップロード画像 (ダミーキャラ / 入村キャラ画像 / 表情差分) を共通検証するヘルパー。
+ *
+ * 検証内容:
+ * - サイズ: 1〜100,000 byte (旧 Thymeleaf 系 `NewVillageFormValidator` / `VillageParticipateFormValidator` /
+ *   `VillageFaceTypeFormValidator` と同条件)。1KB = 1000 byte 換算で「最大 100KB」相当。
+ * - 拡張子ホワイトリスト: png / jpg / jpeg / gif / webp。`CharaDataSource.uploadCharaImage` が
+ *   `originalFilename.lastIndexOf('.')` で拡張子を切り出すため、`.hidden` のような
+ *   ドット始まりや拡張子なしのファイルを弾く + パストラバーサル / 想定外フォーマット防御。
+ *
+ * 旧 Thymeleaf 経路は `CharaDataSource.uploadCharaImage` 内で同等のガードを持つが、
+ * REST 経路では境界 (controller) で先回り検証してエラーメッセージを統一する。
+ */
+object ImageUploadValidator {
+
+    /** 1 byte 〜 100,000 byte (≒ 100 KB)。0 byte (空ファイル) も reject。 */
+    const val MAX_SIZE_BYTES: Long = 100_000L
+
+    val ALLOWED_EXTENSIONS: Set<String> = setOf(".png", ".jpg", ".jpeg", ".gif", ".webp")
+
+    /**
+     * 画像をサイズ + 拡張子の両面で検証する。違反があれば `WolfMansionBusinessException` (= 400)。
+     */
+    fun validate(image: MultipartFile) {
+        if (image.size <= 0L || image.size > MAX_SIZE_BYTES) {
+            throw WolfMansionBusinessException("画像サイズは最大 ${MAX_SIZE_BYTES} byte までです")
+        }
+        val filename = image.originalFilename
+        val dotIndex = filename?.lastIndexOf('.') ?: -1
+        if (filename == null || dotIndex < 1 ||
+            filename.substring(dotIndex).lowercase() !in ALLOWED_EXTENSIONS
+        ) {
+            throw WolfMansionBusinessException(
+                "画像ファイルの拡張子は ${ALLOWED_EXTENSIONS.joinToString(" / ")} のみ対応しています"
+            )
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/NewVillageRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/NewVillageRestController.kt
@@ -5,20 +5,24 @@ import com.ort.app.api.response.village.NewVillageFormView
 import com.ort.app.application.coordinator.VillageCoordinator
 import com.ort.app.application.service.CharaService
 import com.ort.app.application.service.PlayerService
+import com.ort.app.domain.model.chara.Charachips
+import com.ort.app.domain.model.player.Player
 import com.ort.app.fw.exception.WolfMansionBusinessException
-import com.ort.app.fw.exception.WolfMansionNotImplementedException
 import com.ort.app.fw.util.WolfMansionUserInfoUtil
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
 
 /**
  * 新規村作成 (creator) の REST API。
@@ -27,11 +31,13 @@ import org.springframework.web.bind.annotation.RestController
  * `/new-village/create`, `/new-village/divert/...`) の置き換え。
  *
  * - `GET /api/v1/new-village/form-defaults`: 初期 form 値 + 候補値 + canCreate を返す
- * - `POST /api/v1/villages`: 新規村作成 (JSON-only、`shouldOriginalImage=true` は 501)
+ * - `POST /api/v1/villages` (JSON): 新規村作成 (非オリジナル)
+ * - `POST /api/v1/villages` (multipart): 新規村作成 (オリジナルキャラチップ、ダミーキャラ画像必須)
  *
- * **意図的にスコープ外** (Step 8h):
- * - オリジナルキャラチップ村 (`shouldOriginalImage=true`): multipart 画像アップロードが必要。
- *   入村フロー (Step 8a) も同じ理由で 501 にしている。後続 step で multipart endpoint を追加予定。
+ * オリジナル / 非オリジナルは `consumes` で振り分ける。multipart 版は `body` (JSON) と
+ * `dummyCharaImage` (画像 file) の 2 パートを受け取る。
+ *
+ * **意図的にスコープ外** (後続 step):
  * - 既存村からの設定流用 (旧 `/new-village/divert/{id}`): UX 補助機能のため後続 step に持ち越し。
  *   フロントから `villages/{id}/settings/form` 相当を借りるか、専用 endpoint を追加する。
  * - 確認画面: SPA 側で `<dialog>` ベースの確認 UI に置き換え (server preview endpoint 不要)。
@@ -67,32 +73,63 @@ class NewVillageRestController(
         )
     }
 
-    @PostMapping("/villages")
+    @PostMapping("/villages", consumes = [MediaType.APPLICATION_JSON_VALUE])
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(
-        summary = "新規村作成",
-        description = "新規村を作成して 201 + 作成された村 ID を返す。" +
+        summary = "新規村作成 (非オリジナルキャラチップ)",
+        description = "公式キャラチップ村を作成して 201 + 作成された村 ID を返す。" +
                 "creator 認可 (= `player.canCreateVillage()`) を満たさない場合は 400。" +
-                "オリジナルキャラチップ村 (`shouldOriginalImage=true`) は本 endpoint では非対応で 501 を返す。" +
+                "オリジナルキャラチップ村 (`shouldOriginalImage=true`) はこの JSON endpoint では非対応 (400)。" +
+                "オリジナル村は multipart 版 `POST /api/v1/villages` (`consumes=multipart/form-data`) を使用。" +
                 "cross-field バリデーションは旧 `NewVillageFormValidator` を共有。",
     )
     fun create(
         @Valid @RequestBody body: NewVillageCreateBody,
     ): CreatedVillageView {
-        val userName = WolfMansionUserInfoUtil.getUserInfo()?.username
-            ?: throw WolfMansionBusinessException("ログインが必要です")
-        val player = playerService.findPlayer(userName)
-            ?: throw WolfMansionBusinessException("プレイヤー情報が見つかりません")
-        if (!player.isAvailableCreateVillage()) {
-            throw WolfMansionBusinessException("村建てした村の決着がつくまでは村を建てられません。")
-        }
-        // オリジナル画像登録は multipart が必要。本 endpoint では受け付けない。
+        val player = requireCreatorPlayer()
         if (body.shouldOriginalImage == true) {
-            throw WolfMansionNotImplementedException(
-                "オリジナル画像を使用する村の作成はこの API では未対応です。",
+            throw WolfMansionBusinessException(
+                "オリジナルキャラチップ村は multipart endpoint を使用してください。",
             )
         }
-        // 公式キャラチップ村は characterSetId / dummyCharaId が必須
+        return createOfficial(body, player)
+    }
+
+    @PostMapping("/villages", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(
+        summary = "新規村作成 (オリジナルキャラチップ)",
+        description = "オリジナルキャラチップ村を作成する。`body` (JSON) と `dummyCharaImage` (画像) の 2 パート構成。" +
+                "`shouldOriginalImage=true` を必須。creator 認可を満たさない場合は 400。" +
+                "画像は 1〜100KB、許可拡張子は png / jpg / jpeg / gif / webp。",
+    )
+    fun createOriginal(
+        @Valid @RequestPart("body") body: NewVillageCreateBody,
+        @RequestPart("dummyCharaImage") dummyCharaImage: MultipartFile,
+    ): CreatedVillageView {
+        val player = requireCreatorPlayer()
+        if (body.shouldOriginalImage != true) {
+            throw WolfMansionBusinessException(
+                "shouldOriginalImage=true を指定してください (非オリジナル村は JSON endpoint を使用)。",
+            )
+        }
+        validateDummyCharaImage(dummyCharaImage)
+        villageCoordinator.assertCreateVillage(
+            player, body.personMaxNum!!, charachips = emptyCharachips(), isOriginal = true,
+        )
+        val paramVillage = applier.toVillage(body, player)
+        val village = villageCoordinator.registerVillage(
+            paramVillage = paramVillage,
+            dummyCharaName = body.dummyCharaName!!,
+            dummyCharaShortName = body.dummyCharaShortName!!,
+            dummyCharaImage = dummyCharaImage,
+            joinMessage = body.dummyJoinMessage!!,
+            day1Message = body.dummyDay1Message,
+        )
+        return CreatedVillageView(id = village.id)
+    }
+
+    private fun createOfficial(body: NewVillageCreateBody, player: Player): CreatedVillageView {
         val characterSetId = body.characterSetId
         val dummyCharaId = body.dummyCharaId
         if (characterSetId.isNullOrEmpty() || dummyCharaId == null) {
@@ -102,8 +139,6 @@ class NewVillageRestController(
         if (charachips.list.size != characterSetId.size) {
             throw WolfMansionBusinessException("指定したキャラチップが見つかりません")
         }
-        // dummyCharaId が選択したキャラチップ群のいずれかに属していることを検証
-        // (任意の charaId で別チップのキャラをダミーにできないようにする)
         val dummyInScope = charachips.list.any { chip -> chip.charas.list.any { it.id == dummyCharaId } }
         if (!dummyInScope) {
             throw WolfMansionBusinessException("ダミーキャラは選択したキャラチップから選んでください")
@@ -119,6 +154,44 @@ class NewVillageRestController(
             day1Message = body.dummyDay1Message,
         )
         return CreatedVillageView(id = village.id)
+    }
+
+    private fun requireCreatorPlayer(): Player {
+        val userName = WolfMansionUserInfoUtil.getUserInfo()?.username
+            ?: throw WolfMansionBusinessException("ログインが必要です")
+        val player = playerService.findPlayer(userName)
+            ?: throw WolfMansionBusinessException("プレイヤー情報が見つかりません")
+        if (!player.isAvailableCreateVillage()) {
+            throw WolfMansionBusinessException("村建てした村の決着がつくまでは村を建てられません。")
+        }
+        return player
+    }
+
+    /**
+     * オリジナルキャラチップ村のダミーキャラ画像を検証する。
+     * 旧 `NewVillageFormValidator.validateDummyChara` のサイズ制限 (1〜100KB) を踏襲。
+     * 拡張子は `VillageRpRestController.addFaceType` と同じホワイトリストで弾く
+     * (パストラバーサル + 想定外フォーマット防御)。
+     */
+    private fun validateDummyCharaImage(image: MultipartFile) {
+        if (image.size <= 0L || image.size > 100_000L) {
+            throw WolfMansionBusinessException("画像サイズは1〜100KBで指定してください")
+        }
+        val filename = image.originalFilename
+        val dotIndex = filename?.lastIndexOf('.') ?: -1
+        if (filename == null || dotIndex < 1 ||
+            filename.substring(dotIndex).lowercase() !in ALLOWED_IMAGE_EXTS
+        ) {
+            throw WolfMansionBusinessException(
+                "画像ファイルの拡張子は ${ALLOWED_IMAGE_EXTS.joinToString(" / ")} のみ対応しています"
+            )
+        }
+    }
+
+    private fun emptyCharachips(): Charachips = Charachips(list = emptyList())
+
+    private companion object {
+        val ALLOWED_IMAGE_EXTS: Set<String> = setOf(".png", ".jpg", ".jpeg", ".gif", ".webp")
     }
 
     @Schema(description = "作成された村の識別子")

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/NewVillageRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/NewVillageRestController.kt
@@ -2,6 +2,7 @@ package com.ort.app.api.v1.villages
 
 import com.ort.app.api.request.village.NewVillageCreateBody
 import com.ort.app.api.response.village.NewVillageFormView
+import com.ort.app.api.v1.support.ImageUploadValidator
 import com.ort.app.application.coordinator.VillageCoordinator
 import com.ort.app.application.service.CharaService
 import com.ort.app.application.service.PlayerService
@@ -113,7 +114,7 @@ class NewVillageRestController(
                 "shouldOriginalImage=true を指定してください (非オリジナル村は JSON endpoint を使用)。",
             )
         }
-        validateDummyCharaImage(dummyCharaImage)
+        ImageUploadValidator.validate(dummyCharaImage)
         villageCoordinator.assertCreateVillage(
             player, body.personMaxNum!!, charachips = emptyCharachips(), isOriginal = true,
         )
@@ -167,32 +168,7 @@ class NewVillageRestController(
         return player
     }
 
-    /**
-     * オリジナルキャラチップ村のダミーキャラ画像を検証する。
-     * 旧 `NewVillageFormValidator.validateDummyChara` のサイズ制限 (1〜100KB) を踏襲。
-     * 拡張子は `VillageRpRestController.addFaceType` と同じホワイトリストで弾く
-     * (パストラバーサル + 想定外フォーマット防御)。
-     */
-    private fun validateDummyCharaImage(image: MultipartFile) {
-        if (image.size <= 0L || image.size > 100_000L) {
-            throw WolfMansionBusinessException("画像サイズは1〜100KBで指定してください")
-        }
-        val filename = image.originalFilename
-        val dotIndex = filename?.lastIndexOf('.') ?: -1
-        if (filename == null || dotIndex < 1 ||
-            filename.substring(dotIndex).lowercase() !in ALLOWED_IMAGE_EXTS
-        ) {
-            throw WolfMansionBusinessException(
-                "画像ファイルの拡張子は ${ALLOWED_IMAGE_EXTS.joinToString(" / ")} のみ対応しています"
-            )
-        }
-    }
-
     private fun emptyCharachips(): Charachips = Charachips(list = emptyList())
-
-    private companion object {
-        val ALLOWED_IMAGE_EXTS: Set<String> = setOf(".png", ".jpg", ".jpeg", ".gif", ".webp")
-    }
 
     @Schema(description = "作成された村の識別子")
     data class CreatedVillageView(

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageParticipateRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageParticipateRestController.kt
@@ -6,9 +6,7 @@ import com.ort.app.api.response.chara.CharaView
 import com.ort.app.application.coordinator.VillageCoordinator
 import com.ort.app.application.service.CharaService
 import com.ort.app.domain.model.skill.Skill
-import com.ort.app.domain.model.village.Village
 import com.ort.app.fw.exception.WolfMansionBusinessException
-import com.ort.app.fw.exception.WolfMansionNotImplementedException
 import com.ort.app.fw.exception.WolfMansionRecordNotFoundException
 import com.ort.app.fw.interceptor.getIpAddress
 import com.ort.dbflute.allcommon.CDef
@@ -18,6 +16,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -26,15 +25,19 @@ import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
 
 /**
  * 入村 / 退村 / 見学切替 / 希望役職変更 / 選択可キャラ一覧の REST API。
  *
  * 既存 `VillageParticipateController` (Thymeleaf) の置き換え。
- * オリジナルキャラチップ村 (`isOriginalCharachip = true`) でのファイルアップロード入村は
- * 別途 multipart endpoint として将来追加する想定で、本 controller では 501 (Not Implemented)。
+ *
+ * オリジナルキャラチップ村 (`isOriginalCharachip = true`) は multipart 版エンドポイント
+ * (`POST /api/v1/villages/{id}/participate`, `consumes=multipart/form-data`) を使う。
+ * JSON 版は非オリジナル村専用。preview も同様 (画像不要、JSON で `assertParticipate` のみ)。
  *
  * `/participate/switch` は state-changing action だが、リクエスト body を持たない単純トグルで
  * あり PUT/PATCH より POST が自然と判断して POST のまま採用している。
@@ -52,7 +55,8 @@ class VillageParticipateRestController(
     @PostMapping("/{villageId}/participate/preview")
     @Operation(
         summary = "入村プレビュー (assertParticipate)",
-        description = "入村が可能か確認する。問題なければ 204、不正なら 400 (例外メッセージは ErrorResponse)。",
+        description = "入村が可能か確認する。問題なければ 204、不正なら 400 (例外メッセージは ErrorResponse)。" +
+                "オリジナルキャラチップ村でも JSON で OK (画像のサイズ等は最終 submit 時の multipart で検証)。",
     )
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun previewParticipate(
@@ -60,28 +64,77 @@ class VillageParticipateRestController(
         @Valid @RequestBody body: VillageParticipateBody,
     ) {
         val (village, player) = villageContextLoader.loadVillageAndPlayer(villageId)
-        rejectOriginalCharachipFlow(village)
         villageCoordinator.assertParticipate(
             village,
             player,
             body.charaId,
             body.charaName,
             body.charaShortName,
+            // オリジナル村でも preview は assertParticipate の charaImageFile 引数を null で許容する
+            // (`assertParticipate` 内部の `charaImageFile?.size == 0L` ガードは null では false 評価で素通り)。
+            // ファイルサイズ等の画像バリデーションは最終 submit (multipart) で行う。
             null,
             body.joinPassword,
             body.spectator,
         )
     }
 
-    @PostMapping("/{villageId}/participate")
-    @Operation(summary = "入村")
+    @PostMapping("/{villageId}/participate", consumes = [MediaType.APPLICATION_JSON_VALUE])
+    @Operation(
+        summary = "入村 (非オリジナルキャラチップ)",
+        description = "公式キャラチップ村への入村。オリジナル村は multipart 版 `POST /participate` を使う (400)。",
+    )
     @ResponseStatus(HttpStatus.CREATED)
     fun participate(
         @PathVariable villageId: Int,
         @Valid @RequestBody body: VillageParticipateBody,
     ) {
         val (village, player) = villageContextLoader.loadVillageAndPlayer(villageId)
-        rejectOriginalCharachipFlow(village)
+        if (village.setting.chara.isOriginalCharachip) {
+            throw WolfMansionBusinessException(
+                "オリジナルキャラチップ村は multipart endpoint を使用してください。",
+            )
+        }
+        val charaId = body.charaId
+            ?: throw WolfMansionBusinessException("キャラクターを選択してください")
+        val first = resolveSkill(body.requestedSkill)
+        val second = resolveSkill(body.secondRequestedSkill)
+        villageCoordinator.participate(
+            village,
+            player,
+            charaId,
+            body.charaName,
+            body.charaShortName,
+            null,
+            first,
+            second,
+            body.joinMessage,
+            body.joinPassword,
+            body.spectator,
+            httpServletRequest.getIpAddress(),
+        )
+    }
+
+    @PostMapping("/{villageId}/participate", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    @Operation(
+        summary = "入村 (オリジナルキャラチップ)",
+        description = "オリジナルキャラチップ村への入村。`body` (JSON、`VillageParticipateBody`) と `charaImage` (画像) の 2 パート構成。" +
+                "非オリジナル村に対してこの endpoint を呼ぶと 400。" +
+                "画像は 1〜100KB、許可拡張子は png / jpg / jpeg / gif / webp。",
+    )
+    @ResponseStatus(HttpStatus.CREATED)
+    fun participateOriginal(
+        @PathVariable villageId: Int,
+        @Valid @RequestPart("body") body: VillageParticipateBody,
+        @RequestPart("charaImage") charaImage: MultipartFile,
+    ) {
+        val (village, player) = villageContextLoader.loadVillageAndPlayer(villageId)
+        if (!village.setting.chara.isOriginalCharachip) {
+            throw WolfMansionBusinessException(
+                "オリジナルキャラチップ村ではないため multipart endpoint は使用できません。",
+            )
+        }
+        validateCharaImage(charaImage)
         val first = resolveSkill(body.requestedSkill)
         val second = resolveSkill(body.secondRequestedSkill)
         villageCoordinator.participate(
@@ -90,7 +143,7 @@ class VillageParticipateRestController(
             body.charaId,
             body.charaName,
             body.charaShortName,
-            null,
+            charaImage,
             first,
             second,
             body.joinMessage,
@@ -147,11 +200,23 @@ class VillageParticipateRestController(
         return villageCoordinator.findSelectableCharaList(villageId, charachip.id).map { CharaView(it) }
     }
 
-    private fun rejectOriginalCharachipFlow(village: Village) {
-        if (village.setting.chara.isOriginalCharachip) {
-            // multipart 画像アップロードを伴う original charachip 入村は別 endpoint で扱う予定。
-            throw WolfMansionNotImplementedException(
-                "オリジナルキャラチップ村への入村は現状この API では未対応です。",
+    /**
+     * オリジナルキャラチップ村入村時のキャラ画像を検証する。
+     * 旧 `VillageParticipateFormValidator.validateChara` のサイズ制限 (1〜100KB) を踏襲。
+     * 拡張子は `NewVillageRestController.validateDummyCharaImage` / `VillageRpRestController.addFaceType` と
+     * 同じホワイトリストで弾く。
+     */
+    private fun validateCharaImage(image: MultipartFile) {
+        if (image.size <= 0L || image.size > 100_000L) {
+            throw WolfMansionBusinessException("画像サイズは1〜100KBで指定してください")
+        }
+        val filename = image.originalFilename
+        val dotIndex = filename?.lastIndexOf('.') ?: -1
+        if (filename == null || dotIndex < 1 ||
+            filename.substring(dotIndex).lowercase() !in ALLOWED_IMAGE_EXTS
+        ) {
+            throw WolfMansionBusinessException(
+                "画像ファイルの拡張子は ${ALLOWED_IMAGE_EXTS.joinToString(" / ")} のみ対応しています"
             )
         }
     }
@@ -160,5 +225,9 @@ class VillageParticipateRestController(
         if (code.isNullOrBlank()) return Skill(CDef.Skill.おまかせ)
         return CDef.Skill.codeOf(code)?.let { Skill(it) }
             ?: throw WolfMansionBusinessException("skill not found. code=$code")
+    }
+
+    private companion object {
+        val ALLOWED_IMAGE_EXTS: Set<String> = setOf(".png", ".jpg", ".jpeg", ".gif", ".webp")
     }
 }

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageParticipateRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageParticipateRestController.kt
@@ -3,6 +3,7 @@ package com.ort.app.api.v1.villages
 import com.ort.app.api.request.village.VillageChangeRequestSkillBody
 import com.ort.app.api.request.village.VillageParticipateBody
 import com.ort.app.api.response.chara.CharaView
+import com.ort.app.api.v1.support.ImageUploadValidator
 import com.ort.app.application.coordinator.VillageCoordinator
 import com.ort.app.application.service.CharaService
 import com.ort.app.domain.model.skill.Skill
@@ -134,7 +135,7 @@ class VillageParticipateRestController(
                 "オリジナルキャラチップ村ではないため multipart endpoint は使用できません。",
             )
         }
-        validateCharaImage(charaImage)
+        ImageUploadValidator.validate(charaImage)
         val first = resolveSkill(body.requestedSkill)
         val second = resolveSkill(body.secondRequestedSkill)
         villageCoordinator.participate(
@@ -200,34 +201,9 @@ class VillageParticipateRestController(
         return villageCoordinator.findSelectableCharaList(villageId, charachip.id).map { CharaView(it) }
     }
 
-    /**
-     * オリジナルキャラチップ村入村時のキャラ画像を検証する。
-     * 旧 `VillageParticipateFormValidator.validateChara` のサイズ制限 (1〜100KB) を踏襲。
-     * 拡張子は `NewVillageRestController.validateDummyCharaImage` / `VillageRpRestController.addFaceType` と
-     * 同じホワイトリストで弾く。
-     */
-    private fun validateCharaImage(image: MultipartFile) {
-        if (image.size <= 0L || image.size > 100_000L) {
-            throw WolfMansionBusinessException("画像サイズは1〜100KBで指定してください")
-        }
-        val filename = image.originalFilename
-        val dotIndex = filename?.lastIndexOf('.') ?: -1
-        if (filename == null || dotIndex < 1 ||
-            filename.substring(dotIndex).lowercase() !in ALLOWED_IMAGE_EXTS
-        ) {
-            throw WolfMansionBusinessException(
-                "画像ファイルの拡張子は ${ALLOWED_IMAGE_EXTS.joinToString(" / ")} のみ対応しています"
-            )
-        }
-    }
-
     private fun resolveSkill(code: String?): Skill {
         if (code.isNullOrBlank()) return Skill(CDef.Skill.おまかせ)
         return CDef.Skill.codeOf(code)?.let { Skill(it) }
             ?: throw WolfMansionBusinessException("skill not found. code=$code")
-    }
-
-    private companion object {
-        val ALLOWED_IMAGE_EXTS: Set<String> = setOf(".png", ".jpg", ".jpeg", ".gif", ".webp")
     }
 }

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageRpRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageRpRestController.kt
@@ -5,6 +5,7 @@ import com.ort.app.api.request.village.VillageFaceTypeModifyBody
 import com.ort.app.api.request.village.VillageMemoBody
 import com.ort.app.api.response.myself.MyselfFaceTypeView
 import com.ort.app.api.response.myself.MyselfFaceTypesView
+import com.ort.app.api.v1.support.ImageUploadValidator
 import com.ort.app.application.coordinator.VillageCoordinator
 import com.ort.app.application.service.CharaService
 import com.ort.app.application.service.VillageService
@@ -50,11 +51,6 @@ class VillageRpRestController(
     private val charaService: CharaService,
     private val villageCoordinator: VillageCoordinator,
 ) {
-
-    private companion object {
-        /** 許可する画像拡張子 (小文字比較)。パストラバーサル防御 + 想定外フォーマットの拒否。 */
-        val ALLOWED_IMAGE_EXTS: Set<String> = setOf(".png", ".jpg", ".jpeg", ".gif", ".webp")
-    }
 
     @PutMapping("/{villageId}/rp/name")
     @Operation(summary = "キャラ名変更")
@@ -153,26 +149,10 @@ class VillageRpRestController(
         if (trimmedName.isEmpty() || trimmedName.length > 5) {
             throw WolfMansionBusinessException("表情差分名は1〜5文字で入力してください")
         }
-        // 旧 `VillageFaceTypeFormValidator.validateChara` と同条件 (1〜100,000 byte)
-        if (image.size <= 0L || image.size > 100_000L) {
-            throw WolfMansionBusinessException("画像サイズは1〜100KBで指定してください")
-        }
-        // `CharaDataSource.uploadCharaImage` は `originalFilename.lastIndexOf('.')` で
-        // 拡張子を取り出すため、originalFilename が null か `.` を含まないと NPE /
-        // StringIndexOutOfBoundsException で 500 になる (旧 Thymeleaf endpoint も同じ穴を持つ
-        // が、本 endpoint 追加で曝露が広がるため境界側で先回り検証する)。
-        // `lastIndexOf('.') >= 1` で `.hidden` のようなドット始まりファイル
-        // (ext がファイル名全体になってしまう) を弾く。さらに ext は
-        // 許可済み画像拡張子 (png / jpg / jpeg / gif / webp) のホワイトリストでのみ許可。
-        // (`x.sh/../../etc/passwd` 等のパストラバーサル + 想定外フォーマットの拒否)
-        val filename = image.originalFilename
-        val dotIndex = filename?.lastIndexOf('.') ?: -1
-        if (filename == null || dotIndex < 1 ||
-            filename.substring(dotIndex).lowercase() !in ALLOWED_IMAGE_EXTS) {
-            throw WolfMansionBusinessException(
-                "画像ファイルの拡張子は ${ALLOWED_IMAGE_EXTS.joinToString(" / ")} のみ対応しています"
-            )
-        }
+        // サイズ / 拡張子は他のアップロード endpoint と共通の ImageUploadValidator で検証する。
+        // `CharaDataSource.uploadCharaImage` 側でも拡張子を切り出すが、境界 (controller) で
+        // 先回り検証してエラーメッセージを統一する。
+        ImageUploadValidator.validate(image)
         charaService.registerOriginalCharaImage(
             village.setting.chara.charachipIds.first(),
             myself.charaId,

--- a/backend/src/test/kotlin/com/ort/app/api/v1/villages/VillageParticipateRestControllerTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/api/v1/villages/VillageParticipateRestControllerTest.kt
@@ -111,7 +111,7 @@ class VillageParticipateRestControllerTest {
     }
 
     @Test
-    fun `POST participate オリジナルキャラチップ村は 501 Not Implemented`() {
+    fun `POST participate オリジナルキャラチップ村に JSON 版を叩くと 400`() {
         val original = createPrologueVillage().let { v ->
             v.copy(
                 id = 3,
@@ -126,12 +126,14 @@ class VillageParticipateRestControllerTest {
             "charaShortName" to "太",
             "joinMessage" to "よろしく",
         )
+        // 旧仕様では 501 を返していたが、Step 8i で multipart 版 endpoint を追加したため
+        // 「JSON 版に対しオリジナル村」のケースは 400 (multipart endpoint を使えという案内) に変更
         mockMvc.perform(
             post("/api/v1/villages/3/participate")
                 .with(authed())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(mapper.writeValueAsString(body))
-        ).andExpect(status().isNotImplemented)
+        ).andExpect(status().isBadRequest)
     }
 
     @Test

--- a/frontend/app/features/village/detail/ParticipateActions.tsx
+++ b/frontend/app/features/village/detail/ParticipateActions.tsx
@@ -127,7 +127,7 @@ function ParticipateForm({ village }: { village: VillageView }) {
         )}
 
         {isOriginal && (
-          <Field label="キャラ画像 (1〜100KB、png/jpg/jpeg/gif/webp)">
+          <Field label="キャラ画像 (最大 100,000 byte、png/jpg/jpeg/gif/webp)">
             <input
               type="file"
               accept=".png,.jpg,.jpeg,.gif,.webp,image/png,image/jpeg,image/gif,image/webp"

--- a/frontend/app/features/village/detail/ParticipateActions.tsx
+++ b/frontend/app/features/village/detail/ParticipateActions.tsx
@@ -18,8 +18,8 @@ import type {
  * - 未参加 (myself=null): 入村フォーム (キャラ選択 / 希望役職 / メッセージ / 入村パスワード / 見学トグル)
  * - 参加中: 「参加/見学切替」「希望役職変更」「退村」アクション
  *
- * オリジナルキャラチップ村 (`isOriginalCharachip=true`) は multipart 入村 endpoint 未実装のため、
- * 入村 UI は出さず案内テキストのみ表示する。
+ * オリジナルキャラチップ村 (`isOriginalCharachip=true`) では、公式キャラ一覧の代わりに
+ * キャラ名 (必須) + キャラ画像アップロードを受け付け、`postParticipateOriginal` (multipart) を叩く。
  */
 export function ParticipateActions({
   village,
@@ -42,11 +42,11 @@ export function ParticipateActions({
 
 function ParticipateForm({ village }: { village: VillageView }) {
   const { settings, requestableSkills } = village;
+  const isOriginal = settings.isOriginalCharachip;
 
-  // hooks のルール上、early return より前にすべての hook を呼び出す必要がある。
-  // オリジナルキャラチップ村ではキャラ一覧 fetch を発行しない (空配列)。
+  // オリジナル村ではキャラ一覧 fetch を発行しない (空配列)。
   // 通常村は複数キャラチップを持つことがあるので、全 ID に対して並列クエリして結合する。
-  const charachipIds = settings.isOriginalCharachip ? [] : settings.charachipIds;
+  const charachipIds = isOriginal ? [] : settings.charachipIds;
   const charasQuery = useSelectableCharasQuery(village.id, charachipIds);
 
   const mutation = useParticipateMutation(village.id);
@@ -54,21 +54,12 @@ function ParticipateForm({ village }: { village: VillageView }) {
   const [charaId, setCharaId] = useState<number | null>(null);
   const [charaName, setCharaName] = useState("");
   const [charaShortName, setCharaShortName] = useState("");
+  const [charaImage, setCharaImage] = useState<File | null>(null);
   const [joinMessage, setJoinMessage] = useState("");
   const [joinPassword, setJoinPassword] = useState("");
   const [spectator, setSpectator] = useState(false);
   const [requestedSkill, setRequestedSkill] = useState<string>("");
   const [secondRequestedSkill, setSecondRequestedSkill] = useState<string>("");
-
-  if (settings.isOriginalCharachip) {
-    return (
-      <Panel title="入村">
-        <p className="text-slate-400 text-sm">
-          オリジナルキャラチップ村への入村は現在この画面では未対応です (旧画面 / API 拡張 予定)。
-        </p>
-      </Panel>
-    );
-  }
 
   function onSelectChara(id: number) {
     setCharaId(id);
@@ -81,10 +72,17 @@ function ParticipateForm({ village }: { village: VillageView }) {
 
   function submit(e: React.FormEvent) {
     e.preventDefault();
-    if (charaId == null) return;
     if (!charaName.trim() || !charaShortName.trim() || !joinMessage.trim()) return;
-    mutation.mutate({
-      charaId,
+    if (isOriginal) {
+      // オリジナル村は charaId 不要、画像必須
+      if (!charaImage) return;
+    } else {
+      // 公式キャラチップ村は charaId 必須
+      if (charaId == null) return;
+    }
+    const body = {
+      // オリジナル村では charaId 未送信 (multipart endpoint で動的に chara を作る)
+      charaId: isOriginal ? undefined : (charaId ?? undefined),
       charaName: charaName.trim(),
       charaShortName: charaShortName.trim(),
       joinMessage: joinMessage.trim(),
@@ -94,6 +92,10 @@ function ParticipateForm({ village }: { village: VillageView }) {
         settings.isSkillRequestAvailable && secondRequestedSkill ? secondRequestedSkill : undefined,
       joinPassword: settings.joinPasswordRequired ? joinPassword : undefined,
       spectator,
+    };
+    mutation.mutate({
+      body,
+      charaImage: isOriginal && charaImage ? charaImage : undefined,
     });
   }
 
@@ -102,7 +104,7 @@ function ParticipateForm({ village }: { village: VillageView }) {
   // backend の MessageContent.assertMessageRestrict はプロローグでは early return するため、
   // 入村メッセージの長さ上限を frontend で吸収する (旧 Thymeleaf も同様に 400 文字制限)。
   const submittable =
-    charaId != null &&
+    (isOriginal ? charaImage != null : charaId != null) &&
     charaName.trim().length > 0 &&
     charaShortName.trim().length === 1 &&
     joinMessage.trim().length > 0 &&
@@ -112,15 +114,34 @@ function ParticipateForm({ village }: { village: VillageView }) {
   return (
     <Panel title="入村">
       <form onSubmit={submit} className="space-y-3">
-        <Field label="キャラ">
-          {isLoadingCharas ? (
-            <p className="text-slate-400 text-sm">読み込み中...</p>
-          ) : charas.length === 0 ? (
-            <p className="text-slate-400 text-sm">選択可能なキャラがいません</p>
-          ) : (
-            <CharaGrid charas={charas} selectedId={charaId} onSelect={onSelectChara} />
-          )}
-        </Field>
+        {!isOriginal && (
+          <Field label="キャラ">
+            {isLoadingCharas ? (
+              <p className="text-slate-400 text-sm">読み込み中...</p>
+            ) : charas.length === 0 ? (
+              <p className="text-slate-400 text-sm">選択可能なキャラがいません</p>
+            ) : (
+              <CharaGrid charas={charas} selectedId={charaId} onSelect={onSelectChara} />
+            )}
+          </Field>
+        )}
+
+        {isOriginal && (
+          <Field label="キャラ画像 (1〜100KB、png/jpg/jpeg/gif/webp)">
+            <input
+              type="file"
+              accept=".png,.jpg,.jpeg,.gif,.webp,image/png,image/jpeg,image/gif,image/webp"
+              onChange={(e) => setCharaImage(e.target.files?.[0] ?? null)}
+              className={inputClass}
+              disabled={mutation.isPending}
+            />
+            {charaImage && (
+              <p className="text-xs text-slate-400 mt-1">
+                {charaImage.name} ({Math.round(charaImage.size / 1024)} KB)
+              </p>
+            )}
+          </Field>
+        )}
 
         <Field label="表示名">
           <input

--- a/frontend/app/features/village/detail/api.ts
+++ b/frontend/app/features/village/detail/api.ts
@@ -164,7 +164,7 @@ async function readErrorMessage(res: Response): Promise<string> {
   return errBody;
 }
 
-/** POST /api/v1/villages/{id}/participate */
+/** POST /api/v1/villages/{id}/participate (非オリジナル、JSON) */
 export async function postParticipate(
   villageId: number,
   body: VillageParticipateBody,
@@ -176,6 +176,33 @@ export async function postParticipate(
   });
   if (!res.ok) {
     throw new Error(`participate failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+}
+
+/**
+ * POST /api/v1/villages/{id}/participate (オリジナルキャラチップ、multipart)。
+ *
+ * `body` (JSON Content-Type 明示) + `charaImage` (画像) の 2 パート構成。
+ * 非オリジナル村にこれを呼ぶと backend が 400 を返す。
+ */
+export async function postParticipateOriginal(
+  villageId: number,
+  body: VillageParticipateBody,
+  charaImage: File,
+  fetcher: ApiFetch = browserFetch,
+): Promise<void> {
+  const form = new FormData();
+  form.append(
+    "body",
+    new Blob([JSON.stringify(body)], { type: "application/json" }),
+  );
+  form.append("charaImage", charaImage);
+  const res = await fetcher(`/api/v1/villages/${villageId}/participate`, {
+    method: "POST",
+    body: form,
+  });
+  if (!res.ok) {
+    throw new Error(`participate (original) failed: ${res.status} ${await readErrorMessage(res)}`);
   }
 }
 

--- a/frontend/app/features/village/detail/hooks.ts
+++ b/frontend/app/features/village/detail/hooks.ts
@@ -28,6 +28,7 @@ import {
   postFaceType,
   postKick,
   postParticipate,
+  postParticipateOriginal,
   postSay,
   postShortenEpilogue,
   postSwitchParticipate,
@@ -171,12 +172,29 @@ export function useSelectableCharasQuery(
   return { data, isLoading, isError, error: errorResult?.error ?? undefined };
 }
 
+/**
+ * 入村 mutation。非オリジナル / オリジナルキャラチップ村両対応。
+ *
+ * `charaImage` が渡されたら multipart endpoint、そうでなければ JSON endpoint。
+ * 呼び出し側で村の `isOriginalCharachip` と image の有無を整合させる。
+ */
 export function useParticipateMutation(
   villageId: number,
-): UseMutationResult<void, Error, VillageParticipateBody> {
+): UseMutationResult<
+  void,
+  Error,
+  { body: VillageParticipateBody; charaImage?: File }
+> {
   const queryClient = useQueryClient();
-  return useMutation<void, Error, VillageParticipateBody>({
-    mutationFn: (body) => postParticipate(villageId, body),
+  return useMutation<
+    void,
+    Error,
+    { body: VillageParticipateBody; charaImage?: File }
+  >({
+    mutationFn: ({ body, charaImage }) =>
+      charaImage
+        ? postParticipateOriginal(villageId, body, charaImage)
+        : postParticipate(villageId, body),
     onSuccess: () => invalidateVillage(queryClient, villageId),
   });
 }

--- a/frontend/app/features/village/new/NewVillageForm.tsx
+++ b/frontend/app/features/village/new/NewVillageForm.tsx
@@ -255,14 +255,15 @@ function CharaSection({
   }
 
   function toggleOriginal(checked: boolean) {
-    // オリジナル切替時はキャラチップ / ダミーキャラ選択をリセット (相互に意味を持たないため)
+    // オリジナル ⇄ 公式切替時は反対側の入力をリセット (相互に意味を持たないため)。
+    // 古い `dummyCharaImage` ファイルが残ったまま再切替で混入しないよう、どちらの方向でもリセット。
     setBody((s) => ({
       ...s,
       shouldOriginalImage: checked,
       characterSetId: checked ? [] : s.characterSetId,
       dummyCharaId: checked ? null : s.dummyCharaId,
     }));
-    if (!checked) setDummyCharaImage(null);
+    setDummyCharaImage(null);
   }
 
   return (
@@ -331,7 +332,7 @@ function CharaSection({
       )}
 
       {isOriginal && (
-        <Field label="ダミーキャラ画像 (1〜100KB、png/jpg/jpeg/gif/webp)">
+        <Field label="ダミーキャラ画像 (最大 100,000 byte、png/jpg/jpeg/gif/webp)">
           <input
             type="file"
             accept=".png,.jpg,.jpeg,.gif,.webp,image/png,image/jpeg,image/gif,image/webp"

--- a/frontend/app/features/village/new/NewVillageForm.tsx
+++ b/frontend/app/features/village/new/NewVillageForm.tsx
@@ -12,14 +12,17 @@ import { fetchCharachipDetail, type CharachipDetailView } from "~/features/meta/
  * を追加。
  *
  * 確認画面は SPA 内 `<dialog>` ベース (旧 `/new-village/confirm` は不要)。
- * オリジナルキャラチップ村 (`shouldOriginalImage=true`) は backend が 501 を返すので
- * UI でも初期 false / 切り替え不可。後続 step で multipart 対応する予定。
+ *
+ * オリジナルキャラチップ村 (`shouldOriginalImage=true`):
+ * - チップ / ダミーキャラ選択 UI を隠し、ダミーキャラ画像ファイル入力を出す
+ * - 送信時 multipart endpoint (`postNewVillageOriginal`) に切り替え
  *
  * cross-field バリデーションは backend に任せ、フロントでは Required と type のみ最低限。
  */
 export function NewVillageForm({ initial }: { initial: NewVillageFormView }) {
   const navigate = useNavigate();
   const [body, setBody] = useState<NewVillageCreateBody>(() => toInitialBody(initial.defaults));
+  const [dummyCharaImage, setDummyCharaImage] = useState<File | null>(null);
   const mutation = useCreateVillageMutation();
   const [confirmOpen, setConfirmOpen] = useState(false);
 
@@ -83,12 +86,20 @@ export function NewVillageForm({ initial }: { initial: NewVillageFormView }) {
   }
 
   function submit() {
-    mutation.mutate(body, {
-      onSuccess: (res) => {
-        setConfirmOpen(false);
-        navigate(`/villages/${res.id}`);
+    // オリジナル村: shouldOriginalImage=true かつ画像必須
+    if (body.shouldOriginalImage && !dummyCharaImage) return;
+    mutation.mutate(
+      {
+        body,
+        dummyCharaImage: body.shouldOriginalImage ? dummyCharaImage ?? undefined : undefined,
       },
-    });
+      {
+        onSuccess: (res) => {
+          setConfirmOpen(false);
+          navigate(`/villages/${res.id}`);
+        },
+      },
+    );
   }
 
   return (
@@ -101,6 +112,8 @@ export function NewVillageForm({ initial }: { initial: NewVillageFormView }) {
           options={initial.options}
           allCharas={allCharas}
           charaListByChip={charaListByChip}
+          dummyCharaImage={dummyCharaImage}
+          setDummyCharaImage={setDummyCharaImage}
         />
         <DummyCharaSection body={body} setBody={setBody} />
         <TagSection body={body} setBody={setBody} options={initial.options} />
@@ -135,6 +148,7 @@ export function NewVillageForm({ initial }: { initial: NewVillageFormView }) {
         <ConfirmDialog
           body={body}
           allCharas={allCharas}
+          dummyCharaImage={dummyCharaImage}
           onCancel={() => setConfirmOpen(false)}
           onSubmit={submit}
           isPending={mutation.isPending}
@@ -212,12 +226,17 @@ function CharaSection({
   options,
   allCharas,
   charaListByChip,
+  dummyCharaImage,
+  setDummyCharaImage,
 }: SectionProps & {
   options: NewVillageFormView["options"];
   allCharas: CharachipDetailView["charas"];
   charaListByChip: Map<number, CharachipDetailView>;
+  dummyCharaImage: File | null;
+  setDummyCharaImage: (file: File | null) => void;
 }) {
   const characterSetId = body.characterSetId ?? [];
+  const isOriginal = !!body.shouldOriginalImage;
 
   function toggleChip(chipId: number, checked: boolean) {
     setBody((s) => {
@@ -235,43 +254,98 @@ function CharaSection({
     });
   }
 
+  function toggleOriginal(checked: boolean) {
+    // オリジナル切替時はキャラチップ / ダミーキャラ選択をリセット (相互に意味を持たないため)
+    setBody((s) => ({
+      ...s,
+      shouldOriginalImage: checked,
+      characterSetId: checked ? [] : s.characterSetId,
+      dummyCharaId: checked ? null : s.dummyCharaId,
+    }));
+    if (!checked) setDummyCharaImage(null);
+  }
+
   return (
     <Section title="キャラクター設定">
-      <Field label="キャラチップ (複数選択可)">
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-1">
-          {options.charachips.map((c) => {
-            const checked = characterSetId.includes(c.id);
-            return (
-              <label key={c.id} className="flex items-center gap-2 text-sm border border-slate-700 rounded px-2 py-1.5">
-                <input
-                  type="checkbox"
-                  checked={checked}
-                  onChange={(e) => toggleChip(c.id, e.target.checked)}
-                />
-                <img src={c.dummyImageUrl} width={c.dummyImageWidth} height={c.dummyImageHeight} alt={c.name} className="bg-slate-900/60 rounded" />
-                <div className="flex-1 min-w-0">
-                  <span className="block truncate">{c.name}</span>
-                  <span className="block text-xs text-slate-400 truncate">{c.designerName} / {c.charaCount}キャラ</span>
-                </div>
-              </label>
-            );
-          })}
+      <Field label="画像形式">
+        <div className="flex flex-col gap-1 text-sm">
+          <label className="flex items-center gap-2">
+            <input
+              type="radio"
+              name="shouldOriginalImage"
+              checked={!isOriginal}
+              onChange={() => toggleOriginal(false)}
+            />
+            <span>公式キャラチップを使用</span>
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="radio"
+              name="shouldOriginalImage"
+              checked={isOriginal}
+              onChange={() => toggleOriginal(true)}
+            />
+            <span>オリジナル画像を使用 (ダミーキャラ画像のアップロードが必要)</span>
+          </label>
         </div>
       </Field>
 
-      <Field label="ダミーキャラ (選択キャラチップ内から)">
-        <select
-          value={body.dummyCharaId ?? ""}
-          onChange={(e) => setBody((s) => ({ ...s, dummyCharaId: e.target.value ? Number(e.target.value) : null }))}
-          className={inputClass}
-          required
-        >
-          <option value="">選択してください</option>
-          {allCharas.map((c) => (
-            <option key={c.id} value={c.id}>{c.name} [{c.shortName}]</option>
-          ))}
-        </select>
-      </Field>
+      {!isOriginal && (
+        <>
+          <Field label="キャラチップ (複数選択可)">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-1">
+              {options.charachips.map((c) => {
+                const checked = characterSetId.includes(c.id);
+                return (
+                  <label key={c.id} className="flex items-center gap-2 text-sm border border-slate-700 rounded px-2 py-1.5">
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={(e) => toggleChip(c.id, e.target.checked)}
+                    />
+                    <img src={c.dummyImageUrl} width={c.dummyImageWidth} height={c.dummyImageHeight} alt={c.name} className="bg-slate-900/60 rounded" />
+                    <div className="flex-1 min-w-0">
+                      <span className="block truncate">{c.name}</span>
+                      <span className="block text-xs text-slate-400 truncate">{c.designerName} / {c.charaCount}キャラ</span>
+                    </div>
+                  </label>
+                );
+              })}
+            </div>
+          </Field>
+
+          <Field label="ダミーキャラ (選択キャラチップ内から)">
+            <select
+              value={body.dummyCharaId ?? ""}
+              onChange={(e) => setBody((s) => ({ ...s, dummyCharaId: e.target.value ? Number(e.target.value) : null }))}
+              className={inputClass}
+              required
+            >
+              <option value="">選択してください</option>
+              {allCharas.map((c) => (
+                <option key={c.id} value={c.id}>{c.name} [{c.shortName}]</option>
+              ))}
+            </select>
+          </Field>
+        </>
+      )}
+
+      {isOriginal && (
+        <Field label="ダミーキャラ画像 (1〜100KB、png/jpg/jpeg/gif/webp)">
+          <input
+            type="file"
+            accept=".png,.jpg,.jpeg,.gif,.webp,image/png,image/jpeg,image/gif,image/webp"
+            onChange={(e) => setDummyCharaImage(e.target.files?.[0] ?? null)}
+            className={inputClass}
+            required
+          />
+          {dummyCharaImage && (
+            <p className="text-xs text-slate-400 mt-1">
+              {dummyCharaImage.name} ({Math.round(dummyCharaImage.size / 1024)} KB)
+            </p>
+          )}
+        </Field>
+      )}
     </Section>
   );
 }
@@ -679,6 +753,7 @@ function RestrictRow({
 function ConfirmDialog({
   body,
   allCharas,
+  dummyCharaImage,
   onCancel,
   onSubmit,
   isPending,
@@ -686,6 +761,7 @@ function ConfirmDialog({
 }: {
   body: NewVillageCreateBody;
   allCharas: CharachipDetailView["charas"];
+  dummyCharaImage: File | null;
   onCancel: () => void;
   onSubmit: () => void;
   isPending: boolean;
@@ -693,6 +769,7 @@ function ConfirmDialog({
 }) {
   const dummyChara = allCharas.find((c) => c.id === body.dummyCharaId);
   const startStr = `${body.startYear}/${pad2(body.startMonth ?? 0)}/${pad2(body.startDay ?? 0)} ${pad2(body.startHour ?? 0)}:${pad2(body.startMinute ?? 0)}`;
+  const isOriginal = !!body.shouldOriginalImage;
   return (
     <div className="fixed inset-0 bg-black/70 flex items-center justify-center p-4 z-50">
       <div className="max-w-md w-full bg-slate-900 border border-slate-700 rounded-xl p-5 space-y-4 max-h-[90vh] overflow-y-auto">
@@ -703,7 +780,13 @@ function ConfirmDialog({
           <Row k="開始日時" v={startStr} />
           <Row k="更新間隔" v={`${body.dayChangeIntervalHours}h ${body.dayChangeIntervalMinutes}m ${body.dayChangeIntervalSeconds}s`} />
           <Row k="編成" v={body.randomOrganization ? "闇鍋編成" : "固定編成"} />
-          <Row k="ダミーキャラ" v={dummyChara ? `${dummyChara.name} (${dummyChara.shortName})` : `${body.dummyCharaName} (${body.dummyCharaShortName})`} />
+          <Row k="画像" v={isOriginal ? "オリジナル画像" : "公式キャラチップ"} />
+          {!isOriginal && (
+            <Row k="ダミーキャラ" v={dummyChara ? `${dummyChara.name} (${dummyChara.shortName})` : `${body.dummyCharaName} (${body.dummyCharaShortName})`} />
+          )}
+          {isOriginal && dummyCharaImage && (
+            <Row k="ダミー画像" v={`${dummyCharaImage.name} (${Math.round(dummyCharaImage.size / 1024)} KB)`} />
+          )}
           <Row k="表示名" v={body.dummyCharaName ?? ""} />
         </dl>
         <p className="text-xs text-slate-400">

--- a/frontend/app/features/village/new/api.ts
+++ b/frontend/app/features/village/new/api.ts
@@ -40,7 +40,7 @@ export async function fetchNewVillageDefaults(
   return res.json();
 }
 
-/** POST /api/v1/villages — 新規村作成。201 で `{ id }` を返す。 */
+/** POST /api/v1/villages — 新規村作成 (非オリジナル、JSON)。201 で `{ id }` を返す。 */
 export async function postNewVillage(
   body: NewVillageCreateBody,
   fetcher: ApiFetch = browserFetch,
@@ -51,6 +51,35 @@ export async function postNewVillage(
   });
   if (!res.ok) {
     throw new Error(`new-village create failed: ${res.status} ${await readErrorMessage(res)}`);
+  }
+  return res.json();
+}
+
+/**
+ * POST /api/v1/villages — 新規村作成 (オリジナルキャラチップ、multipart)。
+ *
+ * 2 パート構成: `body` (JSON、Content-Type 明示が必要) + `dummyCharaImage` (画像ファイル)。
+ * `body.shouldOriginalImage=true` が必須 (backend で再検証)。
+ */
+export async function postNewVillageOriginal(
+  body: NewVillageCreateBody,
+  dummyCharaImage: File,
+  fetcher: ApiFetch = browserFetch,
+): Promise<CreatedVillageView> {
+  const form = new FormData();
+  // Spring の `@RequestPart @Valid body: NewVillageCreateBody` で Jackson が JSON として
+  // パースするため、Blob に `application/json` の Content-Type を明示する必要がある。
+  form.append(
+    "body",
+    new Blob([JSON.stringify(body)], { type: "application/json" }),
+  );
+  form.append("dummyCharaImage", dummyCharaImage);
+  const res = await fetcher(`/api/v1/villages`, {
+    method: "POST",
+    body: form,
+  });
+  if (!res.ok) {
+    throw new Error(`new-village create (original) failed: ${res.status} ${await readErrorMessage(res)}`);
   }
   return res.json();
 }

--- a/frontend/app/features/village/new/hooks.ts
+++ b/frontend/app/features/village/new/hooks.ts
@@ -7,6 +7,7 @@ import {
 import {
   fetchNewVillageDefaults,
   postNewVillage,
+  postNewVillageOriginal,
   type CreatedVillageView,
   type NewVillageCreateBody,
   type NewVillageFormView,
@@ -32,12 +33,25 @@ export function useNewVillageDefaultsQuery(
   });
 }
 
+/**
+ * 非オリジナル / オリジナルキャラチップ村両対応の作成 mutation。
+ *
+ * `dummyCharaImage` が渡されたら multipart endpoint、そうでなければ JSON endpoint。
+ * 呼び出し側で `body.shouldOriginalImage` と画像の有無を整合させる。
+ */
 export function useCreateVillageMutation(): UseMutationResult<
   CreatedVillageView,
   Error,
-  NewVillageCreateBody
+  { body: NewVillageCreateBody; dummyCharaImage?: File }
 > {
-  return useMutation<CreatedVillageView, Error, NewVillageCreateBody>({
-    mutationFn: (body) => postNewVillage(body),
+  return useMutation<
+    CreatedVillageView,
+    Error,
+    { body: NewVillageCreateBody; dummyCharaImage?: File }
+  >({
+    mutationFn: ({ body, dummyCharaImage }) =>
+      dummyCharaImage
+        ? postNewVillageOriginal(body, dummyCharaImage)
+        : postNewVillage(body),
   });
 }


### PR DESCRIPTION
Step 8a (入村) / Step 8h (新規村作成) で 501 にしていた original charachip フローを
multipart endpoint として実装。

## 変更内容

### backend

- `POST /api/v1/villages` を `consumes` で 2 系統に分岐
  - `application/json` → 公式キャラチップ村 (既存挙動、`shouldOriginalImage=true` は 400)
  - `multipart/form-data` → オリジナルキャラチップ村 (`body` JSON part + `dummyCharaImage` file part)
- `POST /api/v1/villages/{id}/participate` も同様
  - `application/json` → 公式キャラチップ村 (`charaId` 必須、オリジナル村は 400)
  - `multipart/form-data` → オリジナルキャラチップ村 (`body` JSON + `charaImage` file)
- `VillageParticipateBody.charaId` を `Int?` に変更 (オリジナル村では null 可)
- 画像バリデーション (1〜100KB、png/jpg/jpeg/gif/webp ホワイトリスト) は
  PR #26 (`VillageRpRestController.addFaceType`) と同条件
- `WolfMansionNotImplementedException` の使用箇所削除 (501 → 400 へ吸収)

### frontend

- `useCreateVillageMutation` / `useParticipateMutation` を `{ body, image? }` 形式に変更し、
  画像有無で multipart / JSON endpoint を自動切替
- 新規村作成フォーム
  - 「画像形式」ラジオで公式キャラチップ vs オリジナル画像を切替
  - オリジナル時はキャラチップ / ダミーキャラ選択 UI を隠してダミー画像 file input に置換
  - 確認ダイアログにオリジナル画像のファイル名 / サイズを表示
- `ParticipateActions`
  - オリジナル村でも入村フォームを出すよう変更 (旧 "未対応" 表示を撤去)
  - キャラ一覧の代わりにキャラ画像 file input
  - キャラ名 / 略称 / 入村メッセージ等は共通

## 動作確認

- [x] backend: `./gradlew test` pass
- [x] frontend: `pnpm typecheck && pnpm test && pnpm build` pass
- [ ] ユーザー手動確認依頼:
  - オリジナルキャラチップ村を「画像形式」=オリジナルで作成し、ダミー画像が登録されること
  - 公式キャラチップ村に対する旧フロー (JSON) が引き続き動作すること
  - オリジナル村への入村フォームで画像アップロード → 201、村画面にキャラ画像が表示されること
  - 公式キャラチップ村に multipart endpoint を叩くと 400 (frontend は呼ばないが直叩き耐性)

## 既知の制約 / 後続対応

- `divert` (既存村から流用) は本 PR 対象外 (Step 8h 同様、後続 step で別途追加)
- 401 vs 400 のセマンティクス統一は Step 11 cutover 時に一括対応 (HANDOFF.md 参照)