### PR TITLE
Step 10: E2E 初期化 (Playwright, auth / village smoke)

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.auth/
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/

--- a/e2e/.npmrc
+++ b/e2e/.npmrc
@@ -1,0 +1,5 @@
+registry=https://registry.npmjs.org/
+# サプライチェーン対策: post-install スクリプトをデフォルトで実行しない
+ignore-scripts=true
+fund=false
+audit=false

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,45 @@
+# e2e — wolf-mansion E2E テスト (Playwright)
+
+`backend/` `frontend/` と並列のトップディレクトリ。Playwright で
+frontend (`http://localhost:5173/wolf-mansion`) をブラウザ操作して検証する。
+
+## 前提
+
+E2E 実行前に以下を起動しておくこと:
+
+| サービス | 起動方法 |
+|---|---|
+| MySQL (:4306) | `werewolf_mansiondb` がローカルで稼働していること |
+| backend (:8089) | `cd backend && JAVA_HOME=<zulu-21> ./gradlew bootRun` |
+
+frontend dev server (:5173) は `playwright.config.ts` の `webServer` が自動起動する
+(既に起動済みなら `reuseExistingServer` で再利用)。
+
+テストユーザはローカル DB の `testuser01` 〜 / `master`。パスワードは全員 `testuser`。
+
+## セットアップ
+
+```bash
+cd e2e
+pnpm install --frozen-lockfile
+pnpm exec playwright install chromium
+```
+
+## 実行
+
+```bash
+pnpm test          # ヘッドレス実行
+pnpm test:ui       # UI モード
+pnpm report        # 直近の HTML レポートを開く
+```
+
+`globalSetup` が `testuser01` でログインし `.auth/player.json` に storageState を
+保存する。認証が必要なテストはこれを再利用する。
+
+## スコープ (第一段階)
+
+- auth: ログイン成功 / 失敗、ログアウト、未認証ガード
+- village: トップ / 村一覧の表示
+
+村作成・参加・発言・能力・日付更新・足音隠蔽・admin 操作などの game-flow
+シナリオは後続フェーズ (`.issues/` 参照)。CI workflow も後続。

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -28,6 +28,7 @@ pnpm exec playwright install chromium
 ## 実行
 
 ```bash
+cd e2e
 pnpm test          # ヘッドレス実行
 pnpm test:ui       # UI モード
 pnpm report        # 直近の HTML レポートを開く

--- a/e2e/fixtures/users.ts
+++ b/e2e/fixtures/users.ts
@@ -1,0 +1,9 @@
+/**
+ * テスト用ユーザ。ローカル DB に投入済みのプレイヤーで、パスワードは全員 `testuser`。
+ */
+export const USERS = {
+  /** 一般プレイヤー権限 */
+  player: { userId: "testuser01", password: "testuser" },
+  /** 管理者権限 */
+  admin: { userId: "master", password: "testuser" },
+} as const;

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,29 @@
+import { chromium, type FullConfig } from "@playwright/test";
+import { mkdirSync } from "node:fs";
+import { USERS } from "./fixtures/users";
+import { APP, PLAYER_STORAGE } from "./helpers/app";
+
+/**
+ * テスト用 player でログインし、認証 Cookie を storageState として保存する。
+ * 認証が必要なテストは `test.use({ storageState: PLAYER_STORAGE })` で再利用する。
+ */
+async function globalSetup(config: FullConfig): Promise<void> {
+  const origin = config.projects[0]?.use?.baseURL ?? "http://localhost:5173";
+  mkdirSync(".auth", { recursive: true });
+
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage();
+    await page.goto(`${origin}${APP}/login`);
+    await page.fill("#userId", USERS.player.userId);
+    await page.fill("#password", USERS.player.password);
+    await page.click('button[type="submit"]');
+    // ログイン成功でトップ (basename 直下) へ遷移する
+    await page.waitForURL(new RegExp(`${APP}/?$`));
+    await page.context().storageState({ path: PLAYER_STORAGE });
+  } finally {
+    await browser.close();
+  }
+}
+
+export default globalSetup;

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,23 +1,27 @@
 import { chromium, type FullConfig } from "@playwright/test";
 import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
 import { USERS } from "./fixtures/users";
 import { APP, PLAYER_STORAGE } from "./helpers/app";
 
 /**
  * テスト用 player でログインし、認証 Cookie を storageState として保存する。
  * 認証が必要なテストは `test.use({ storageState: PLAYER_STORAGE })` で再利用する。
+ *
+ * globalSetup は `page` fixture / baseURL を使えないため、origin を config から
+ * 取得して URL を自前で組み立てる (各 spec は baseURL 相対で書ける)。
  */
 async function globalSetup(config: FullConfig): Promise<void> {
   const origin = config.projects[0]?.use?.baseURL ?? "http://localhost:5173";
-  mkdirSync(".auth", { recursive: true });
+  mkdirSync(dirname(PLAYER_STORAGE), { recursive: true });
 
   const browser = await chromium.launch();
   try {
     const page = await browser.newPage();
     await page.goto(`${origin}${APP}/login`);
-    await page.fill("#userId", USERS.player.userId);
-    await page.fill("#password", USERS.player.password);
-    await page.click('button[type="submit"]');
+    await page.locator("#userId").fill(USERS.player.userId);
+    await page.locator("#password").fill(USERS.player.password);
+    await page.locator('button[type="submit"]').click();
     // ログイン成功でトップ (basename 直下) へ遷移する
     await page.waitForURL(new RegExp(`${APP}/?$`));
     await page.context().storageState({ path: PLAYER_STORAGE });

--- a/e2e/helpers/app.ts
+++ b/e2e/helpers/app.ts
@@ -1,8 +1,18 @@
+import { join } from "node:path";
+
 /** アプリの basename。react-router.config.ts の basename と一致させる。 */
 export const APP = "/wolf-mansion";
 
-/** globalSetup が保存する player のログイン storageState ファイル。 */
-export const PLAYER_STORAGE = ".auth/player.json";
+/** e2e/ ディレクトリの絶対パス (このファイルは e2e/helpers/ 配下)。 */
+const E2E_ROOT = join(import.meta.dirname, "..");
+
+/**
+ * globalSetup が保存する player のログイン storageState (絶対パス)。
+ *
+ * 絶対パスにしているのは、`playwright test` を e2e/ 以外から `--config` 指定で
+ * 実行しても globalSetup の保存先とテストの読込先がズレないようにするため。
+ */
+export const PLAYER_STORAGE = join(E2E_ROOT, ".auth", "player.json");
 
 /** 未認証コンテキスト (storageState を空にする) 用の指定値。 */
 export const NO_AUTH = { cookies: [], origins: [] };

--- a/e2e/helpers/app.ts
+++ b/e2e/helpers/app.ts
@@ -1,0 +1,8 @@
+/** アプリの basename。react-router.config.ts の basename と一致させる。 */
+export const APP = "/wolf-mansion";
+
+/** globalSetup が保存する player のログイン storageState ファイル。 */
+export const PLAYER_STORAGE = ".auth/player.json";
+
+/** 未認証コンテキスト (storageState を空にする) 用の指定値。 */
+export const NO_AUTH = { cookies: [], origins: [] };

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.33.0",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "test": "playwright test",
     "test:ui": "playwright test --ui",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "e2e",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@10.33.0",
+  "scripts": {
+    "test": "playwright test",
+    "test:ui": "playwright test --ui",
+    "report": "playwright show-report",
+    "typecheck": "tsc"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.59.1",
+    "@types/node": "^25.6.2",
+    "typescript": "^6.0.3"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/** frontend dev server のオリジン。アプリ自体は basename `/wolf-mansion` 配下。 */
+const FRONTEND_ORIGIN = "http://localhost:5173";
+
+/**
+ * wolf-mansion E2E。
+ *
+ * 前提: backend (:8089) と MySQL (:4306) は事前に起動しておくこと (README 参照)。
+ * frontend dev server は webServer が起動 / 再利用する。
+ */
+export default defineConfig({
+  testDir: "./tests",
+  globalSetup: "./global-setup.ts",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: "html",
+  use: {
+    baseURL: FRONTEND_ORIGIN,
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "pnpm dev",
+    cwd: "../frontend",
+    url: `${FRONTEND_ORIGIN}/wolf-mansion/`,
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+});

--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -1,0 +1,77 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
+      '@types/node':
+        specifier: ^25.6.2
+        version: 25.6.2
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
+packages:
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@types/node@25.6.2':
+    resolution: {integrity: sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+snapshots:
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
+  '@types/node@25.6.2':
+    dependencies:
+      undici-types: 7.19.2
+
+  fsevents@2.3.2:
+    optional: true
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  typescript@6.0.3: {}
+
+  undici-types@7.19.2: {}

--- a/e2e/tests/auth/guard.spec.ts
+++ b/e2e/tests/auth/guard.spec.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "@playwright/test";
+import { APP, NO_AUTH } from "../../helpers/app";
+
+test.use({ storageState: NO_AUTH });
+
+test("未認証で認証必須ページに来るとログインへリダイレクトされる", async ({ page }) => {
+  await page.goto(`${APP}/me`);
+
+  await expect(page).toHaveURL(new RegExp(`${APP}/login\\?redirect=`));
+  await expect(page.getByRole("heading", { name: "wolf-mansion ログイン" })).toBeVisible();
+});

--- a/e2e/tests/auth/login.spec.ts
+++ b/e2e/tests/auth/login.spec.ts
@@ -7,9 +7,9 @@ test.use({ storageState: NO_AUTH });
 
 test("正しい資格情報でログインしトップに遷移する", async ({ page }) => {
   await page.goto(`${APP}/login`);
-  await page.fill("#userId", USERS.player.userId);
-  await page.fill("#password", USERS.player.password);
-  await page.click('button[type="submit"]');
+  await page.locator("#userId").fill(USERS.player.userId);
+  await page.locator("#password").fill(USERS.player.password);
+  await page.locator('button[type="submit"]').click();
 
   await expect(page).toHaveURL(new RegExp(`${APP}/?$`));
   await expect(page.getByRole("heading", { name: "wolf-mansion", exact: true })).toBeVisible();
@@ -17,9 +17,9 @@ test("正しい資格情報でログインしトップに遷移する", async ({
 
 test("誤ったパスワードはエラーメッセージを表示する", async ({ page }) => {
   await page.goto(`${APP}/login`);
-  await page.fill("#userId", USERS.player.userId);
-  await page.fill("#password", "wrong-password");
-  await page.click('button[type="submit"]');
+  await page.locator("#userId").fill(USERS.player.userId);
+  await page.locator("#password").fill("wrong-password");
+  await page.locator('button[type="submit"]').click();
 
   await expect(page.getByRole("alert")).toHaveText("ID またはパスワードが違います");
   await expect(page).toHaveURL(new RegExp(`${APP}/login`));

--- a/e2e/tests/auth/login.spec.ts
+++ b/e2e/tests/auth/login.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+import { USERS } from "../../fixtures/users";
+import { APP, NO_AUTH } from "../../helpers/app";
+
+// ログインフロー自体を検証するので未認証で開始する
+test.use({ storageState: NO_AUTH });
+
+test("正しい資格情報でログインしトップに遷移する", async ({ page }) => {
+  await page.goto(`${APP}/login`);
+  await page.fill("#userId", USERS.player.userId);
+  await page.fill("#password", USERS.player.password);
+  await page.click('button[type="submit"]');
+
+  await expect(page).toHaveURL(new RegExp(`${APP}/?$`));
+  await expect(page.getByRole("heading", { name: "wolf-mansion", exact: true })).toBeVisible();
+});
+
+test("誤ったパスワードはエラーメッセージを表示する", async ({ page }) => {
+  await page.goto(`${APP}/login`);
+  await page.fill("#userId", USERS.player.userId);
+  await page.fill("#password", "wrong-password");
+  await page.click('button[type="submit"]');
+
+  await expect(page.getByRole("alert")).toHaveText("ID またはパスワードが違います");
+  await expect(page).toHaveURL(new RegExp(`${APP}/login`));
+});

--- a/e2e/tests/auth/logout.spec.ts
+++ b/e2e/tests/auth/logout.spec.ts
@@ -10,4 +10,8 @@ test("ログイン済みユーザはマイページからログアウトでき�
   await page.getByRole("button", { name: "ログアウト" }).click();
 
   await expect(page).toHaveURL(new RegExp(`${APP}/login`));
+
+  // セッションが無効化され、再び認証必須ページに入れないことを確認する
+  await page.goto(`${APP}/me`);
+  await expect(page).toHaveURL(new RegExp(`${APP}/login\\?redirect=`));
 });

--- a/e2e/tests/auth/logout.spec.ts
+++ b/e2e/tests/auth/logout.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "@playwright/test";
+import { APP, PLAYER_STORAGE } from "../../helpers/app";
+
+test.use({ storageState: PLAYER_STORAGE });
+
+test("ログイン済みユーザはマイページからログアウトできる", async ({ page }) => {
+  await page.goto(`${APP}/me`);
+  await expect(page.getByRole("heading", { name: "マイページ" })).toBeVisible();
+
+  await page.getByRole("button", { name: "ログアウト" }).click();
+
+  await expect(page).toHaveURL(new RegExp(`${APP}/login`));
+});

--- a/e2e/tests/village/village-list.spec.ts
+++ b/e2e/tests/village/village-list.spec.ts
@@ -10,5 +10,5 @@ test("トップから全村一覧へ遷移できる", async ({ page }) => {
 
   await page.getByRole("link", { name: "全村一覧" }).click();
 
-  await expect(page).toHaveURL(new RegExp(`${APP}/villages`));
+  await expect(page).toHaveURL(new RegExp(`${APP}/villages($|[?#])`));
 });

--- a/e2e/tests/village/village-list.spec.ts
+++ b/e2e/tests/village/village-list.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "@playwright/test";
+import { APP, NO_AUTH } from "../../helpers/app";
+
+// 村一覧・トップは認証不要なので未認証で検証する
+test.use({ storageState: NO_AUTH });
+
+test("トップから全村一覧へ遷移できる", async ({ page }) => {
+  await page.goto(`${APP}/`);
+  await expect(page.getByRole("heading", { name: "wolf-mansion", exact: true })).toBeVisible();
+
+  await page.getByRole("link", { name: "全村一覧" }).click();
+
+  await expect(page).toHaveURL(new RegExp(`${APP}/villages`));
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Summary

monorepo 移行 Step 10。`backend/` `frontend/` と並列の `e2e/` ディレクトリを新設し、Playwright による E2E テスト基盤を整備した。

- `e2e/` スキャフォールド — `package.json` / `.npmrc` (ignore-scripts) / `tsconfig.json` / `playwright.config.ts` / `README.md`
- `globalSetup` で `testuser01` をログインさせ `storageState` を保存。認証必須テストで再利用
- スペック 5 件 — ログイン成功 / 失敗、ログアウト、未認証ガード、トップ→村一覧遷移
- `webServer` が frontend dev server (:5173) を起動 / 再利用。backend (:8089) と MySQL (:4306) は前提 (README に明記)
- chromium のみ。CI workflow は後続

## スコープ判断

`plan.md` 5章の「第一段階シナリオ」のうち **game-flow 系 (村作成→参加→発言→退村、能力→日付更新、足音隠蔽、admin 操作) は意図的にスコープ外**。村進行や日付更新はセットアップが重く flaky になりやすいため、まず安定した基盤を確立した。残りは `.issues/9` (game-flow) / `.issues/10` (CI workflow) として後続フェーズへ引き継ぎ。

## Test plan

- [x] `pnpm install` + `pnpm exec playwright install chromium`
- [x] backend + frontend + DB 起動下で `pnpm test` — 5 passed
- [x] `pnpm typecheck` (tsc) パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)