### PR TITLE
fix: 日付更新トリガーを REST 復旧 (DaychangeScheduler 新設) (#11)

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/application/scheduler/DaychangeScheduler.kt
+++ b/backend/src/main/kotlin/com/ort/app/application/scheduler/DaychangeScheduler.kt
@@ -2,7 +2,6 @@ package com.ort.app.application.scheduler
 
 import com.ort.app.application.coordinator.DaychangeCoordinator
 import com.ort.app.application.service.VillageService
-import com.ort.app.domain.model.village.VillageQuery
 import com.ort.app.domain.model.village.VillageStatus
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -31,9 +30,9 @@ class DaychangeScheduler(
 
     @Scheduled(fixedDelayString = "\${app.daychange.interval-ms:60000}")
     fun changeDay() {
-        val villageIds = villageService.findVillages(
-            VillageQuery(statuses = VillageStatus.notFinishedStatusList.map { VillageStatus(it) })
-        ).list.map { it.id }
+        val villageIds = villageService.findVillageIds(
+            VillageStatus.notFinishedStatusList.map { VillageStatus(it) }
+        )
         // 1 村の日付更新失敗 (例外) が他村を巻き込まないよう、村ごとに隔離する。
         // changeDayIfNeeded 自体が @Transactional なのでロールバック境界も村単位。
         for (villageId in villageIds) {

--- a/backend/src/main/kotlin/com/ort/app/application/scheduler/DaychangeScheduler.kt
+++ b/backend/src/main/kotlin/com/ort/app/application/scheduler/DaychangeScheduler.kt
@@ -1,0 +1,48 @@
+package com.ort.app.application.scheduler
+
+import com.ort.app.application.coordinator.DaychangeCoordinator
+import com.ort.app.application.service.VillageService
+import com.ort.app.domain.model.village.VillageQuery
+import com.ort.app.domain.model.village.VillageStatus
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+/**
+ * 未終了の村の日付更新を定期実行する。
+ *
+ * 旧 Thymeleaf 版ではクライアントのポーリング (`POST /village/{id}/update`) が
+ * `changeDayIfNeeded` を駆動していたが、REST 化でこの経路が失われたためスケジューラで
+ * 代替する。実際に日付を進めるかは `changeDayIfNeeded` 内が各村の更新時刻を見て判定する。
+ *
+ * デフォルトは 60 秒間隔。`app.daychange.interval-ms` で上書き可能。
+ *
+ * `app.daychange.enabled=false` で無効化できる (テストでは `@Scheduled` の発火が
+ * モック検証に干渉するため無効化している)。
+ */
+@Component
+@ConditionalOnProperty(name = ["app.daychange.enabled"], matchIfMissing = true)
+class DaychangeScheduler(
+    private val villageService: VillageService,
+    private val daychangeCoordinator: DaychangeCoordinator,
+) {
+    private val logger = LoggerFactory.getLogger(DaychangeScheduler::class.java)
+
+    @Scheduled(fixedDelayString = "\${app.daychange.interval-ms:60000}")
+    fun changeDay() {
+        val villageIds = villageService.findVillages(
+            VillageQuery(statuses = VillageStatus.notFinishedStatusList.map { VillageStatus(it) })
+        ).list.map { it.id }
+        // 1 村の日付更新失敗 (例外) が他村を巻き込まないよう、村ごとに隔離する。
+        // changeDayIfNeeded 自体が @Transactional なのでロールバック境界も村単位。
+        for (villageId in villageIds) {
+            try {
+                val village = villageService.findVillage(villageId, excludeGone = false) ?: continue
+                daychangeCoordinator.changeDayIfNeeded(village)
+            } catch (e: Exception) {
+                logger.error("daychange failed for village {}", villageId, e)
+            }
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/application/service/VillageService.kt
+++ b/backend/src/main/kotlin/com/ort/app/application/service/VillageService.kt
@@ -23,6 +23,10 @@ class VillageService(
         statusList: List<VillageStatus>
     ): Int = villageRepository.findLatestVillageId(statusList)
 
+    fun findVillageIds(
+        statusList: List<VillageStatus>
+    ): List<Int> = villageRepository.findVillageIds(statusList)
+
     fun findVillages(
         query: VillageQuery
     ): Villages = villageRepository.findVillages(query)

--- a/backend/src/main/kotlin/com/ort/app/domain/model/village/VillageRepository.kt
+++ b/backend/src/main/kotlin/com/ort/app/domain/model/village/VillageRepository.kt
@@ -14,6 +14,11 @@ interface VillageRepository {
         statusList: List<VillageStatus>
     ): Int
 
+    /** 指定ステータスの村 ID のみを取得する (フル hydration を避けた軽量クエリ)。 */
+    fun findVillageIds(
+        statusList: List<VillageStatus>
+    ): List<Int>
+
     fun findVillages(
         query: VillageQuery
     ): Villages

--- a/backend/src/main/kotlin/com/ort/app/infrastructure/datasource/VillageDataSource.kt
+++ b/backend/src/main/kotlin/com/ort/app/infrastructure/datasource/VillageDataSource.kt
@@ -37,6 +37,14 @@ class VillageDataSource(
         }.orElse(0)
     }
 
+    override fun findVillageIds(statusList: List<VillageStatus>): List<Int> {
+        return villageBhv.selectList { cb: VillageCB ->
+            cb.specify().columnVillageId()
+            cb.query().setVillageStatusCode_InScope_AsVillageStatus(statusList.map { it.toCdef() })
+            cb.query().addOrderBy_VillageId_Asc()
+        }.map { it.villageId }
+    }
+
     override fun findVillages(
         query: VillageQuery
     ): Villages {

--- a/backend/src/main/resources/config/application.yml
+++ b/backend/src/main/resources/config/application.yml
@@ -37,6 +37,10 @@ app:
   original-image:
     basedir: /var/www/html/wmansion/original
     baseurl: /wmansion/original
+  daychange:
+    # 日付更新スケジューラの実行間隔 (ミリ秒)
+    interval-ms: 60000
+    # enabled は未指定なら有効。テスト時のみ src/test/resources/application.properties で false
   cors:
     allowed-origins: http://localhost:5173,http://localhost:3000
   cookie:

--- a/backend/src/test/kotlin/com/ort/app/application/scheduler/DaychangeSchedulerTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/application/scheduler/DaychangeSchedulerTest.kt
@@ -2,7 +2,6 @@ package com.ort.app.application.scheduler
 
 import com.ort.app.application.coordinator.DaychangeCoordinator
 import com.ort.app.application.service.VillageService
-import com.ort.app.domain.model.village.Villages
 import com.ort.app.domain.model.village.createPrologueVillage
 import com.ort.dbflute.allcommon.CDef
 import org.junit.jupiter.api.Test
@@ -20,7 +19,7 @@ class DaychangeSchedulerTest {
         val v1 = createPrologueVillage().copy(id = 1)
         val v2 = createPrologueVillage().copy(id = 2)
         val villageService = mock<VillageService> {
-            on { findVillages(any()) } doReturn Villages(listOf(v1, v2))
+            on { findVillageIds(any()) } doReturn listOf(1, 2)
             on { findVillage(1, false) } doReturn v1
             on { findVillage(2, false) } doReturn v2
         }
@@ -35,13 +34,13 @@ class DaychangeSchedulerTest {
     @Test
     fun `未終了ステータスのみを対象に村を取得する`() {
         val villageService = mock<VillageService> {
-            on { findVillages(any()) } doReturn Villages(emptyList())
+            on { findVillageIds(any()) } doReturn emptyList()
         }
 
         DaychangeScheduler(villageService, mock()).changeDay()
 
-        verify(villageService).findVillages(check { query ->
-            val statuses = query.statuses.map { it.toCdef() }.toSet()
+        verify(villageService).findVillageIds(check { statusList ->
+            val statuses = statusList.map { it.toCdef() }.toSet()
             require(
                 statuses == setOf(
                     CDef.VillageStatus.募集中,
@@ -59,7 +58,7 @@ class DaychangeSchedulerTest {
         val v1 = createPrologueVillage().copy(id = 1)
         val v2 = createPrologueVillage().copy(id = 2)
         val villageService = mock<VillageService> {
-            on { findVillages(any()) } doReturn Villages(listOf(v1, v2))
+            on { findVillageIds(any()) } doReturn listOf(1, 2)
             on { findVillage(1, false) } doReturn v1
             on { findVillage(2, false) } doReturn v2
         }

--- a/backend/src/test/kotlin/com/ort/app/application/scheduler/DaychangeSchedulerTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/application/scheduler/DaychangeSchedulerTest.kt
@@ -1,0 +1,75 @@
+package com.ort.app.application.scheduler
+
+import com.ort.app.application.coordinator.DaychangeCoordinator
+import com.ort.app.application.service.VillageService
+import com.ort.app.domain.model.village.Villages
+import com.ort.app.domain.model.village.createPrologueVillage
+import com.ort.dbflute.allcommon.CDef
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.check
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class DaychangeSchedulerTest {
+
+    @Test
+    fun `未終了の村すべてに changeDayIfNeeded を呼ぶ`() {
+        val v1 = createPrologueVillage().copy(id = 1)
+        val v2 = createPrologueVillage().copy(id = 2)
+        val villageService = mock<VillageService> {
+            on { findVillages(any()) } doReturn Villages(listOf(v1, v2))
+            on { findVillage(1, false) } doReturn v1
+            on { findVillage(2, false) } doReturn v2
+        }
+        val coordinator = mock<DaychangeCoordinator>()
+
+        DaychangeScheduler(villageService, coordinator).changeDay()
+
+        verify(coordinator).changeDayIfNeeded(v1)
+        verify(coordinator).changeDayIfNeeded(v2)
+    }
+
+    @Test
+    fun `未終了ステータスのみを対象に村を取得する`() {
+        val villageService = mock<VillageService> {
+            on { findVillages(any()) } doReturn Villages(emptyList())
+        }
+
+        DaychangeScheduler(villageService, mock()).changeDay()
+
+        verify(villageService).findVillages(check { query ->
+            val statuses = query.statuses.map { it.toCdef() }.toSet()
+            require(
+                statuses == setOf(
+                    CDef.VillageStatus.募集中,
+                    CDef.VillageStatus.進行中,
+                    CDef.VillageStatus.エピローグ,
+                )
+            ) {
+                "未終了ステータスのみを対象にすべき。actual=$statuses"
+            }
+        })
+    }
+
+    @Test
+    fun `1 村の例外が他村の処理を止めない`() {
+        val v1 = createPrologueVillage().copy(id = 1)
+        val v2 = createPrologueVillage().copy(id = 2)
+        val villageService = mock<VillageService> {
+            on { findVillages(any()) } doReturn Villages(listOf(v1, v2))
+            on { findVillage(1, false) } doReturn v1
+            on { findVillage(2, false) } doReturn v2
+        }
+        val coordinator = mock<DaychangeCoordinator> {
+            on { changeDayIfNeeded(v1) } doThrow RuntimeException("boom")
+        }
+
+        DaychangeScheduler(villageService, coordinator).changeDay()
+
+        // v1 が例外を投げても v2 は処理される
+        verify(coordinator).changeDayIfNeeded(v2)
+    }
+}

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+# テスト時は日付更新スケジューラを無効化する。
+# @SpringBootTest で @Scheduled が発火すると VillageService モックの検証に干渉するため。
+app.daychange.enabled=false


### PR DESCRIPTION
closes .issues/11-daychange-trigger-rest.md

## 背景 / 根本原因

旧 Thymeleaf 版では村画面のポーリング先 `POST /village/{id}/update` が `daychangeCoordinator.changeDayIfNeeded(village)` を呼び、**ポーリングが日付更新を駆動**していた。REST 化 (Step 6 でポーリング REST 化、Step 9 で旧 `VillageController` を `.old-thymeleaf/` へ退避) の過程でこの経路が移植されず、`api/v1/` 配下に `DaychangeCoordinator` 呼び出しが 0 件・`@Scheduled` も refresh_token 用のみ = **REST 版アプリは村の日付を一切進められない**移行リグレッションになっていた。

## 変更内容

- `application/scheduler/DaychangeScheduler` を新設。`@Scheduled` (デフォルト 60 秒、`app.daychange.interval-ms` で上書き可) で未終了 (募集中/進行中/エピローグ) の村を列挙し、各村に `changeDayIfNeeded` を呼ぶ。実際に進めるかは既存ロジックが更新時刻で判定
- 1 村の例外が他村を止めないよう村ごとに try/catch + error ログ
- `@SpringBootTest` で `@Scheduled` 発火が `VillageService` モック検証に干渉するため、`@ConditionalOnProperty(app.daychange.enabled)` で制御し `src/test/resources/application.properties` でテスト時のみ無効化
- 単体テスト 3 件 (全村呼び出し / 未終了ステータス絞り込み / 例外分離)

旧実装はポーリング駆動だったが、スケジューラ駆動の方が「閲覧者がいなくても進む」正しい挙動になり、既存 `RefreshTokenCleanupJob` と同じ `@Scheduled` パターンに乗る。

## 動作確認

- [x] `./gradlew build` / `test` — 121 tests, 0 failures
- [x] bootRun でスケジューラ起動を確認。実データ (村 1/2) に対し例外・daychange エラーなし
- [ ] ユーザー手動確認依頼: 更新時刻を過ぎた進行中の村で、60 秒以内に日付が進むこと (E2E 化は #9 で対応予定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)