### PR TITLE
Step 12a: 村画面に日付ナビ + メッセージ表示の質的改善 (#12)

### DIFF
--- a/frontend/app/features/village/detail/MessageCard.tsx
+++ b/frontend/app/features/village/detail/MessageCard.tsx
@@ -1,0 +1,235 @@
+import type { MessageView, VillageParticipantView } from "./api";
+
+/**
+ * 1 発言ぶんのカード。`MessageView.typeCode` に応じて色 / 番号プレフィックスを出し分け、
+ * 発言者キャラ画像とプレイヤー名 (エピローグ以降のみ backend が返す) を表示する。
+ *
+ * 旧 Thymeleaf 版 `.old-thymeleaf/templates/village-template/message-partial.html` の
+ * 表示種別 (NORMAL_SAY / WEREWOLF_SAY / MASON_SAY / LOVERS_SAY / MONOLOGUE_SAY /
+ * SECRET_SAY / GRAVE_SAY / SPECTATE_SAY / CREATOR_SAY / TELEPATHY / ACTION / 各種
+ * PRIVATE_* / PUBLIC_SYSTEM / PARTICIPANTS) を一通りカバーする。表情差分 / 大声 /
+ * 虹色 / 返信 / 秘話 ボタンは Step 12d で扱う。
+ */
+export function MessageCard({
+  message,
+  participantsById,
+}: {
+  message: MessageView;
+  participantsById: Map<number, VillageParticipantView>;
+}) {
+  const style = MESSAGE_STYLES[message.typeCode] ?? DEFAULT_STYLE;
+  const fromParticipant = message.fromParticipantId != null
+    ? participantsById.get(message.fromParticipantId)
+    : undefined;
+
+  // PUBLIC_SYSTEM / PRIVATE_* / PARTICIPANTS 等は番号も発言者も持たない単純な
+  // システム枠で出す (旧画面 message-public-system / message-private-* に対応)。
+  if (style.kind === "system") {
+    return (
+      <article
+        className={`rounded border px-3 py-2 text-sm whitespace-pre-wrap ${style.body}`}
+        data-message-type={message.typeCode}
+      >
+        {message.text}
+      </article>
+    );
+  }
+
+  const anchor = renderAnchor(style.anchorPrefix, message.number);
+
+  return (
+    <article
+      className={`rounded border ${style.frame}`}
+      data-message-type={message.typeCode}
+    >
+      <header className="px-3 pt-2 text-xs text-slate-400 flex flex-wrap items-center gap-x-2 gap-y-0.5">
+        {anchor && <span className="font-mono">{anchor}</span>}
+        <span className="text-slate-200">{message.fromCharaName ?? style.fallbackFrom}</span>
+        {message.toCharaName && (
+          <span className="text-slate-400">→ {message.toCharaName}</span>
+        )}
+        {fromParticipant?.playerName && (
+          <span className="text-slate-500">[{fromParticipant.playerName}]</span>
+        )}
+        <span className="text-slate-500 ml-auto">{formatTime(message.datetime)}</span>
+      </header>
+      <div className="px-3 pb-2 pt-1 flex gap-2">
+        {fromParticipant && (
+          <img
+            src={fromParticipant.chara.defaultImageUrl}
+            width={fromParticipant.chara.imageWidth}
+            height={fromParticipant.chara.imageHeight}
+            alt=""
+            loading="lazy"
+            className="shrink-0 rounded border border-slate-700"
+            style={{
+              maxWidth: 60,
+              maxHeight: 60,
+              width: "auto",
+              height: "auto",
+            }}
+          />
+        )}
+        <p className={`flex-1 text-sm whitespace-pre-wrap ${style.text}`}>{message.text}</p>
+      </div>
+    </article>
+  );
+}
+
+// ---------- styles ----------
+
+type MessageKind = "say" | "system";
+
+type MessageStyle = {
+  kind: MessageKind;
+  /** カード枠 (kind=say のときに使用) */
+  frame: string;
+  /** 本文文字色 (kind=say のときに使用) */
+  text: string;
+  /** システム枠の background+border (kind=system のときに使用) */
+  body: string;
+  /** >>N のような番号プレフィックス記号 (旧画面のアンカー記法に揃える) */
+  anchorPrefix: string;
+  /** fromCharaName が null のときに表示するフォールバック (主に creator) */
+  fallbackFrom: string;
+};
+
+const DEFAULT_STYLE: MessageStyle = {
+  kind: "say",
+  frame: "bg-slate-800/40 border-slate-700",
+  text: "text-slate-100",
+  body: "",
+  anchorPrefix: ">>",
+  fallbackFrom: "?",
+};
+
+// 旧 .old-thymeleaf/templates/village-template/message-partial.html の anchor 記法と
+// 配色を Tailwind に移植したもの。背景は slate ベースに寄せて統一感を出す。
+const MESSAGE_STYLES: Record<string, MessageStyle> = {
+  NORMAL_SAY: {
+    kind: "say",
+    frame: "bg-slate-800/50 border-slate-600",
+    text: "text-slate-100",
+    body: "",
+    anchorPrefix: ">>",
+    fallbackFrom: "?",
+  },
+  WEREWOLF_SAY: {
+    kind: "say",
+    frame: "bg-rose-950/40 border-rose-700",
+    text: "text-rose-100",
+    body: "",
+    anchorPrefix: ">>*",
+    fallbackFrom: "?",
+  },
+  MASON_SAY: {
+    kind: "say",
+    frame: "bg-violet-950/40 border-violet-700",
+    text: "text-violet-100",
+    body: "",
+    anchorPrefix: ">>=",
+    fallbackFrom: "?",
+  },
+  LOVERS_SAY: {
+    kind: "say",
+    frame: "bg-pink-950/40 border-pink-700",
+    text: "text-pink-100",
+    body: "",
+    anchorPrefix: ">>?",
+    fallbackFrom: "?",
+  },
+  MONOLOGUE_SAY: {
+    kind: "say",
+    frame: "bg-slate-900/60 border-slate-700",
+    text: "text-slate-300 italic",
+    body: "",
+    anchorPrefix: ">>-",
+    fallbackFrom: "?",
+  },
+  SECRET_SAY: {
+    kind: "say",
+    frame: "bg-amber-950/40 border-amber-700",
+    text: "text-amber-100",
+    body: "",
+    anchorPrefix: ">>s",
+    fallbackFrom: "?",
+  },
+  GRAVE_SAY: {
+    kind: "say",
+    frame: "bg-zinc-900/70 border-zinc-700",
+    text: "text-zinc-300",
+    body: "",
+    anchorPrefix: ">>+",
+    fallbackFrom: "?",
+  },
+  SPECTATE_SAY: {
+    kind: "say",
+    frame: "bg-sky-950/40 border-sky-700",
+    text: "text-sky-100",
+    body: "",
+    anchorPrefix: ">>@",
+    fallbackFrom: "?",
+  },
+  CREATOR_SAY: {
+    kind: "say",
+    frame: "bg-yellow-950/40 border-yellow-700",
+    text: "text-yellow-100",
+    body: "",
+    anchorPrefix: ">>#",
+    fallbackFrom: "天からのお告げ",
+  },
+  TELEPATHY: {
+    kind: "say",
+    frame: "bg-indigo-950/40 border-indigo-700",
+    text: "text-indigo-100",
+    body: "",
+    anchorPrefix: ">>_",
+    fallbackFrom: "?",
+  },
+  ACTION: {
+    kind: "say",
+    frame: "bg-slate-800/30 border-slate-700",
+    text: "text-slate-300 italic",
+    body: "",
+    anchorPrefix: ">>a",
+    fallbackFrom: "",
+  },
+  // システム / 個別役職向け private 系: 番号もキャラ画像も持たない一行枠
+  PUBLIC_SYSTEM: makeSystem("bg-slate-700/30 border-slate-600 text-slate-100"),
+  PRIVATE_SYSTEM: makeSystem("bg-slate-800/50 border-slate-600 text-slate-200"),
+  PRIVATE_SEER: makeSystem("bg-emerald-950/40 border-emerald-700 text-emerald-100"),
+  PRIVATE_WISE: makeSystem("bg-emerald-950/40 border-emerald-700 text-emerald-100"),
+  PRIVATE_PSYCHIC: makeSystem("bg-teal-950/40 border-teal-700 text-teal-100"),
+  PRIVATE_GURU: makeSystem("bg-teal-950/40 border-teal-700 text-teal-100"),
+  PRIVATE_CORONER: makeSystem("bg-teal-950/40 border-teal-700 text-teal-100"),
+  PRIVATE_INVESTIGATE: makeSystem("bg-cyan-950/40 border-cyan-700 text-cyan-100"),
+  PRIVATE_WEREWOLF: makeSystem("bg-rose-950/40 border-rose-700 text-rose-100"),
+  PRIVATE_LOVER: makeSystem("bg-pink-950/40 border-pink-700 text-pink-100"),
+  PRIVATE_FOX: makeSystem("bg-orange-950/40 border-orange-700 text-orange-100"),
+  PRIVATE_ABILITY: makeSystem("bg-slate-800/60 border-slate-600 text-slate-200"),
+  PARTICIPANTS: makeSystem("bg-slate-700/30 border-slate-600 text-slate-100"),
+};
+
+function makeSystem(body: string): MessageStyle {
+  return {
+    kind: "system",
+    frame: "",
+    text: "",
+    body,
+    anchorPrefix: "",
+    fallbackFrom: "",
+  };
+}
+
+function renderAnchor(prefix: string, num: number | null | undefined): string {
+  if (!prefix || num == null) return "";
+  return `${prefix}${num}.`;
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mi = String(d.getMinutes()).padStart(2, "0");
+  return `${hh}:${mi}`;
+}

--- a/frontend/app/features/village/detail/MessageCard.tsx
+++ b/frontend/app/features/village/detail/MessageCard.tsx
@@ -70,6 +70,10 @@ export function MessageCard({
             }}
           />
         )}
+        {/* React JSX は子要素の文字列を textContent としてレンダリングするため、
+            `message.text` を直接埋め込んでも XSS にはならない。旧 Thymeleaf の
+            `{{{messageContent}}}` (HTML 非エスケープ) に相当する HTML 装飾
+            (大声 / 虹色 / アンカー link) は Step 12d で安全に再実装する。 */}
         <p className={`flex-1 text-sm whitespace-pre-wrap ${style.text}`}>{message.text}</p>
       </div>
     </article>

--- a/frontend/app/routes/villages.$id.tsx
+++ b/frontend/app/routes/villages.$id.tsx
@@ -114,15 +114,22 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
   const isViewingLatestDay = selectedDay === village.time.latestDay;
 
   const latestDay = village.time.latestDay;
+  // setParams の updater 形式で前回値を取り、`params` を依存配列から外す
+  // (URLSearchParams は毎 render 新インスタンスなので依存に入れると memo が無効化される)。
   const selectDay = useCallback(
     (day: number) => {
-      // 最新日に戻すときは ?day= を消して URL を綺麗に保つ。
-      const next = new URLSearchParams(params);
-      if (day === latestDay) next.delete("day");
-      else next.set("day", String(day));
-      setParams(next, { replace: true });
+      setParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          // 最新日に戻すときは ?day= を消して URL を綺麗に保つ。
+          if (day === latestDay) next.delete("day");
+          else next.set("day", String(day));
+          return next;
+        },
+        { replace: true },
+      );
     },
-    [params, setParams, latestDay],
+    [setParams, latestDay],
   );
 
   return (
@@ -262,7 +269,8 @@ function DayTabs({
 }) {
   if (days.length === 0) return null;
   // 単一の MessagesPanel に対する切替なので tablist パターンを採用 (role=tab + aria-selected)。
-  // 12b 以降で role=tabpanel を加える際にこのまま延長できる。
+  // 矢印キーナビ (roving tabindex) は実装しないため tabIndex は全タブ 0 のまま
+  // (= Tab キーで巡回できる)。12b 以降で role=tabpanel + 矢印キー対応をまとめて入れる。
   return (
     <div
       role="tablist"
@@ -277,7 +285,6 @@ function DayTabs({
             type="button"
             role="tab"
             aria-selected={active}
-            tabIndex={active ? 0 : -1}
             onClick={() => onSelect(day)}
             className={
               "rounded px-2.5 py-1 text-xs font-mono transition " +

--- a/frontend/app/routes/villages.$id.tsx
+++ b/frontend/app/routes/villages.$id.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Link, useSearchParams } from "react-router";
 import type { Route } from "./+types/villages.$id";
 import {
@@ -36,6 +36,8 @@ export function meta({ data }: Route.MetaArgs) {
 /**
  * `?day=` を整数に変換。負数 / NaN / 範囲外チェックは下流の backend に任せる
  * (backend は範囲外の day でも空の MessagesView を返す)。0 はプロローグなので valid。
+ *
+ * loader (SSR) とコンポーネント (CSR) 両方から呼ぶため module top に置く。
  */
 function parseDayParam(raw: string | null): number | undefined {
   if (raw == null || raw === "") return undefined;
@@ -100,19 +102,28 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
   const isAdmin = authority === "管理者";
 
   const village = villageQuery.data ?? initialVillage;
-  const messages = messagesQuery.data ?? messagesInitialData ?? null;
+  // useVillageMessagesQuery に initialData を渡しているので messagesQuery.data は
+  // 同値で同期される。`?? messagesInitialData` を再度書く必要はない。
+  const messages = messagesQuery.data ?? null;
   const footsteps = footstepsQuery.data ?? initialFootsteps ?? null;
   const myself = myselfQuery.data ?? initialMyself ?? null;
   // creator パネルの表示判定: 村建て本人または管理者 (旧仕様: 管理者 = 全村 creator 扱い)。
   const canSeeCreatorPanel = village.isCreator || isAdmin;
+  // 発言は常に最新日に積まれる。過去日タブを見ているときに発言してもその日には
+  // 出ないので、混乱を避けるため SayForm は最新日表示時のみ出す。
+  const isViewingLatestDay = selectedDay === village.time.latestDay;
 
-  function selectDay(day: number) {
-    const next = new URLSearchParams(params);
-    // 最新日に戻すときは ?day= を消して URL を綺麗に保つ。
-    if (day === village.time.latestDay) next.delete("day");
-    else next.set("day", String(day));
-    setParams(next, { replace: true });
-  }
+  const latestDay = village.time.latestDay;
+  const selectDay = useCallback(
+    (day: number) => {
+      // 最新日に戻すときは ?day= を消して URL を綺麗に保つ。
+      const next = new URLSearchParams(params);
+      if (day === latestDay) next.delete("day");
+      else next.set("day", String(day));
+      setParams(next, { replace: true });
+    },
+    [params, setParams, latestDay],
+  );
 
   return (
     <main className="min-h-screen bg-slate-900 text-slate-100">
@@ -145,7 +156,7 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
           participants={village.participants.list}
         />
 
-        {myself && !myself.isSpectator && !myself.isDead && (
+        {myself && !myself.isSpectator && !myself.isDead && isViewingLatestDay && (
           <SayForm villageId={villageId} />
         )}
 
@@ -250,8 +261,11 @@ function DayTabs({
   onSelect: (day: number) => void;
 }) {
   if (days.length === 0) return null;
+  // 単一の MessagesPanel に対する切替なので tablist パターンを採用 (role=tab + aria-selected)。
+  // 12b 以降で role=tabpanel を加える際にこのまま延長できる。
   return (
-    <nav
+    <div
+      role="tablist"
       aria-label="日付ナビゲーション"
       className="flex flex-wrap gap-1 rounded-xl bg-slate-800/30 border border-slate-700 p-2"
     >
@@ -261,8 +275,10 @@ function DayTabs({
           <button
             key={day}
             type="button"
+            role="tab"
+            aria-selected={active}
+            tabIndex={active ? 0 : -1}
             onClick={() => onSelect(day)}
-            aria-pressed={active}
             className={
               "rounded px-2.5 py-1 text-xs font-mono transition " +
               (active
@@ -274,7 +290,7 @@ function DayTabs({
           </button>
         );
       })}
-    </nav>
+    </div>
   );
 }
 

--- a/frontend/app/routes/villages.$id.tsx
+++ b/frontend/app/routes/villages.$id.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { Link } from "react-router";
+import { useMemo, useState } from "react";
+import { Link, useSearchParams } from "react-router";
 import type { Route } from "./+types/villages.$id";
 import {
   fetchMyself,
@@ -22,6 +22,7 @@ import {
 import { ActionPanel } from "~/features/village/detail/ActionPanel";
 import { AdminPanel } from "~/features/village/detail/AdminPanel";
 import { CreatorPanel } from "~/features/village/detail/CreatorPanel";
+import { MessageCard } from "~/features/village/detail/MessageCard";
 import { ParticipateActions } from "~/features/village/detail/ParticipateActions";
 import { RpActions } from "~/features/village/detail/RpActions";
 import { useMeQuery } from "~/features/auth/hooks";
@@ -32,29 +33,64 @@ export function meta({ data }: Route.MetaArgs) {
   return [{ title: `${name} - wolf-mansion` }];
 }
 
+/**
+ * `?day=` を整数に変換。負数 / NaN / 範囲外チェックは下流の backend に任せる
+ * (backend は範囲外の day でも空の MessagesView を返す)。0 はプロローグなので valid。
+ */
+function parseDayParam(raw: string | null): number | undefined {
+  if (raw == null || raw === "") return undefined;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 0) return undefined;
+  return n;
+}
+
 export async function loader({ request, params }: Route.LoaderArgs) {
   const villageId = Number(params.id);
   if (!Number.isFinite(villageId)) {
     throw new Response("invalid village id", { status: 400 });
   }
+  const url = new URL(request.url);
+  const dayParam = parseDayParam(url.searchParams.get("day"));
   const api = ssrFetch(request);
   // 村の存在確認を先行させる。村が無い場合に messages / footsteps / myself へ
   // 無駄な API コール (backend で同じく 404 になる) が走るのを避けるため。
   const village = await fetchVillage(villageId, api).catch(() => null);
   if (!village) throw new Response("village not found", { status: 404 });
+  // 初期表示日: ?day= があればそれ、無ければ最新日 (= backend で `day` 未指定時と同じ)。
+  // 「latest」をクエリキーに乗せる都合で、ここでは明示的に number に正規化して渡す。
+  const initialDay = dayParam ?? village.time.latestDay;
   const [messages, footsteps, myself] = await Promise.all([
-    fetchVillageMessages(villageId, undefined, api).catch(() => null),
+    fetchVillageMessages(villageId, initialDay, api).catch(() => null),
     fetchVillageFootsteps(villageId, api).catch(() => null),
     fetchMyself(villageId, api).catch(() => null),
   ]);
-  return { villageId, village, messages, footsteps, myself };
+  return { villageId, village, initialDay, messages, footsteps, myself };
 }
 
 export default function VillageDetail({ loaderData }: Route.ComponentProps) {
-  const { villageId, village: initialVillage, messages: initialMessages, footsteps: initialFootsteps, myself: initialMyself } = loaderData;
+  const {
+    villageId,
+    village: initialVillage,
+    initialDay,
+    messages: initialMessages,
+    footsteps: initialFootsteps,
+    myself: initialMyself,
+  } = loaderData;
+
+  const [params, setParams] = useSearchParams();
+  // ?day を最優先で使い、無ければ loader で求めた initialDay (= latest) にフォールバック。
+  const selectedDay = parseDayParam(params.get("day")) ?? initialDay;
 
   const villageQuery = useVillageQuery(villageId, initialVillage);
-  const messagesQuery = useVillageMessagesQuery(villageId, undefined, initialMessages ?? undefined);
+  // 表示日が初期と一致するときだけ SSR の initialMessages を渡す。タブ切替後は
+  // initial を使い回すと別日のデータを掴むため必ず再 fetch させる。
+  const messagesInitialData =
+    selectedDay === initialDay ? initialMessages ?? undefined : undefined;
+  const messagesQuery = useVillageMessagesQuery(
+    villageId,
+    selectedDay,
+    messagesInitialData,
+  );
   const footstepsQuery = useVillageFootstepsQuery(villageId, initialFootsteps ?? undefined);
   const myselfQuery = useMyselfQuery(villageId, initialMyself);
   // 認証情報を取得して管理者 (CDef.Authority.管理者) 判定に使う。
@@ -64,16 +100,30 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
   const isAdmin = authority === "管理者";
 
   const village = villageQuery.data ?? initialVillage;
-  const messages = messagesQuery.data ?? initialMessages ?? null;
+  const messages = messagesQuery.data ?? messagesInitialData ?? null;
   const footsteps = footstepsQuery.data ?? initialFootsteps ?? null;
   const myself = myselfQuery.data ?? initialMyself ?? null;
   // creator パネルの表示判定: 村建て本人または管理者 (旧仕様: 管理者 = 全村 creator 扱い)。
   const canSeeCreatorPanel = village.isCreator || isAdmin;
 
+  function selectDay(day: number) {
+    const next = new URLSearchParams(params);
+    // 最新日に戻すときは ?day= を消して URL を綺麗に保つ。
+    if (day === village.time.latestDay) next.delete("day");
+    else next.set("day", String(day));
+    setParams(next, { replace: true });
+  }
+
   return (
     <main className="min-h-screen bg-slate-900 text-slate-100">
       <section className="max-w-4xl mx-auto px-6 py-10 space-y-6">
         <VillageHeader village={village} />
+
+        <DayTabs
+          days={village.days.list.map((d) => d.day)}
+          selectedDay={selectedDay}
+          onSelect={selectDay}
+        />
 
         {myself && <MyselfPanel myself={myself} />}
 
@@ -89,7 +139,11 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
 
         <ParticipantsPanel participants={village.participants.list} />
 
-        <MessagesPanel messages={messages} latestDay={village.time.latestDay} />
+        <MessagesPanel
+          messages={messages}
+          day={selectedDay}
+          participants={village.participants.list}
+        />
 
         {myself && !myself.isSpectator && !myself.isDead && (
           <SayForm villageId={villageId} />
@@ -182,6 +236,48 @@ function VillageHeader({ village }: { village: VillageView }) {
   );
 }
 
+/**
+ * 旧 .old-thymeleaf/templates/village/village-day-list.html 相当の日付タブ。
+ * `?day=N` を URL に同期させ、ページ遷移なしで messages を切り替える。
+ */
+function DayTabs({
+  days,
+  selectedDay,
+  onSelect,
+}: {
+  days: number[];
+  selectedDay: number;
+  onSelect: (day: number) => void;
+}) {
+  if (days.length === 0) return null;
+  return (
+    <nav
+      aria-label="日付ナビゲーション"
+      className="flex flex-wrap gap-1 rounded-xl bg-slate-800/30 border border-slate-700 p-2"
+    >
+      {days.map((day) => {
+        const active = day === selectedDay;
+        return (
+          <button
+            key={day}
+            type="button"
+            onClick={() => onSelect(day)}
+            aria-pressed={active}
+            className={
+              "rounded px-2.5 py-1 text-xs font-mono transition " +
+              (active
+                ? "bg-indigo-500/40 text-indigo-50 border border-indigo-400"
+                : "border border-transparent text-slate-300 hover:bg-slate-700/40")
+            }
+          >
+            {day === 0 ? "プロローグ" : `${day}日目`}
+          </button>
+        );
+      })}
+    </nav>
+  );
+}
+
 function MyselfPanel({ myself }: { myself: MyselfView }) {
   return (
     <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
@@ -231,20 +327,34 @@ function ParticipantsPanel({ participants }: { participants: VillageParticipantV
   );
 }
 
-function MessagesPanel({ messages, latestDay }: { messages: MessagesView | null; latestDay: number }) {
+function MessagesPanel({
+  messages,
+  day,
+  participants,
+}: {
+  messages: MessagesView | null;
+  day: number;
+  participants: VillageParticipantView[];
+}) {
+  // fromParticipantId → VillageParticipantView の逆引きマップを 1 回だけ作る。
+  // useMemo で participants 配列の identity が変わったときのみ作り直す。
+  const participantsById = useMemo(
+    () => new Map(participants.map((p) => [p.id, p])),
+    [participants],
+  );
+  const count = messages?.list.length ?? 0;
   return (
     <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
-      <h2 className="text-sm text-slate-400 mb-3">発言 ({latestDay}日目)</h2>
-      {!messages || messages.list.length === 0 ? (
+      <h2 className="text-sm text-slate-400 mb-3">
+        発言 ({day === 0 ? "プロローグ" : `${day}日目`} · {count}件)
+      </h2>
+      {!messages || count === 0 ? (
         <p className="text-slate-400 text-sm py-2">この日の閲覧可能な発言はありません</p>
       ) : (
-        <ul className="space-y-2 max-h-[480px] overflow-y-auto">
+        <ul className="space-y-2 max-h-[640px] overflow-y-auto pr-1">
           {messages.list.map((m, i) => (
-            <li key={`${m.typeCode}-${m.number ?? i}`} className="text-sm border-b border-slate-700/40 pb-2">
-              <p className="text-xs text-slate-400">
-                {m.fromCharaName ?? "system"} · {m.typeName} · {formatDateTime(m.datetime)}
-              </p>
-              <p className="whitespace-pre-wrap">{m.text}</p>
+            <li key={`${m.typeCode}-${m.number ?? i}`}>
+              <MessageCard message={m} participantsById={participantsById} />
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary

旧 Thymeleaf 画面で当たり前に出ていた「日付タブ」「発言種別の色分け」「発言者キャラ画像」を React 側に復元する Step 12 の第一弾 (12a)。

### 変更点

- **日付タブ** (`?day=N` で URL 同期): プロローグ含む全日を列挙し、押すと当該日の発言に切り替わる。loader でも `?day` を見て初期 fetch を分岐
- **MessageCard 新設**: 発言種別ごとに色 + アンカー記号 (`>>N` / `>>*N` / `>>=N` / `>>?N` / `>>-N` / `>>sN` / `>>+N` / `>>@N` / `>>#N` / `>>_N` / `>>aN`) を出し分け。`PUBLIC_SYSTEM` / `PRIVATE_*` / `PARTICIPANTS` はシステム枠で出す
- **キャラ画像表示**: `fromParticipantId` を `village.participants` から逆引きして `defaultImageUrl` をメッセージ左に並べる (システム発言は省略)
- **プレイヤー名表示**: backend がエピローグ以降のみ返す `playerName` を `[...]` で発言者名横に表示
- **発言件数表示**: 見出しに「(N日目 · X件)」を追加

### 設計

- backend 変更なし (`/api/v1/villages/{id}/messages?day=N` は既存)
- 表情差分 / 大声 / 虹色 / `>>N` アンカー自動入力 / 秘話・返信ボタン / フィルタ / ページネーション / 状況・投票・部屋割りパネルは **Step 12b 〜 12e で扱う**
- `selectedDay === initialDay` のときだけ SSR の `initialMessages` を渡し、タブ切替後は別日のデータを掴まないよう必ず再 fetch

## Test plan

- [x] `cd frontend && pnpm typecheck`
- [x] `cd frontend && pnpm test` (11 passed)
- [x] `cd frontend && pnpm build`
- [ ] ローカル backend + frontend を立ち上げ、ブラウザで村画面の日付タブ / 発言色分け / キャラ画像 / プレイヤー名 (エピローグ以降) を目視確認
- [ ] pr-reviewer サブエージェントで review → 反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)