### PR TITLE
Step 12b: 参加者拡張 (生死分離 / memo) + 部屋割り (room grid) (#13)

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/response/village/VillageParticipantView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/village/VillageParticipantView.kt
@@ -15,7 +15,14 @@ data class VillageParticipantView(
     val chara: CharaView,
     @field:Schema(description = "表示名 ([部屋番号略称] 名前)")
     val name: String,
-    @field:Schema(description = "簡易メモ (RP 用、未設定なら null / 全員分公開)")
+    /**
+     * 簡易メモ。旧 Thymeleaf 画面 (situation.html) でも全参加者ぶん公開して
+     * いたので踏襲。プレイヤー自由入力 (max 20 chars) のため意図せず戦略情報が
+     * 露出するリスクは認識しているが、公開範囲ポリシーの変更 (自分のみ /
+     * 同陣営のみ等) は memo を補助的に使っている既存ユーザへの影響が大きく、
+     * 別途仕様検討する。
+     */
+    @field:Schema(description = "簡易メモ (RP 用、未設定なら null / 全員分公開、旧画面と同等)")
     val memo: String?,
     @field:Schema(description = "部屋番号 (未割当なら null)")
     val roomNumber: Int?,

--- a/backend/src/main/kotlin/com/ort/app/api/response/village/VillageParticipantView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/village/VillageParticipantView.kt
@@ -15,6 +15,8 @@ data class VillageParticipantView(
     val chara: CharaView,
     @field:Schema(description = "表示名 ([部屋番号略称] 名前)")
     val name: String,
+    @field:Schema(description = "簡易メモ (RP 用、未設定なら null / 全員分公開)")
+    val memo: String?,
     @field:Schema(description = "部屋番号 (未割当なら null)")
     val roomNumber: Int?,
     @field:Schema(description = "見学者か")
@@ -23,6 +25,10 @@ data class VillageParticipantView(
     val isDead: Boolean,
     @field:Schema(description = "死亡理由コード (生存中は null)")
     val deadReasonCode: String?,
+    @field:Schema(description = "死亡理由表示名 (例: 処刑 / 襲撃 / 突然、生存中は null)")
+    val deadReasonName: String?,
+    @field:Schema(description = "死亡日 (生存中は null)")
+    val deadDay: Int?,
     @field:Schema(description = "退村済みか")
     val isGone: Boolean,
     @field:Schema(description = "勝利したか (確定前は null)")
@@ -47,10 +53,13 @@ data class VillageParticipantView(
         id = participant.id,
         chara = CharaView(chara),
         name = participant.name(),
+        memo = participant.memo,
         roomNumber = participant.room?.number,
         isSpectator = participant.isSpectator,
         isDead = participant.dead.isDead,
         deadReasonCode = participant.dead.reason?.code,
+        deadReasonName = participant.dead.reason?.name,
+        deadDay = participant.dead.deadDay,
         isGone = participant.isGone,
         isWin = participant.isWin,
         skill = if (shouldHideSkill) null else participant.skill?.let { SkillView(it) },

--- a/frontend/app/features/village/detail/RoomGridPanel.tsx
+++ b/frontend/app/features/village/detail/RoomGridPanel.tsx
@@ -1,0 +1,101 @@
+import type { VillageParticipantView, VillageView } from "./api";
+
+/**
+ * 部屋割りグリッド (旧 .old-thymeleaf/templates/village/situation.html の room
+ * 部分を React に移植したもの)。
+ *
+ * 表示条件: 村の `roomWidth` が確定済 (= プロローグ終了後) かつ `day > 0`。
+ * `village.participants.list` のうち `roomNumber` が割り当てられたものを対象に、
+ * `roomWidth` 列のグリッドへ並べる。見学者は除外。
+ *
+ * 死亡者は半透明 + `<deadDay>d <記号>` を重ねる (記号: 襲撃=▲ / 処刑=▼ / 突然=凸 /
+ * 後追=❤ / その他=空)。死亡判定は backend が現状 (最新日基準) で返す `isDead /
+ * deadDay / deadReasonCode` を使う (任意の日の生死再現は範囲外、12c 以降)。
+ */
+export function RoomGridPanel({
+  village,
+  day,
+}: {
+  village: VillageView;
+  day: number;
+}) {
+  if (village.roomWidth == null || day <= 0) return null;
+
+  const roomed = village.participants.list.filter((p) => p.roomNumber != null);
+  if (roomed.length === 0) return null;
+
+  // 部屋番号昇順に並べる (backend は基本的に sorted で返してくるが念のため)
+  const sorted = [...roomed].sort((a, b) => (a.roomNumber ?? 0) - (b.roomNumber ?? 0));
+
+  return (
+    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
+      <h2 className="text-sm text-slate-400 mb-3">部屋割り</h2>
+      <div
+        className="grid gap-2"
+        style={{
+          gridTemplateColumns: `repeat(${village.roomWidth}, minmax(0, 1fr))`,
+        }}
+      >
+        {sorted.map((p) => (
+          <RoomCell key={p.id} participant={p} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function RoomCell({ participant }: { participant: VillageParticipantView }) {
+  const isDead = participant.isDead;
+  const room = participant.roomNumber != null
+    ? String(participant.roomNumber).padStart(2, "0")
+    : "--";
+  const deadMark = deadMarkOf(participant.deadReasonCode);
+  return (
+    <div
+      className={
+        "relative flex flex-col items-center justify-end rounded border border-slate-700 bg-slate-900/40 p-1 " +
+        (isDead ? "opacity-40" : "")
+      }
+      title={participant.name}
+    >
+      <img
+        src={participant.chara.defaultImageUrl}
+        width={participant.chara.imageWidth}
+        height={participant.chara.imageHeight}
+        alt=""
+        loading="lazy"
+        className="shrink-0"
+        style={{ maxWidth: 60, maxHeight: 60, width: "auto", height: "auto" }}
+      />
+      <div className="text-[10px] font-mono text-center leading-tight text-slate-200 mt-0.5">
+        <span>{room} {participant.chara.shortName}</span>
+        {isDead && (
+          <span className="block text-rose-300">
+            {participant.deadDay != null ? `${participant.deadDay}d` : ""}
+            {deadMark ? ` ${deadMark}` : ""}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * `CDef.DeadReason` の code から旧画面表記の記号を返す。マップしないものは空。
+ * (旧 situation.html の `room.deadReason == 'EXECUTE' ? '▼' : ...` と同等)
+ */
+function deadMarkOf(code: string | null | undefined): string {
+  if (!code) return "";
+  switch (code) {
+    case "EXECUTE":
+      return "▼";
+    case "ATTACK":
+      return "▲";
+    case "SUDDON": // backend の DeadReason 突然 の code は「SUDDON」(spelling は backend 既存)
+      return "凸";
+    case "SUICIDE":
+      return "❤";
+    default:
+      return "";
+  }
+}

--- a/frontend/app/features/village/detail/RoomGridPanel.tsx
+++ b/frontend/app/features/village/detail/RoomGridPanel.tsx
@@ -21,11 +21,12 @@ export function RoomGridPanel({
 }) {
   if (village.roomWidth == null || day <= 0) return null;
 
-  const roomed = village.participants.list.filter((p) => p.roomNumber != null);
+  // 退村済み (isGone) は旧画面でも部屋割りから外れていたので除外する。
+  // 部屋番号順は backend (`sortedByRoomNumber()`) で確定済なのでフロント側 sort は不要。
+  const roomed = village.participants.list.filter(
+    (p) => p.roomNumber != null && !p.isGone,
+  );
   if (roomed.length === 0) return null;
-
-  // 部屋番号昇順に並べる (backend は基本的に sorted で返してくるが念のため)
-  const sorted = [...roomed].sort((a, b) => (a.roomNumber ?? 0) - (b.roomNumber ?? 0));
 
   return (
     <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
@@ -36,7 +37,7 @@ export function RoomGridPanel({
           gridTemplateColumns: `repeat(${village.roomWidth}, minmax(0, 1fr))`,
         }}
       >
-        {sorted.map((p) => (
+        {roomed.map((p) => (
           <RoomCell key={p.id} participant={p} />
         ))}
       </div>
@@ -62,7 +63,7 @@ function RoomCell({ participant }: { participant: VillageParticipantView }) {
         src={participant.chara.defaultImageUrl}
         width={participant.chara.imageWidth}
         height={participant.chara.imageHeight}
-        alt=""
+        alt={participant.name}
         loading="lazy"
         className="shrink-0"
         style={{ maxWidth: 60, maxHeight: 60, width: "auto", height: "auto" }}
@@ -81,21 +82,29 @@ function RoomCell({ participant }: { participant: VillageParticipantView }) {
 }
 
 /**
- * `CDef.DeadReason` の code から旧画面表記の記号を返す。マップしないものは空。
- * (旧 situation.html の `room.deadReason == 'EXECUTE' ? '▼' : ...` と同等)
+ * `CDef.DeadReason` の code から旧画面表記の記号を返す。
+ * 旧 situation.html (line 80) の三項演算子は `EXECUTE → ▼`, `SUDDON → 凸`,
+ * `SUICIDE → ❤︎`, それ以外 (襲撃系) → `▲` だったので、ATTACK 系
+ * (`ATTACK / DIVINED / TRAPPED / BOMBED / ZAKO`) を明示列挙して同じ ▲ にする。
+ * 不明 code は安全側に倒して `▲` (= 何らかの非自然死) として扱う。
  */
 function deadMarkOf(code: string | null | undefined): string {
   if (!code) return "";
   switch (code) {
     case "EXECUTE":
       return "▼";
-    case "ATTACK":
-      return "▲";
     case "SUDDON": // backend の DeadReason 突然 の code は「SUDDON」(spelling は backend 既存)
       return "凸";
     case "SUICIDE":
       return "❤";
+    // 旧画面で同色 (#ff0000) 扱いだった襲撃系。記号は ATTACK 含め全て ▲ に揃える
+    case "ATTACK":
+    case "DIVINED":
+    case "TRAPPED":
+    case "BOMBED":
+    case "ZAKO":
+      return "▲";
     default:
-      return "";
+      return "▲";
   }
 }

--- a/frontend/app/routes/villages.$id.tsx
+++ b/frontend/app/routes/villages.$id.tsx
@@ -24,6 +24,7 @@ import { AdminPanel } from "~/features/village/detail/AdminPanel";
 import { CreatorPanel } from "~/features/village/detail/CreatorPanel";
 import { MessageCard } from "~/features/village/detail/MessageCard";
 import { ParticipateActions } from "~/features/village/detail/ParticipateActions";
+import { RoomGridPanel } from "~/features/village/detail/RoomGridPanel";
 import { RpActions } from "~/features/village/detail/RpActions";
 import { useMeQuery } from "~/features/auth/hooks";
 import { ssrFetch } from "~/lib/api/client";
@@ -154,6 +155,8 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
         {canSeeCreatorPanel && <CreatorPanel village={village} />}
 
         {isAdmin && <AdminPanel village={village} />}
+
+        <RoomGridPanel village={village} day={selectedDay} />
 
         <ParticipantsPanel participants={village.participants.list} />
 
@@ -315,6 +318,10 @@ function MyselfPanel({ myself }: { myself: MyselfView }) {
   );
 }
 
+/**
+ * 旧 .old-thymeleaf/templates/village/situation.html 参加者タブ相当。
+ * 生存 / 死亡 (見学者は別途末尾) に分割表示し、memo / 死亡日時を出す。
+ */
 function ParticipantsPanel({ participants }: { participants: VillageParticipantView[] }) {
   if (participants.length === 0) {
     return (
@@ -324,29 +331,81 @@ function ParticipantsPanel({ participants }: { participants: VillageParticipantV
       </section>
     );
   }
+  // 生存 (見学を含めない) / 死亡 / 見学 の 3 カテゴリへ振り分け。
+  // 見学者は backend で末尾に並んでいるが、表示位置を明示的にコントロールしたい。
+  const alive: VillageParticipantView[] = [];
+  const dead: VillageParticipantView[] = [];
+  const spectators: VillageParticipantView[] = [];
+  for (const p of participants) {
+    if (p.isSpectator) spectators.push(p);
+    else if (p.isDead) dead.push(p);
+    else alive.push(p);
+  }
   return (
-    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
-      <h2 className="text-sm text-slate-400 mb-3">参加者 ({participants.length})</h2>
-      <ul className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-        {participants.map((p) => (
+    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4 space-y-4">
+      <h2 className="text-sm text-slate-400">
+        参加者 (生存 {alive.length} / 死亡 {dead.length}
+        {spectators.length > 0 ? ` / 見学 ${spectators.length}` : ""})
+      </h2>
+      <ParticipantSubList title={`生存 (${alive.length})`} items={alive} />
+      <ParticipantSubList title={`死亡 (${dead.length})`} items={dead} isDead />
+      {spectators.length > 0 && (
+        <ParticipantSubList title={`見学 (${spectators.length})`} items={spectators} isSpectator />
+      )}
+    </section>
+  );
+}
+
+function ParticipantSubList({
+  title,
+  items,
+  isDead = false,
+  isSpectator = false,
+}: {
+  title: string;
+  items: VillageParticipantView[];
+  isDead?: boolean;
+  isSpectator?: boolean;
+}) {
+  if (items.length === 0) {
+    return (
+      <div>
+        <h3 className="text-xs text-slate-400 mb-1">{title}</h3>
+        <p className="text-xs text-slate-500 px-2">なし</p>
+      </div>
+    );
+  }
+  return (
+    <div>
+      <h3 className="text-xs text-slate-400 mb-1">{title}</h3>
+      <ul className="grid grid-cols-1 sm:grid-cols-2 gap-1.5">
+        {items.map((p) => (
           <li key={p.id} className="flex items-center gap-2 text-sm">
             <span className="font-mono text-slate-500 w-10 shrink-0">
               {p.roomNumber != null ? String(p.roomNumber).padStart(2, "0") : "--"}
             </span>
-            <span className="flex-1 truncate">{p.name}</span>
+            <span className={`flex-1 truncate ${isDead ? "text-slate-400" : ""}`}>
+              {p.name}
+              {p.memo && (
+                <span className="ml-2 text-slate-500 text-xs">[{p.memo}]</span>
+              )}
+            </span>
             {p.skill && (
               <span className="text-xs text-indigo-300 shrink-0">[{p.skill.shortName}]</span>
             )}
-            {p.isSpectator && (
+            {isSpectator && (
               <span className="text-xs text-slate-400 shrink-0">見学</span>
             )}
-            {p.isDead && (
-              <span className="text-xs text-rose-300 shrink-0">{p.deadReasonCode ?? "死亡"}</span>
+            {isDead && (
+              <span className="text-xs text-rose-300 shrink-0">
+                {p.deadDay != null ? `${p.deadDay}d ` : ""}
+                {p.deadReasonName ?? "死亡"}
+              </span>
             )}
           </li>
         ))}
       </ul>
-    </section>
+    </div>
   );
 }
 

--- a/frontend/app/routes/villages.$id.tsx
+++ b/frontend/app/routes/villages.$id.tsx
@@ -331,12 +331,13 @@ function ParticipantsPanel({ participants }: { participants: VillageParticipantV
       </section>
     );
   }
-  // 生存 (見学を含めない) / 死亡 / 見学 の 3 カテゴリへ振り分け。
-  // 見学者は backend で末尾に並んでいるが、表示位置を明示的にコントロールしたい。
+  // 退村済み (isGone) は旧画面でも参加者一覧から外れていたので除外する。
+  // 残りを生存 (見学を含めない) / 死亡 / 見学 の 3 カテゴリへ振り分ける。
   const alive: VillageParticipantView[] = [];
   const dead: VillageParticipantView[] = [];
   const spectators: VillageParticipantView[] = [];
   for (const p of participants) {
+    if (p.isGone) continue;
     if (p.isSpectator) spectators.push(p);
     else if (p.isDead) dead.push(p);
     else alive.push(p);


### PR DESCRIPTION
## Summary

旧 Thymeleaf `situation.html` の参加者タブ / 部屋割りタブ相当を React に復元する Step 12 の 2 つ目のサブブロック。

### Backend

`VillageParticipantView` に以下を追加 (旧画面準拠で全参加者ぶん公開、隠蔽しない):
- \`memo: String?\` — 簡易メモ
- \`deadDay: Int?\` — 死亡日
- \`deadReasonName: String?\` — 死亡理由表示名 (処刑 / 襲撃 / 突然 / ...)

### Frontend

- **ParticipantsPanel** を生存 / 死亡 / 見学の 3 sub-list に分割。各行に \`[memo]\` と \`<deadDay>d <deadReasonName>\` を表示
- **RoomGridPanel 新設**: \`roomWidth\` 列のグリッドに参加者を並べ、キャラ画像 + \`部屋番号 略称\` + 死亡記号 (▲=襲撃 / ▼=処刑 / 凸=突然 / ❤=後追) を表示。表示条件は \`roomWidth != null && day > 0\`
- \`pnpm gen:api\` で OpenAPI 型を再生成 (gitignore 対象、各環境で再実行)

### 範囲外 (= 12c 以降)

- 投票テーブル / 各日の死亡サマリ → 12c
- 任意の日の生死再現 (\`isDeadWhen(day)\` 相当) → 12c
- ダミーキャラ表示 / 役職スポイラー時の表示 → 別途

## Test plan

- [x] \`cd backend && ./gradlew test\` (passing)
- [x] \`cd frontend && pnpm typecheck\`
- [x] \`cd frontend && pnpm test\` (11 passed)
- [x] \`cd frontend && pnpm build\`
- [ ] ローカル backend + frontend で進行中・終了村を開き、部屋割りグリッド / 生死分離 / memo 表示を目視確認
- [ ] pr-reviewer サブエージェントで review → 反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)