### PR TITLE
fix: 進行中の無惨死の死亡理由を API でマスク (#14)

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/response/village/VillageParticipantView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/village/VillageParticipantView.kt
@@ -30,11 +30,19 @@ data class VillageParticipantView(
     val isSpectator: Boolean,
     @field:Schema(description = "死亡しているか")
     val isDead: Boolean,
-    @field:Schema(description = "死亡理由コード (生存中は null)")
+    @field:Schema(
+        description = "死亡理由コード。" +
+                "進行中は無惨死 (襲撃 / 呪殺 / 罠死 / 爆死 / 雑魚) を null でマスクし、" +
+                "公開して良い死因 (突然 / 処刑 / 後追) のみ返す。エピローグ以降は全公開。" +
+                "生存中も null。"
+    )
     val deadReasonCode: String?,
-    @field:Schema(description = "死亡理由表示名 (例: 処刑 / 襲撃 / 突然、生存中は null)")
+    @field:Schema(
+        description = "死亡理由表示名 (例: 処刑 / 襲撃 / 突然)。" +
+                "deadReasonCode と同じマスク方針で進行中の無惨死は null。生存中も null。"
+    )
     val deadReasonName: String?,
-    @field:Schema(description = "死亡日 (生存中は null)")
+    @field:Schema(description = "死亡日 (生存中は null)。マスク対象ではないので進行中も日付は出る")
     val deadDay: Int?,
     @field:Schema(description = "退村済みか")
     val isGone: Boolean,
@@ -56,6 +64,7 @@ data class VillageParticipantView(
         shouldHideSkill: Boolean,
         shouldHidePlayer: Boolean,
         shouldHideAccess: Boolean,
+        shouldMaskDeadReason: Boolean,
     ) : this(
         id = participant.id,
         chara = CharaView(chara),
@@ -64,8 +73,11 @@ data class VillageParticipantView(
         roomNumber = participant.room?.number,
         isSpectator = participant.isSpectator,
         isDead = participant.dead.isDead,
-        deadReasonCode = participant.dead.reason?.code,
-        deadReasonName = participant.dead.reason?.name,
+        // 進行中の無惨死 (襲撃 / 呪殺 / 罠死 / 爆死 / 雑魚) は役職推理に直結する
+        // ため code/name 両方を null にマスクする。突然 / 処刑 / 後追 は公開して
+        // 良い死因なので透過。エピローグ以降 (isSpoilerOpen=true) は全公開。
+        deadReasonCode = maskedReason(participant, shouldMaskDeadReason)?.code,
+        deadReasonName = maskedReason(participant, shouldMaskDeadReason)?.name,
         deadDay = participant.dead.deadDay,
         isGone = participant.isGone,
         isWin = participant.isWin,
@@ -74,4 +86,14 @@ data class VillageParticipantView(
         playerName = if (shouldHidePlayer) null else playerName,
         lastAccessDatetime = if (shouldHideAccess) null else participant.lastAccessDatetime,
     )
+
+    companion object {
+        private fun maskedReason(
+            participant: VillageParticipant,
+            shouldMaskDeadReason: Boolean,
+        ): com.ort.app.domain.model.village.participant.dead.DeadReason? {
+            val reason = participant.dead.reason ?: return null
+            return if (shouldMaskDeadReason && reason.isMiserable()) null else reason
+        }
+    }
 }

--- a/backend/src/main/kotlin/com/ort/app/api/response/village/VillageParticipantView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/village/VillageParticipantView.kt
@@ -4,6 +4,7 @@ import com.ort.app.api.response.chara.CharaView
 import com.ort.app.api.response.skill.SkillView
 import com.ort.app.domain.model.chara.Chara
 import com.ort.app.domain.model.village.participant.VillageParticipant
+import com.ort.app.domain.model.village.participant.dead.DeadReason
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
@@ -66,6 +67,27 @@ data class VillageParticipantView(
         shouldHideAccess: Boolean,
         shouldMaskDeadReason: Boolean,
     ) : this(
+        participant = participant,
+        chara = chara,
+        playerName = playerName,
+        shouldHideSkill = shouldHideSkill,
+        shouldHidePlayer = shouldHidePlayer,
+        shouldHideAccess = shouldHideAccess,
+        // 進行中の無惨死 (襲撃 / 呪殺 / 罠死 / 爆死 / 雑魚) は役職推理に直結する
+        // ため code/name 両方を null にマスクする。突然 / 処刑 / 後追 は公開して
+        // 良い死因なので透過。エピローグ以降 (isSpoilerOpen=true) は全公開。
+        maskedReason = maskedReason(participant, shouldMaskDeadReason),
+    )
+
+    private constructor(
+        participant: VillageParticipant,
+        chara: Chara,
+        playerName: String?,
+        shouldHideSkill: Boolean,
+        shouldHidePlayer: Boolean,
+        shouldHideAccess: Boolean,
+        maskedReason: DeadReason?,
+    ) : this(
         id = participant.id,
         chara = CharaView(chara),
         name = participant.name(),
@@ -73,11 +95,8 @@ data class VillageParticipantView(
         roomNumber = participant.room?.number,
         isSpectator = participant.isSpectator,
         isDead = participant.dead.isDead,
-        // 進行中の無惨死 (襲撃 / 呪殺 / 罠死 / 爆死 / 雑魚) は役職推理に直結する
-        // ため code/name 両方を null にマスクする。突然 / 処刑 / 後追 は公開して
-        // 良い死因なので透過。エピローグ以降 (isSpoilerOpen=true) は全公開。
-        deadReasonCode = maskedReason(participant, shouldMaskDeadReason)?.code,
-        deadReasonName = maskedReason(participant, shouldMaskDeadReason)?.name,
+        deadReasonCode = maskedReason?.code,
+        deadReasonName = maskedReason?.name,
         deadDay = participant.dead.deadDay,
         isGone = participant.isGone,
         isWin = participant.isWin,
@@ -91,7 +110,7 @@ data class VillageParticipantView(
         private fun maskedReason(
             participant: VillageParticipant,
             shouldMaskDeadReason: Boolean,
-        ): com.ort.app.domain.model.village.participant.dead.DeadReason? {
+        ): DeadReason? {
             val reason = participant.dead.reason ?: return null
             return if (shouldMaskDeadReason && reason.isMiserable()) null else reason
         }

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
@@ -201,7 +201,10 @@ class VillageDetailRestController(
                 shouldHideAccess = shouldHideAccess(ctx, participant, isSpoilerOpen),
                 // 進行中は無惨死 (襲撃 / 呪殺 / 罠死 / 爆死 / 雑魚) の区別を隠す。
                 // 突然 / 処刑 / 後追 は公開して良いのでマスクしない。
-                // 自分自身の死因も同じく隠す (詳細は private system メッセージで通知)。
+                // 自分自身の死因も同じく隠す: PRIVATE_SYSTEM 系は admin のみが
+                // 閲覧可能 (VillageParticipant.isViewablePrivateSystemMessage)
+                // なので、一般プレイヤーには「自分が呪殺されたか襲撃されたか」を
+                // API でもメッセージでも進行中は公開しない (無惨死として扱う) 方針。
                 shouldMaskDeadReason = !isSpoilerOpen,
             )
         }

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
@@ -199,6 +199,10 @@ class VillageDetailRestController(
                 shouldHideSkill = shouldHideSkill(ctx, participant, isSpoilerOpen),
                 shouldHidePlayer = shouldHidePlayer(ctx, participant, isSpoilerOpen),
                 shouldHideAccess = shouldHideAccess(ctx, participant, isSpoilerOpen),
+                // 進行中は無惨死 (襲撃 / 呪殺 / 罠死 / 爆死 / 雑魚) の区別を隠す。
+                // 突然 / 処刑 / 後追 は公開して良いのでマスクしない。
+                // 自分自身の死因も同じく隠す (詳細は private system メッセージで通知)。
+                shouldMaskDeadReason = !isSpoilerOpen,
             )
         }
         return VillageParticipantsView(

--- a/frontend/app/features/village/detail/RoomGridPanel.tsx
+++ b/frontend/app/features/village/detail/RoomGridPanel.tsx
@@ -86,10 +86,15 @@ function RoomCell({ participant }: { participant: VillageParticipantView }) {
  * 旧 situation.html (line 80) の三項演算子は `EXECUTE → ▼`, `SUDDON → 凸`,
  * `SUICIDE → ❤︎`, それ以外 (襲撃系) → `▲` だったので、ATTACK 系
  * (`ATTACK / DIVINED / TRAPPED / BOMBED / ZAKO`) を明示列挙して同じ ▲ にする。
- * 不明 code は安全側に倒して `▲` (= 何らかの非自然死) として扱う。
+ *
+ * `code` が **null になる経路** が 2 種類ある:
+ *   1. 生存中 (deadReasonCode 自体が null)
+ *   2. 進行中の無惨死で backend が code/name をマスクして null にしている
+ * 呼び出し側で `isDead` を判定済の前提なら 2 番に該当するので ▲ を返す。
+ * 不明 code も安全側に倒して `▲` (= 何らかの無惨な死) として扱う。
  */
 function deadMarkOf(code: string | null | undefined): string {
-  if (!code) return "";
+  if (!code) return "▲";
   switch (code) {
     case "EXECUTE":
       return "▼";

--- a/frontend/app/features/village/detail/RoomGridPanel.tsx
+++ b/frontend/app/features/village/detail/RoomGridPanel.tsx
@@ -8,9 +8,11 @@ import type { VillageParticipantView, VillageView } from "./api";
  * `village.participants.list` のうち `roomNumber` が割り当てられたものを対象に、
  * `roomWidth` 列のグリッドへ並べる。見学者は除外。
  *
- * 死亡者は半透明 + `<deadDay>d <記号>` を重ねる (記号: 襲撃=▲ / 処刑=▼ / 突然=凸 /
- * 後追=❤ / その他=空)。死亡判定は backend が現状 (最新日基準) で返す `isDead /
- * deadDay / deadReasonCode` を使う (任意の日の生死再現は範囲外、12c 以降)。
+ * 死亡者は半透明 + `<deadDay>d <記号>` を重ねる (記号: 襲撃系=▲ / 処刑=▼ /
+ * 突然=凸 / 後追=❤ / その他・null=▲)。進行中の無惨死は backend がマスクして
+ * code/name を null で返すので、isDead && null → ▲ にフォールバックする。
+ * 死亡判定は backend が現状 (最新日基準) で返す `isDead / deadDay /
+ * deadReasonCode` を使う (任意の日の生死再現は範囲外、12c 以降)。
  */
 export function RoomGridPanel({
   village,
@@ -50,6 +52,8 @@ function RoomCell({ participant }: { participant: VillageParticipantView }) {
   const room = participant.roomNumber != null
     ? String(participant.roomNumber).padStart(2, "0")
     : "--";
+  // deadMark は isDead のときだけ使う。生存者でも計算されるが安価で、結果は
+  // 下の `{isDead && ...}` ブロックでしか参照されないので問題ない。
   const deadMark = deadMarkOf(participant.deadReasonCode);
   return (
     <div
@@ -90,7 +94,8 @@ function RoomCell({ participant }: { participant: VillageParticipantView }) {
  * `code` が **null になる経路** が 2 種類ある:
  *   1. 生存中 (deadReasonCode 自体が null)
  *   2. 進行中の無惨死で backend が code/name をマスクして null にしている
- * 呼び出し側で `isDead` を判定済の前提なら 2 番に該当するので ▲ を返す。
+ * この関数自体は両者を区別せず ▲ を返す。呼び出し側で `isDead` を判定して
+ * 死亡時のみ結果を表示する (= 生存者の ▲ は描画されない)。
  * 不明 code も安全側に倒して `▲` (= 何らかの無惨な死) として扱う。
  */
 function deadMarkOf(code: string | null | undefined): string {

--- a/frontend/app/routes/villages.$id.tsx
+++ b/frontend/app/routes/villages.$id.tsx
@@ -400,7 +400,10 @@ function ParticipantSubList({
             {isDead && (
               <span className="text-xs text-rose-300 shrink-0">
                 {p.deadDay != null ? `${p.deadDay}d ` : ""}
-                {p.deadReasonName ?? "死亡"}
+                {/* deadReasonName が null = 進行中の無惨死 (襲撃 / 呪殺 / 罠死 /
+                    爆死 / 雑魚) でマスクされている状態。旧 DeadReason.getDisplayName
+                    と同じ「無惨死」表記でカバーする */}
+                {p.deadReasonName ?? "無惨死"}
               </span>
             )}
           </li>


### PR DESCRIPTION
## Summary

Step 12b (PR #34) で \`deadReasonName\` を追加した際に、進行中の村でも無惨死 (襲撃 / 呪殺 / 罠死 / 爆死 / 雑魚) の区別が API レスポンスから読めてしまい、役職推理に直結するネタバレになっていた。\`deadReasonCode\` は PR #34 以前からの既存リーク。本 PR で進行中はマスクし、エピローグ以降のみ全公開する。

### Backend

- \`VillageParticipantView\` constructor に \`shouldMaskDeadReason: Boolean\` 追加
- \`true && reason.isMiserable()\` のとき \`deadReasonCode\` / \`deadReasonName\` を共に null にマスク (公開して良い 突然 / 処刑 / 後追 はそのまま)
- \`VillageDetailRestController.buildParticipants\` で \`!isSpoilerOpen\` を渡す。自己例外なし (自分の死因詳細は private system メッセージで通知)
- @Schema description を更新

### Frontend

- \`ParticipantsPanel\` (villages.\$id.tsx): 死亡者表示で \`p.deadReasonName ?? "無惨死"\` フォールバック (旧 \`DeadReason.getDisplayName(isSettled=false)\` と同じ表記)
- \`RoomGridPanel.deadMarkOf\`: null も ▲ 扱いを明示

### マスク方針

| 死因 | 進行中 | エピローグ / 終了 |
|---|---|---|
| 突然 (SUDDON) | code/name 公開 | 公開 |
| 処刑 (EXECUTE) | code/name 公開 | 公開 |
| 後追 (SUICIDE) | code/name 公開 | 公開 |
| **襲撃 / 呪殺 / 罠死 / 爆死 / 雑魚** (isMiserable) | **code/name 共に null** | 公開 |

## Test plan

- [x] \`cd backend && ./gradlew test\` passing
- [x] \`cd frontend && pnpm typecheck && pnpm test && pnpm build\` passing
- [ ] ローカル backend + frontend で進行中・エピローグ後の村を開き、deadReasonCode/Name の出力を DevTools Network で目視確認
- [ ] pr-reviewer サブエージェントで review → 反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)