### PR TITLE
refactor: 死亡情報を DeadView にネスト + MISERABLE / 無惨 で統一マスク (#15)

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/response/village/VillageParticipantView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/village/VillageParticipantView.kt
@@ -2,9 +2,9 @@ package com.ort.app.api.response.village
 
 import com.ort.app.api.response.chara.CharaView
 import com.ort.app.api.response.skill.SkillView
+import com.ort.app.api.response.village.dead.DeadView
 import com.ort.app.domain.model.chara.Chara
 import com.ort.app.domain.model.village.participant.VillageParticipant
-import com.ort.app.domain.model.village.participant.dead.DeadReason
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
@@ -29,22 +29,11 @@ data class VillageParticipantView(
     val roomNumber: Int?,
     @field:Schema(description = "見学者か")
     val isSpectator: Boolean,
-    @field:Schema(description = "死亡しているか")
-    val isDead: Boolean,
     @field:Schema(
-        description = "死亡理由コード。" +
-                "進行中は無惨死 (襲撃 / 呪殺 / 罠死 / 爆死 / 雑魚) を null でマスクし、" +
-                "公開して良い死因 (突然 / 処刑 / 後追) のみ返す。エピローグ以降は全公開。" +
-                "生存中も null。"
+        description = "死亡情報。生存中は null。" +
+                "code / name は進行中の無惨死マスク済 (DeadView 参照)。"
     )
-    val deadReasonCode: String?,
-    @field:Schema(
-        description = "死亡理由表示名 (例: 処刑 / 襲撃 / 突然)。" +
-                "deadReasonCode と同じマスク方針で進行中の無惨死は null。生存中も null。"
-    )
-    val deadReasonName: String?,
-    @field:Schema(description = "死亡日 (生存中は null)。マスク対象ではないので進行中も日付は出る")
-    val deadDay: Int?,
+    val dead: DeadView?,
     @field:Schema(description = "退村済みか")
     val isGone: Boolean,
     @field:Schema(description = "勝利したか (確定前は null)")
@@ -67,37 +56,15 @@ data class VillageParticipantView(
         shouldHideAccess: Boolean,
         shouldMaskDeadReason: Boolean,
     ) : this(
-        participant = participant,
-        chara = chara,
-        playerName = playerName,
-        shouldHideSkill = shouldHideSkill,
-        shouldHidePlayer = shouldHidePlayer,
-        shouldHideAccess = shouldHideAccess,
-        // 進行中の無惨死 (襲撃 / 呪殺 / 罠死 / 爆死 / 雑魚) は役職推理に直結する
-        // ため code/name 両方を null にマスクする。突然 / 処刑 / 後追 は公開して
-        // 良い死因なので透過。エピローグ以降 (isSpoilerOpen=true) は全公開。
-        maskedReason = maskedReason(participant, shouldMaskDeadReason),
-    )
-
-    private constructor(
-        participant: VillageParticipant,
-        chara: Chara,
-        playerName: String?,
-        shouldHideSkill: Boolean,
-        shouldHidePlayer: Boolean,
-        shouldHideAccess: Boolean,
-        maskedReason: DeadReason?,
-    ) : this(
         id = participant.id,
         chara = CharaView(chara),
         name = participant.name(),
         memo = participant.memo,
         roomNumber = participant.room?.number,
         isSpectator = participant.isSpectator,
-        isDead = participant.dead.isDead,
-        deadReasonCode = maskedReason?.code,
-        deadReasonName = maskedReason?.name,
-        deadDay = participant.dead.deadDay,
+        dead = if (participant.dead.isDead) {
+            DeadView(participant.dead, shouldMaskMiserable = shouldMaskDeadReason)
+        } else null,
         isGone = participant.isGone,
         isWin = participant.isWin,
         skill = if (shouldHideSkill) null else participant.skill?.let { SkillView(it) },
@@ -105,14 +72,4 @@ data class VillageParticipantView(
         playerName = if (shouldHidePlayer) null else playerName,
         lastAccessDatetime = if (shouldHideAccess) null else participant.lastAccessDatetime,
     )
-
-    companion object {
-        private fun maskedReason(
-            participant: VillageParticipant,
-            shouldMaskDeadReason: Boolean,
-        ): DeadReason? {
-            val reason = participant.dead.reason ?: return null
-            return if (shouldMaskDeadReason && reason.isMiserable()) null else reason
-        }
-    }
 }

--- a/backend/src/main/kotlin/com/ort/app/api/response/village/dead/DeadView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/village/dead/DeadView.kt
@@ -17,8 +17,9 @@ import io.swagger.v3.oas.annotations.media.Schema
 @Schema(description = "死亡情報 (生存中は VillageParticipantView.dead 自体が null)")
 data class DeadView(
     @field:Schema(
-        description = "死亡理由コード。CDef.DeadReason のコード、または進行中の無惨死を統一する " +
-                "API 専用の合成コード 'MISERABLE'。"
+        description = "死亡理由コード。CDef.DeadReason のコード " +
+                "(EXECUTE / SUDDON ※DBFlute の typo / SUICIDE 等)、または進行中の無惨死を " +
+                "統一する API 専用の合成コード 'MISERABLE'。"
     )
     val code: String,
     @field:Schema(description = "死亡理由表示名。例: 処刑 / 襲撃 / 突然 / 無惨")
@@ -27,10 +28,14 @@ data class DeadView(
     val day: Int,
 ) {
     constructor(dead: Dead, shouldMaskMiserable: Boolean) : this(
+        // 進行中の無惨死、または DB 不整合で reason=null になっているデータも
+        // MISERABLE / 無惨 にフォールバック (旧 maskedReason の null ガード相当)。
+        // 後者は理論上発生しないはずだが、isDead=true && reason=null のレコードが
+        // 存在しても 500 にせず役職推理にも影響しない安全な値で返す。
         code = if (shouldMaskMiserable && dead.isMiserableDead()) MISERABLE_CODE
-        else dead.reason!!.code,
+        else dead.reason?.code ?: MISERABLE_CODE,
         name = if (shouldMaskMiserable && dead.isMiserableDead()) MISERABLE_NAME
-        else dead.reason!!.name,
+        else dead.reason?.name ?: MISERABLE_NAME,
         // 呼び出し側で `dead.isDead == true` を確認してから渡す前提なので
         // `deadDay` も非 null 想定。null だったら未死亡で本クラスを作っているので
         // バグなので明示的に !! で潰す。
@@ -38,7 +43,7 @@ data class DeadView(
     )
 
     companion object {
-        const val MISERABLE_CODE = "MISERABLE"
-        const val MISERABLE_NAME = "無惨"
+        private const val MISERABLE_CODE = "MISERABLE"
+        private const val MISERABLE_NAME = "無惨"
     }
 }

--- a/backend/src/main/kotlin/com/ort/app/api/response/village/dead/DeadView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/village/dead/DeadView.kt
@@ -1,0 +1,44 @@
+package com.ort.app.api.response.village.dead
+
+import com.ort.app.domain.model.village.participant.dead.Dead
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 死亡情報。`VillageParticipant.dead` (= ドメインモデルの Dead) に対応する API view。
+ *
+ * 生存中の参加者では `VillageParticipantView.dead` 自体が null になるので、ここでは
+ * 必ず「死亡している」状態を表す (= `isDead: Boolean` フィールドは持たない)。
+ *
+ * 進行中の村では「無惨死」 (襲撃 / 呪殺 / 罠死 / 爆死 / 雑魚) を区別すると役職推理に
+ * 直結するため、`shouldMaskMiserable=true` のとき code / name を `MISERABLE` / `無惨`
+ * の合成値に統一する (firewolf の `DeadView` と同方式)。
+ * 突然 (SUDDON) / 処刑 (EXECUTE) / 後追 (SUICIDE) は公開して良い死因なので透過。
+ */
+@Schema(description = "死亡情報 (生存中は VillageParticipantView.dead 自体が null)")
+data class DeadView(
+    @field:Schema(
+        description = "死亡理由コード。CDef.DeadReason のコード、または進行中の無惨死を統一する " +
+                "API 専用の合成コード 'MISERABLE'。"
+    )
+    val code: String,
+    @field:Schema(description = "死亡理由表示名。例: 処刑 / 襲撃 / 突然 / 無惨")
+    val name: String,
+    @field:Schema(description = "死亡日 (= 何日目に死亡したか)")
+    val day: Int,
+) {
+    constructor(dead: Dead, shouldMaskMiserable: Boolean) : this(
+        code = if (shouldMaskMiserable && dead.isMiserableDead()) MISERABLE_CODE
+        else dead.reason!!.code,
+        name = if (shouldMaskMiserable && dead.isMiserableDead()) MISERABLE_NAME
+        else dead.reason!!.name,
+        // 呼び出し側で `dead.isDead == true` を確認してから渡す前提なので
+        // `deadDay` も非 null 想定。null だったら未死亡で本クラスを作っているので
+        // バグなので明示的に !! で潰す。
+        day = dead.deadDay!!,
+    )
+
+    companion object {
+        const val MISERABLE_CODE = "MISERABLE"
+        const val MISERABLE_NAME = "無惨"
+    }
+}

--- a/frontend/app/features/village/detail/AdminPanel.tsx
+++ b/frontend/app/features/village/detail/AdminPanel.tsx
@@ -90,7 +90,7 @@ function ForceLeaveSection({ village }: { village: VillageView }) {
   // とはいえ admin パネルとしてはステータスにかかわらず一覧を出し、
   // backend が assertLeave で 400 を返す挙動に従う方が「管理者は何でもできる」感がある。
   const candidates = village.participants.list.filter(
-    (p) => !p.isSpectator && !p.isDead,
+    (p) => !p.isSpectator && !p.dead,
   );
 
   function onLeave(p: VillageParticipantView) {

--- a/frontend/app/features/village/detail/CreatorPanel.tsx
+++ b/frontend/app/features/village/detail/CreatorPanel.tsx
@@ -114,7 +114,7 @@ function SettingsLink({ villageId }: { villageId: number }) {
 function KickForm({ village }: { village: VillageView }) {
   const mutation = useKickMutation(village.id);
   const candidates = village.participants.list.filter(
-    (p) => !p.isSpectator && !p.isDead,
+    (p) => !p.isSpectator && !p.dead,
   );
 
   function onKick(p: VillageParticipantView) {

--- a/frontend/app/features/village/detail/RoomGridPanel.tsx
+++ b/frontend/app/features/village/detail/RoomGridPanel.tsx
@@ -6,13 +6,14 @@ import type { VillageParticipantView, VillageView } from "./api";
  *
  * 表示条件: 村の `roomWidth` が確定済 (= プロローグ終了後) かつ `day > 0`。
  * `village.participants.list` のうち `roomNumber` が割り当てられたものを対象に、
- * `roomWidth` 列のグリッドへ並べる。見学者は除外。
+ * `roomWidth` 列のグリッドへ並べる。見学者と退村済は除外。
  *
- * 死亡者は半透明 + `<deadDay>d <記号>` を重ねる (記号: 襲撃系=▲ / 処刑=▼ /
- * 突然=凸 / 後追=❤ / その他・null=▲)。進行中の無惨死は backend がマスクして
- * code/name を null で返すので、isDead && null → ▲ にフォールバックする。
- * 死亡判定は backend が現状 (最新日基準) で返す `isDead / deadDay /
- * deadReasonCode` を使う (任意の日の生死再現は範囲外、12c 以降)。
+ * 死亡者は半透明 + `<dead.day>d <記号>` を重ねる (記号: 襲撃系=▲ / 処刑=▼ /
+ * 突然=凸 / 後追=❤ / MISERABLE=▲)。進行中の無惨死は backend が code/name を
+ * `MISERABLE` / `無惨` に統一して返すので、フロントは MISERABLE → ▲ で扱う。
+ *
+ * 死亡判定は backend が現状 (最新日基準) で返す `dead` (= DeadView | null) を
+ * 使う (任意の日の生死再現は範囲外、12c 以降)。
  */
 export function RoomGridPanel({
   village,
@@ -23,7 +24,7 @@ export function RoomGridPanel({
 }) {
   if (village.roomWidth == null || day <= 0) return null;
 
-  // 退村済み (isGone) は旧画面でも部屋割りから外れていたので除外する。
+  // 退村済 (isGone) は旧画面でも部屋割りから外れていたので除外する。
   // 部屋番号順は backend (`sortedByRoomNumber()`) で確定済なのでフロント側 sort は不要。
   const roomed = village.participants.list.filter(
     (p) => p.roomNumber != null && !p.isGone,
@@ -48,18 +49,15 @@ export function RoomGridPanel({
 }
 
 function RoomCell({ participant }: { participant: VillageParticipantView }) {
-  const isDead = participant.isDead;
+  const dead = participant.dead;
   const room = participant.roomNumber != null
     ? String(participant.roomNumber).padStart(2, "0")
     : "--";
-  // deadMark は isDead のときだけ使う。生存者でも計算されるが安価で、結果は
-  // 下の `{isDead && ...}` ブロックでしか参照されないので問題ない。
-  const deadMark = deadMarkOf(participant.deadReasonCode);
   return (
     <div
       className={
         "relative flex flex-col items-center justify-end rounded border border-slate-700 bg-slate-900/40 p-1 " +
-        (isDead ? "opacity-40" : "")
+        (dead ? "opacity-40" : "")
       }
       title={participant.name}
     >
@@ -74,10 +72,9 @@ function RoomCell({ participant }: { participant: VillageParticipantView }) {
       />
       <div className="text-[10px] font-mono text-center leading-tight text-slate-200 mt-0.5">
         <span>{room} {participant.chara.shortName}</span>
-        {isDead && (
+        {dead && (
           <span className="block text-rose-300">
-            {participant.deadDay != null ? `${participant.deadDay}d` : ""}
-            {deadMark ? ` ${deadMark}` : ""}
+            {dead.day}d {deadMarkOf(dead.code)}
           </span>
         )}
       </div>
@@ -86,20 +83,14 @@ function RoomCell({ participant }: { participant: VillageParticipantView }) {
 }
 
 /**
- * `CDef.DeadReason` の code から旧画面表記の記号を返す。
+ * `CDef.DeadReason` の code (または backend の合成コード MISERABLE) から旧画面
+ * 表記の記号を返す。
  * 旧 situation.html (line 80) の三項演算子は `EXECUTE → ▼`, `SUDDON → 凸`,
- * `SUICIDE → ❤︎`, それ以外 (襲撃系) → `▲` だったので、ATTACK 系
- * (`ATTACK / DIVINED / TRAPPED / BOMBED / ZAKO`) を明示列挙して同じ ▲ にする。
- *
- * `code` が **null になる経路** が 2 種類ある:
- *   1. 生存中 (deadReasonCode 自体が null)
- *   2. 進行中の無惨死で backend が code/name をマスクして null にしている
- * この関数自体は両者を区別せず ▲ を返す。呼び出し側で `isDead` を判定して
- * 死亡時のみ結果を表示する (= 生存者の ▲ は描画されない)。
+ * `SUICIDE → ❤︎`, それ以外 (襲撃系) → `▲`。襲撃系 (`ATTACK / DIVINED /
+ * TRAPPED / BOMBED / ZAKO`) と `MISERABLE` (進行中マスク) を明示列挙して同じ ▲ にする。
  * 不明 code も安全側に倒して `▲` (= 何らかの無惨な死) として扱う。
  */
-function deadMarkOf(code: string | null | undefined): string {
-  if (!code) return "▲";
+function deadMarkOf(code: string): string {
   switch (code) {
     case "EXECUTE":
       return "▼";
@@ -107,12 +98,14 @@ function deadMarkOf(code: string | null | undefined): string {
       return "凸";
     case "SUICIDE":
       return "❤";
-    // 旧画面で同色 (#ff0000) 扱いだった襲撃系。記号は ATTACK 含め全て ▲ に揃える
+    // 旧画面で同色 (#ff0000) 扱いだった襲撃系。記号は ATTACK 含め全て ▲ に揃える。
+    // MISERABLE は進行中マスクの合成コード (backend が無惨死を統一して返す)。
     case "ATTACK":
     case "DIVINED":
     case "TRAPPED":
     case "BOMBED":
     case "ZAKO":
+    case "MISERABLE":
       return "▲";
     default:
       return "▲";

--- a/frontend/app/routes/villages.$id.tsx
+++ b/frontend/app/routes/villages.$id.tsx
@@ -339,7 +339,7 @@ function ParticipantsPanel({ participants }: { participants: VillageParticipantV
   for (const p of participants) {
     if (p.isGone) continue;
     if (p.isSpectator) spectators.push(p);
-    else if (p.isDead) dead.push(p);
+    else if (p.dead) dead.push(p);
     else alive.push(p);
   }
   return (
@@ -348,25 +348,25 @@ function ParticipantsPanel({ participants }: { participants: VillageParticipantV
         参加者 (生存 {alive.length} / 死亡 {dead.length}
         {spectators.length > 0 ? ` / 見学 ${spectators.length}` : ""})
       </h2>
-      <ParticipantSubList title={`生存 (${alive.length})`} items={alive} />
-      <ParticipantSubList title={`死亡 (${dead.length})`} items={dead} isDead />
+      <ParticipantSubList title={`生存 (${alive.length})`} items={alive} kind="alive" />
+      <ParticipantSubList title={`死亡 (${dead.length})`} items={dead} kind="dead" />
       {spectators.length > 0 && (
-        <ParticipantSubList title={`見学 (${spectators.length})`} items={spectators} isSpectator />
+        <ParticipantSubList title={`見学 (${spectators.length})`} items={spectators} kind="spectator" />
       )}
     </section>
   );
 }
 
+type ParticipantKind = "alive" | "dead" | "spectator";
+
 function ParticipantSubList({
   title,
   items,
-  isDead = false,
-  isSpectator = false,
+  kind,
 }: {
   title: string;
   items: VillageParticipantView[];
-  isDead?: boolean;
-  isSpectator?: boolean;
+  kind: ParticipantKind;
 }) {
   if (items.length === 0) {
     return (
@@ -376,6 +376,8 @@ function ParticipantSubList({
       </div>
     );
   }
+  const isDead = kind === "dead";
+  const isSpectator = kind === "spectator";
   return (
     <div>
       <h3 className="text-xs text-slate-400 mb-1">{title}</h3>
@@ -397,13 +399,10 @@ function ParticipantSubList({
             {isSpectator && (
               <span className="text-xs text-slate-400 shrink-0">見学</span>
             )}
-            {isDead && (
+            {/* p.dead は backend で進行中の無惨死を MISERABLE / 無惨 にマスク済 */}
+            {isDead && p.dead && (
               <span className="text-xs text-rose-300 shrink-0">
-                {p.deadDay != null ? `${p.deadDay}d ` : ""}
-                {/* deadReasonName が null = 進行中の無惨死 (襲撃 / 呪殺 / 罠死 /
-                    爆死 / 雑魚) でマスクされている状態。旧 DeadReason.getDisplayName
-                    と同じ「無惨死」表記でカバーする */}
-                {p.deadReasonName ?? "無惨死"}
+                {p.dead.day}d {p.dead.name}
               </span>
             )}
           </li>


### PR DESCRIPTION
## Summary

PR #35 (fix #14) で進行中の無惨死を null マスクしたが、null だと「未死亡 / マスク / バグ」の区別が API consumer から付きにくい。neighborhood project の [firewolf の DeadView](https://github.com/h-orito/firewolf/blob/main/backend/src/main/kotlin/com/ort/firewolf/api/view/dead/DeadView.kt) / [VillageParticipantView](https://github.com/h-orito/firewolf/blob/main/backend/src/main/kotlin/com/ort/firewolf/api/view/village/VillageParticipantView.kt) に揃えて以下に変更:

### Backend

- **新規 \`api/response/village/dead/DeadView.kt\`**:
  - フィールド: \`code: String\`, \`name: String\`, \`day: Int\`
  - \`constructor(dead, shouldMaskMiserable)\` でマスク判定し、無惨死 (襲撃 / 呪殺 / 罠死 / 爆死 / 雑魚) は code=**\"MISERABLE\"**, name=**\"無惨\"** に統一 (CDef にない API 専用合成コード)
  - 突然 / 処刑 / 後追 は CDef コード透過
- **\`VillageParticipantView\` から \`isDead\` / \`deadReasonCode\` / \`deadReasonName\` / \`deadDay\` の 4 フィールドを除去**し、\`dead: DeadView?\` (生存中は null) に統合
  - ドメインモデル \`VillageParticipant.dead: Dead\` と対称になる

### Frontend

- \`pnpm gen:api\` で OpenAPI 型再生成 (構造変更を含むため必須)
- **RoomGridPanel**: \`participant.isDead/deadReasonCode/deadDay\` → \`participant.dead?\` 経由に。\`deadMarkOf\` に \`case \"MISERABLE\" → \"▲\"\` を明示追加
- **villages.\$id.tsx (ParticipantsPanel)**: \`p.isDead/deadReasonName/deadDay\` → \`p.dead?\` に。\`?? \"無惨死\"\` フォールバックは不要 (backend が必ず返す)
- **CreatorPanel / AdminPanel**: \`!p.isDead\` → \`!p.dead\`

## Test plan

- [x] \`cd backend && ./gradlew test\` passing
- [x] \`cd frontend && pnpm typecheck && pnpm test && pnpm build\` passing
- [ ] ローカル backend + frontend で進行中の村を開き、DevTools で API response の \`dead.code === \"MISERABLE\"\` / \`dead.name === \"無惨\"\` を確認
- [ ] pr-reviewer サブエージェントで review → 反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)