### PR TITLE
Step 12c: 状況サマリ / 投票テーブル / 日別足音を REST 化 + 復元 (#17)

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/response/village/situation/VillageSituationView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/village/situation/VillageSituationView.kt
@@ -73,13 +73,20 @@ data class VillageSituationVoteView(
     @field:Schema(
         description = "投票の最大カラム数 (= 表示すべき日数)。" +
                 "domain の `convertToVillageSituation` が黒箱日除外後の vote を返すため、" +
-                "ここでは行ごとの vote 数の最大を取る (= 旧画面 `VillageVoteContent.maxVoteCount` 互換)",
+                "ここでは行ごとの vote 数の最大を取る (= 旧画面 `VillageVoteContent.maxVoteCount` 互換)。" +
+                "現状 frontend は `list[].voteList[].day` の最大値から自前で列数を決めるため未使用だが、" +
+                "外部連携 / 別 UI で日列数を即座に知りたいケースのために残置する",
     )
     val maxVoteCount: Int,
 ) {
     constructor(village: Village, situation: VillageVoteSituation) : this(
         list = situation.list.map { memberVotes ->
             VillageSituationVoteMemberView(
+                // 投票者の行ヘッダは複数日の投票をまとめるため、特定の日に固定できない。
+                // 旧 Thymeleaf 実装 (`VillageMemberVoteContent`) も `shortName()` (= 最新部屋番号)
+                // を使っていたため踏襲。target 側はセルごとに `shortNameWhen(vote.day)`
+                // (投票日時点の部屋番号) を使うので、見た目上は「投票日の target」と
+                // 「現在の投票者」が混在するが、これは旧画面と同じ挙動。
                 participantId = memberVotes.participant.id,
                 charaShortName = memberVotes.participant.shortName(),
                 voteList = memberVotes.voteList.map { vote ->

--- a/backend/src/main/kotlin/com/ort/app/api/response/village/situation/VillageSituationView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/village/situation/VillageSituationView.kt
@@ -1,0 +1,121 @@
+package com.ort.app.api.response.village.situation
+
+import com.ort.app.domain.model.situation.village.VillageFootstepSituation
+import com.ort.app.domain.model.situation.village.VillageVoteSituation
+import com.ort.app.domain.model.situation.village.VillageWholeSituation
+import com.ort.app.domain.model.village.Village
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 旧 Thymeleaf `situation.html` の "状況 / 投票 / 足音" タブ相当のサマリ。
+ *
+ * - `whole`: 各日の死亡 (突然 / 処刑 / 無惨 / 後追) と復活、能力履歴 (spoiler open 時のみ非空)
+ * - `vote`: 参加者 × 各日の投票テーブル (黒箱日は除外済み、`maxVoteCount` は表のカラム数算出に使う)
+ * - `dayFootsteps`: 日別足音 (= `VillageFootstepSituation`)。
+ *   登録単位リストは `/footsteps` を、日別文字列はこちらを参照する。
+ *
+ * `day` パラメータで「現在の表示日」を渡し、それより未来の whole / vote 行は backend 側で
+ * 切らずにそのまま返す (旧画面は client 側で「現在表示中の day まで」描画する設計)。
+ */
+@Schema(description = "村の状況サマリ (whole / vote / dayFootsteps)")
+data class VillageSituationView(
+    @field:Schema(description = "各日の死亡・復活・能力")
+    val whole: List<VillageSituationDayView>,
+    @field:Schema(description = "投票テーブル")
+    val vote: VillageSituationVoteView,
+    @field:Schema(description = "日別足音 (進行中は他者足音が空文字 or 隠匿される可能性あり)")
+    val dayFootsteps: List<VillageDayFootstepView>,
+) {
+    constructor(
+        village: Village,
+        whole: VillageWholeSituation,
+        vote: VillageVoteSituation,
+        footstep: VillageFootstepSituation,
+    ) : this(
+        whole = whole.list.map { detail ->
+            VillageSituationDayView(
+                day = detail.day,
+                suddenlyDeath = detail.suddenlyDeath.list.map { it.shortNameWhen(detail.day - 1) },
+                executed = detail.executed.list.map { it.shortNameWhen(detail.day - 1) },
+                miserable = detail.miserable.list.map { it.shortNameWhen(detail.day - 1) },
+                revival = detail.revival.list.map { it.shortNameWhen(detail.day - 1) },
+                suicide = detail.suicide.list.map { it.shortNameWhen(detail.day - 1) },
+                ability = detail.ability,
+            )
+        },
+        vote = VillageSituationVoteView(village, vote),
+        dayFootsteps = footstep.list.map { VillageDayFootstepView(day = it.day, footstep = it.footstep) },
+    )
+}
+
+@Schema(description = "ある 1 日の死亡・復活・能力サマリ")
+data class VillageSituationDayView(
+    @field:Schema(description = "何日目か")
+    val day: Int,
+    @field:Schema(description = "突然死した参加者の表示名 (= 部屋番号+略称) 一覧")
+    val suddenlyDeath: List<String>,
+    @field:Schema(description = "処刑された参加者の表示名一覧")
+    val executed: List<String>,
+    @field:Schema(description = "無惨死 (襲撃 / 呪殺 / 罠死 / 爆死 / 雑魚 等) の表示名一覧")
+    val miserable: List<String>,
+    @field:Schema(description = "復活した参加者の表示名一覧")
+    val revival: List<String>,
+    @field:Schema(description = "後追した参加者の表示名一覧")
+    val suicide: List<String>,
+    @field:Schema(description = "能力履歴 (spoiler 非公開時は空配列)")
+    val ability: List<String>,
+)
+
+@Schema(description = "投票テーブル")
+data class VillageSituationVoteView(
+    @field:Schema(description = "参加者ごとの行 (退村済 / 見学 / dummy も含む。表側で除外しない)")
+    val list: List<VillageSituationVoteMemberView>,
+    @field:Schema(
+        description = "投票の最大カラム数 (= 表示すべき日数)。" +
+                "domain の `convertToVillageSituation` が黒箱日除外後の vote を返すため、" +
+                "ここでは行ごとの vote 数の最大を取る (= 旧画面 `VillageVoteContent.maxVoteCount` 互換)",
+    )
+    val maxVoteCount: Int,
+) {
+    constructor(village: Village, situation: VillageVoteSituation) : this(
+        list = situation.list.map { memberVotes ->
+            VillageSituationVoteMemberView(
+                participantId = memberVotes.participant.id,
+                charaShortName = memberVotes.participant.shortName(),
+                voteList = memberVotes.voteList.map { vote ->
+                    VillageSituationVoteCellView(
+                        day = vote.day,
+                        targetCharaShortName = village.participants.chara(vote.targetCharaId).shortNameWhen(vote.day),
+                    )
+                },
+            )
+        },
+        maxVoteCount = situation.list.maxOfOrNull { it.voteList.size } ?: 0,
+    )
+}
+
+@Schema(description = "投票テーブルの 1 行 (1 参加者)")
+data class VillageSituationVoteMemberView(
+    @field:Schema(description = "参加者 ID")
+    val participantId: Int,
+    @field:Schema(description = "表示名 (= 部屋番号+略称)")
+    val charaShortName: String,
+    @field:Schema(description = "投票履歴 (黒箱日は domain 側で除外済み)")
+    val voteList: List<VillageSituationVoteCellView>,
+)
+
+@Schema(description = "投票テーブルの 1 セル (1 日の投票先)")
+data class VillageSituationVoteCellView(
+    @field:Schema(description = "投票が行われた日")
+    val day: Int,
+    @field:Schema(description = "投票先の表示名")
+    val targetCharaShortName: String,
+)
+
+@Schema(description = "日別足音 (旧画面の足音タブ用)")
+data class VillageDayFootstepView(
+    @field:Schema(description = "何日目か")
+    val day: Int,
+    @field:Schema(description = "足音 (改行区切りの整形済み文字列)")
+    val footstep: String,
+)

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
@@ -7,6 +7,7 @@ import com.ort.app.api.response.village.VillageFootstepsView
 import com.ort.app.api.response.village.VillageParticipantView
 import com.ort.app.api.response.village.VillageParticipantsView
 import com.ort.app.api.response.village.VillageView
+import com.ort.app.api.response.village.situation.VillageSituationView
 import com.ort.app.application.coordinator.CreatorCoordinator
 import com.ort.app.application.coordinator.VillageCoordinator
 import com.ort.app.application.service.AbilityService
@@ -139,6 +140,41 @@ class VillageDetailRestController(
                 )
             }
         return VillageFootstepsView(list = views)
+    }
+
+    @GetMapping("/{villageId}/situation")
+    @Operation(
+        summary = "状況サマリ取得",
+        description = "旧 Thymeleaf 画面の '状況 / 投票 / 足音' タブ相当。各日の死亡・復活・能力履歴、" +
+                "参加者ごとの投票テーブル、日別の足音まとめを返す。\n" +
+                "- `whole.ability` は spoiler 開示状態 (= エピローグ以降 / 見学 / 開示村の死亡など) でのみ非空\n" +
+                "- `vote` は黒箱日 (隠蔽能力対象) を domain 側で除外済み\n" +
+                "- `dayFootsteps` の足音文字列は domain `FootstepDomainService.convertToSituation` の隠匿ロジックを通る",
+    )
+    fun situation(
+        @PathVariable villageId: Int,
+        @Parameter(description = "現在表示中の日。投票表 / 状況表の範囲決定は frontend 側で行うため、ここでは domain への day 引数 (= ability 履歴の起点) として渡す。未指定なら最新日。", required = false)
+        @RequestParam(required = false) day: Int?,
+    ): VillageSituationView {
+        val ctx = loadContext(villageId)
+        val targetDay = day ?: ctx.village.latestDay()
+        val votes = voteService.findVotes(ctx.village.id)
+        val abilities = abilityService.findAbilities(ctx.village.id)
+        val footsteps = footstepService.findFootsteps(ctx.village.id)
+        val situation = villageCoordinator.findVillageSituation(
+            village = ctx.village,
+            myself = ctx.myself,
+            votes = votes,
+            abilities = abilities,
+            footsteps = footsteps,
+            day = targetDay,
+        )
+        return VillageSituationView(
+            village = ctx.village,
+            whole = situation.whole,
+            vote = situation.vote,
+            footstep = situation.footstep,
+        )
     }
 
     @GetMapping("/{villageId}/myself")

--- a/frontend/app/features/village/detail/SituationPanel.tsx
+++ b/frontend/app/features/village/detail/SituationPanel.tsx
@@ -1,0 +1,209 @@
+import { useMemo } from "react";
+import type {
+  VillageSituationDayView,
+  VillageSituationView,
+  VillageSituationVoteMemberView,
+} from "./api";
+
+/**
+ * 旧 .old-thymeleaf/templates/village/situation.html の "状況 / 投票 / 足音 (日別)"
+ * タブ相当を React に復元。
+ *
+ * 表示順: 状況テーブル → 投票テーブル → 日別足音 (旧画面と同じ順)。
+ *
+ * `selectedDay` は「今表示している日」を渡す。旧画面では `situation.day` が範囲
+ * 上限として使われていたため、本パネルでも各表を `day <= selectedDay` で切る。
+ * (= 過去日タブを開いている時にネタバレを出さない)
+ */
+export function SituationPanel({
+  situation,
+  selectedDay,
+}: {
+  situation: VillageSituationView | null;
+  selectedDay: number;
+}) {
+  // React hooks の順序固定のため、useMemo は早期 return より前で呼ぶ。
+  // situation == null のときも空配列扱いで evaluate して問題ない (重い処理ではない)。
+  const visibleWhole = useMemo(
+    () => (situation ? situation.whole.filter((d) => d.day <= selectedDay) : []),
+    [situation, selectedDay],
+  );
+  const visibleDayFootsteps = useMemo(
+    () => (situation ? situation.dayFootsteps.filter((d) => d.day <= selectedDay) : []),
+    [situation, selectedDay],
+  );
+
+  if (!situation) return null;
+  // 旧画面と同じく、`day = 0` (プロローグ) では何も意味ある情報がない (= テーブル全部空) ので
+  // パネルごと非表示にする。
+  if (selectedDay <= 0) return null;
+
+  const hasWhole = visibleWhole.length > 0;
+  const hasVote = situation.vote.list.length > 0 && situation.vote.maxVoteCount > 0;
+  const hasDayFootsteps = visibleDayFootsteps.some((d) => d.footstep.trim().length > 0);
+
+  // 3 サブブロックいずれも内容なしならパネル自体出さない。
+  if (!hasWhole && !hasVote && !hasDayFootsteps) return null;
+
+  return (
+    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4 space-y-5">
+      <h2 className="text-sm text-slate-400">状況</h2>
+      {hasWhole && <WholeTable rows={visibleWhole} />}
+      {hasVote && <VoteTable vote={situation.vote} selectedDay={selectedDay} />}
+      {hasDayFootsteps && <DayFootstepsTable rows={visibleDayFootsteps} />}
+    </section>
+  );
+}
+
+function WholeTable({ rows }: { rows: VillageSituationDayView[] }) {
+  // 旧画面では `能力` 列は spoiler 公開時のみ表示していた。backend が spoiler
+  // 非公開時に `ability` を空配列で返すため、ここでは「全行が空なら列ごと非表示」
+  // で判定する (= dispSpoilerContent 相当)。
+  const hasAbility = rows.some((r) => r.ability.length > 0);
+  return (
+    <div className="overflow-x-auto">
+      <h3 className="text-xs text-slate-400 mb-1">日次状況</h3>
+      <table className="min-w-full text-xs border-collapse">
+        <thead>
+          <tr className="text-slate-400">
+            <th className="border border-slate-700 px-2 py-1 text-center w-12">日付</th>
+            <th className="border border-slate-700 px-2 py-1 text-left">突然死</th>
+            <th className="border border-slate-700 px-2 py-1 text-left">処刑</th>
+            <th className="border border-slate-700 px-2 py-1 text-left">無惨</th>
+            <th className="border border-slate-700 px-2 py-1 text-left">復活</th>
+            <th className="border border-slate-700 px-2 py-1 text-left">後追</th>
+            {hasAbility && (
+              <th className="border border-slate-700 px-2 py-1 text-left">能力</th>
+            )}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.day}>
+              <td className="border border-slate-700 px-2 py-1 text-center text-slate-300">
+                {r.day}d
+              </td>
+              <td className="border border-slate-700 px-2 py-1">{formatList(r.suddenlyDeath)}</td>
+              <td className="border border-slate-700 px-2 py-1">{formatList(r.executed)}</td>
+              <td className="border border-slate-700 px-2 py-1">{formatList(r.miserable)}</td>
+              <td className="border border-slate-700 px-2 py-1">{formatList(r.revival)}</td>
+              <td className="border border-slate-700 px-2 py-1">{formatList(r.suicide)}</td>
+              {hasAbility && (
+                <td className="border border-slate-700 px-2 py-1 whitespace-pre-line">
+                  {r.ability.join("\n")}
+                </td>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/**
+ * 旧画面の投票テーブルは「列 = 投票日 (2d, 3d, ..., maxVoteCount+1)」「行 = 参加者」。
+ * domain は黒箱日を除外して `voteList` を返すため、行ごとに `voteList` の `day` を
+ * 直接突き合わせる (= 旧 VillageMemberVoteContent.voteTargetList と同じ復元方法)。
+ */
+function VoteTable({
+  vote,
+  selectedDay,
+}: {
+  vote: VillageSituationView["vote"];
+  selectedDay: number;
+}) {
+  // 表示すべき日列を計算: 2d 〜 (selectedDay - 1) まで (= 投票は前日に行われ翌日処刑)
+  // ただし「実際に存在する vote の最大日」も超えないように cap する (旧 `maxVoteCount` 互換)。
+  const maxDayInVotes = vote.list.reduce<number>((acc, m) => {
+    const dmax = m.voteList.reduce<number>((a, v) => Math.max(a, v.day), 0);
+    return Math.max(acc, dmax);
+  }, 0);
+  // selectedDay - 1 まで (= 当日 selectedDay で開示できる投票は前日まで)
+  // 例: selectedDay=3 なら 2d 投票結果は確定済みで表示してよい。
+  const upperDay = Math.min(maxDayInVotes, Math.max(0, selectedDay - 1));
+  if (upperDay < 2) return null;
+  const dayCols: number[] = [];
+  for (let d = 2; d <= upperDay; d++) dayCols.push(d);
+
+  return (
+    <div className="overflow-x-auto">
+      <h3 className="text-xs text-slate-400 mb-1">投票</h3>
+      <table className="min-w-full text-xs border-collapse">
+        <thead>
+          <tr className="text-slate-400">
+            <th className="border border-slate-700 px-2 py-1 text-left">投票者</th>
+            {dayCols.map((d) => (
+              <th key={d} className="border border-slate-700 px-2 py-1 text-center">
+                {d}d
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {vote.list.map((member) => (
+            <VoteRow key={member.participantId} member={member} dayCols={dayCols} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function VoteRow({
+  member,
+  dayCols,
+}: {
+  member: VillageSituationVoteMemberView;
+  dayCols: number[];
+}) {
+  // O(N×M) を避けるため day→target の Map を作る。投票は 1 日 1 回。
+  const byDay = useMemo(() => {
+    const m = new Map<number, string>();
+    for (const cell of member.voteList) m.set(cell.day, cell.targetCharaShortName);
+    return m;
+  }, [member.voteList]);
+  return (
+    <tr>
+      <td className="border border-slate-700 px-2 py-1 text-slate-300 whitespace-nowrap">
+        {member.charaShortName}
+      </td>
+      {dayCols.map((d) => (
+        <td key={d} className="border border-slate-700 px-2 py-1 text-center text-slate-200">
+          {byDay.get(d) ?? ""}
+        </td>
+      ))}
+    </tr>
+  );
+}
+
+function DayFootstepsTable({
+  rows,
+}: {
+  rows: { day: number; footstep: string }[];
+}) {
+  return (
+    <div className="overflow-x-auto">
+      <h3 className="text-xs text-slate-400 mb-1">足音 (日別)</h3>
+      <table className="min-w-full text-xs border-collapse">
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.day}>
+              <td className="border border-slate-700 px-2 py-1 text-center text-slate-300 w-12">
+                {r.day}d
+              </td>
+              <td className="border border-slate-700 px-2 py-1 whitespace-pre-line">
+                {r.footstep.trim().length > 0 ? r.footstep : "なし"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function formatList(items: string[]): string {
+  if (items.length === 0) return "なし";
+  return items.join("、");
+}

--- a/frontend/app/features/village/detail/SituationPanel.tsx
+++ b/frontend/app/features/village/detail/SituationPanel.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import type {
+  VillageDayFootstepView,
   VillageSituationDayView,
   VillageSituationView,
   VillageSituationVoteMemberView,
@@ -39,7 +40,14 @@ export function SituationPanel({
   if (selectedDay <= 0) return null;
 
   const hasWhole = visibleWhole.length > 0;
-  const hasVote = situation.vote.list.length > 0 && situation.vote.maxVoteCount > 0;
+  // 投票は前日に行われ翌日処刑なので、`selectedDay >= 3` ではじめて表示可能な投票が
+  // 1 つでも存在する (= 2d 投票結果が公開できる)。`VoteTable` の内部判定と
+  // 整合させ、`selectedDay <= 2` のときは「状況」セクションに投票表が無いだけで
+  // whole / dayFootsteps があれば表示する。
+  const hasVote =
+    situation.vote.list.length > 0 &&
+    situation.vote.maxVoteCount > 0 &&
+    selectedDay >= 3;
   const hasDayFootsteps = visibleDayFootsteps.some((d) => d.footstep.trim().length > 0);
 
   // 3 サブブロックいずれも内容なしならパネル自体出さない。
@@ -89,6 +97,10 @@ function WholeTable({ rows }: { rows: VillageSituationDayView[] }) {
               <td className="border border-slate-700 px-2 py-1">{formatList(r.revival)}</td>
               <td className="border border-slate-700 px-2 py-1">{formatList(r.suicide)}</td>
               {hasAbility && (
+                // 能力履歴は backend (`AbilityDomainService.mapAbilitySituation`) が
+                // `[type]from → to` の整形済み文字列を 1 件 1 行で List に詰めて返す。
+                // 他の列 (突然死 / 処刑等) は単純な name list なので `formatList` で
+                // 「、」区切りにするが、ability は 1 件ずつが長い文字列のため改行で並べる。
                 <td className="border border-slate-700 px-2 py-1 whitespace-pre-line">
                   {r.ability.join("\n")}
                 </td>
@@ -180,7 +192,7 @@ function VoteRow({
 function DayFootstepsTable({
   rows,
 }: {
-  rows: { day: number; footstep: string }[];
+  rows: VillageDayFootstepView[];
 }) {
   return (
     <div className="overflow-x-auto">

--- a/frontend/app/features/village/detail/api.ts
+++ b/frontend/app/features/village/detail/api.ts
@@ -19,6 +19,12 @@ export type VillageParticipantView = components["schemas"]["VillageParticipantVi
 export type VillageParticipantsView = components["schemas"]["VillageParticipantsView"];
 export type VillageFootstepView = components["schemas"]["VillageFootstepView"];
 export type VillageFootstepsView = components["schemas"]["VillageFootstepsView"];
+export type VillageSituationView = components["schemas"]["VillageSituationView"];
+export type VillageSituationDayView = components["schemas"]["VillageSituationDayView"];
+export type VillageSituationVoteView = components["schemas"]["VillageSituationVoteView"];
+export type VillageSituationVoteMemberView = components["schemas"]["VillageSituationVoteMemberView"];
+export type VillageSituationVoteCellView = components["schemas"]["VillageSituationVoteCellView"];
+export type VillageDayFootstepView = components["schemas"]["VillageDayFootstepView"];
 export type MessageView = components["schemas"]["MessageView"];
 export type MessagesView = components["schemas"]["MessagesView"];
 export type MyselfView = components["schemas"]["MyselfView"];
@@ -76,6 +82,17 @@ export async function fetchVillageFootsteps(
 ): Promise<VillageFootstepsView> {
   const res = await fetcher(`/api/v1/villages/${villageId}/footsteps`);
   if (!res.ok) throw new Error(`footsteps fetch failed: ${res.status}`);
+  return res.json();
+}
+
+export async function fetchVillageSituation(
+  villageId: number,
+  day: number | undefined,
+  fetcher: ApiFetch = browserFetch,
+): Promise<VillageSituationView> {
+  const qs = typeof day === "number" ? `?day=${day}` : "";
+  const res = await fetcher(`/api/v1/villages/${villageId}/situation${qs}`);
+  if (!res.ok) throw new Error(`situation fetch failed: ${res.status}`);
   return res.json();
 }
 

--- a/frontend/app/features/village/detail/hooks.ts
+++ b/frontend/app/features/village/detail/hooks.ts
@@ -18,6 +18,7 @@ import {
   fetchVillage,
   fetchVillageFootsteps,
   fetchVillageMessages,
+  fetchVillageSituation,
   postAbility,
   postAdminForceAccess,
   postAdminForceLeave,
@@ -53,6 +54,7 @@ import {
   type VillageCreatorSayBody,
   type VillageFaceTypeModifyBody,
   type VillageFootstepsView,
+  type VillageSituationView,
   type VillageKickBody,
   type VillageMemoBody,
   type VillageParticipateBody,
@@ -101,6 +103,26 @@ export function useVillageFootstepsQuery(
   return useQuery<VillageFootstepsView>({
     queryKey: ["village", villageId, "footsteps"],
     queryFn: () => fetchVillageFootsteps(villageId),
+    initialData,
+    initialDataUpdatedAt: initialData ? Date.now() : undefined,
+    refetchInterval: POLL_INTERVAL_MS,
+    staleTime: POLL_INTERVAL_MS,
+  });
+}
+
+/**
+ * 状況サマリ (whole / vote / dayFootsteps) を取得する。
+ * 日付タブを切替えても `day` は domain 側では ability 履歴の起点としてしか使われず、
+ * vote / whole / footstep の中身は同じになるため、queryKey に day は含めない。
+ * (旧 Thymeleaf 画面でも 1 ページにつき 1 回しか取得していなかった)。
+ */
+export function useVillageSituationQuery(
+  villageId: number,
+  initialData?: VillageSituationView,
+): UseQueryResult<VillageSituationView> {
+  return useQuery<VillageSituationView>({
+    queryKey: ["village", villageId, "situation"],
+    queryFn: () => fetchVillageSituation(villageId, undefined),
     initialData,
     initialDataUpdatedAt: initialData ? Date.now() : undefined,
     refetchInterval: POLL_INTERVAL_MS,

--- a/frontend/app/features/village/detail/hooks.ts
+++ b/frontend/app/features/village/detail/hooks.ts
@@ -112,9 +112,15 @@ export function useVillageFootstepsQuery(
 
 /**
  * 状況サマリ (whole / vote / dayFootsteps) を取得する。
- * 日付タブを切替えても `day` は domain 側では ability 履歴の起点としてしか使われず、
- * vote / whole / footstep の中身は同じになるため、queryKey に day は含めない。
- * (旧 Thymeleaf 画面でも 1 ページにつき 1 回しか取得していなかった)。
+ * `day` を渡さなければ backend は `latestDay` を採用し、すべての過去日を網羅した
+ * whole / vote / dayFootsteps を返す。frontend は受け取ったデータを `selectedDay`
+ * で client side に切るだけなので、`day` の値を変えて再 fetch する必要がない =
+ * queryKey に day を含めない (= 過去日タブ切替えで API コールを発生させない)。
+ *
+ * 注: domain 側では `day` は `whole` (能力履歴の起点) と `vote` (`filterPastDay`)
+ * の両方で使われており、`day` を変えると返却内容も変わりうる。ここで `undefined`
+ * (= latestDay) 固定にしているのは「常に最新までのデータを取り、client で切る」
+ * という設計判断であり、API 仕様上は `day` 引数で範囲を絞れる。
  */
 export function useVillageSituationQuery(
   villageId: number,

--- a/frontend/app/routes/villages.$id.tsx
+++ b/frontend/app/routes/villages.$id.tsx
@@ -6,6 +6,7 @@ import {
   fetchVillage,
   fetchVillageFootsteps,
   fetchVillageMessages,
+  fetchVillageSituation,
   type MessagesView,
   type MyselfView,
   type VillageFootstepsView,
@@ -18,6 +19,7 @@ import {
   useVillageFootstepsQuery,
   useVillageMessagesQuery,
   useVillageQuery,
+  useVillageSituationQuery,
 } from "~/features/village/detail/hooks";
 import { ActionPanel } from "~/features/village/detail/ActionPanel";
 import { AdminPanel } from "~/features/village/detail/AdminPanel";
@@ -26,6 +28,7 @@ import { MessageCard } from "~/features/village/detail/MessageCard";
 import { ParticipateActions } from "~/features/village/detail/ParticipateActions";
 import { RoomGridPanel } from "~/features/village/detail/RoomGridPanel";
 import { RpActions } from "~/features/village/detail/RpActions";
+import { SituationPanel } from "~/features/village/detail/SituationPanel";
 import { useMeQuery } from "~/features/auth/hooks";
 import { ssrFetch } from "~/lib/api/client";
 
@@ -62,12 +65,15 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   // 初期表示日: ?day= があればそれ、無ければ最新日 (= backend で `day` 未指定時と同じ)。
   // 「latest」をクエリキーに乗せる都合で、ここでは明示的に number に正規化して渡す。
   const initialDay = dayParam ?? village.time.latestDay;
-  const [messages, footsteps, myself] = await Promise.all([
+  const [messages, footsteps, myself, situation] = await Promise.all([
     fetchVillageMessages(villageId, initialDay, api).catch(() => null),
     fetchVillageFootsteps(villageId, api).catch(() => null),
     fetchMyself(villageId, api).catch(() => null),
+    // situation は day を渡さなくても backend 側で latestDay を採用するため未指定で OK。
+    // CSR でも `useVillageSituationQuery` は day なしで叩く想定。
+    fetchVillageSituation(villageId, undefined, api).catch(() => null),
   ]);
-  return { villageId, village, initialDay, messages, footsteps, myself };
+  return { villageId, village, initialDay, messages, footsteps, myself, situation };
 }
 
 export default function VillageDetail({ loaderData }: Route.ComponentProps) {
@@ -78,6 +84,7 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
     messages: initialMessages,
     footsteps: initialFootsteps,
     myself: initialMyself,
+    situation: initialSituation,
   } = loaderData;
 
   const [params, setParams] = useSearchParams();
@@ -96,6 +103,7 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
   );
   const footstepsQuery = useVillageFootstepsQuery(villageId, initialFootsteps ?? undefined);
   const myselfQuery = useMyselfQuery(villageId, initialMyself);
+  const situationQuery = useVillageSituationQuery(villageId, initialSituation ?? undefined);
   // 認証情報を取得して管理者 (CDef.Authority.管理者) 判定に使う。
   // SSR / 未ログイン時は失敗するが、`error` を握りつぶし `isAdmin=false` 扱いで進める。
   const meQuery = useMeQuery();
@@ -108,6 +116,7 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
   const messages = messagesQuery.data ?? null;
   const footsteps = footstepsQuery.data ?? initialFootsteps ?? null;
   const myself = myselfQuery.data ?? initialMyself ?? null;
+  const situation = situationQuery.data ?? initialSituation ?? null;
   // creator パネルの表示判定: 村建て本人または管理者 (旧仕様: 管理者 = 全村 creator 扱い)。
   const canSeeCreatorPanel = village.isCreator || isAdmin;
   // 発言は常に最新日に積まれる。過去日タブを見ているときに発言してもその日には
@@ -159,6 +168,8 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
         <RoomGridPanel village={village} day={selectedDay} />
 
         <ParticipantsPanel participants={village.participants.list} />
+
+        <SituationPanel situation={situation} selectedDay={selectedDay} />
 
         <MessagesPanel
           messages={messages}


### PR DESCRIPTION
## Summary

旧 Thymeleaf `situation.html` の "状況 / 投票 / 足音 (日別)" タブ相当を React 側に復元。
domain (`VillageWholeSituation` / `VillageVoteSituation` / `VillageFootstepSituation`)
は既存なので、それを REST 経由で公開し、フロントエンドで 3 テーブルを表示する。

- backend: `GET /api/v1/villages/{id}/situation?day={N}` (`VillageDetailRestController`)
  - `VillageSituationView` = `whole` (日次死亡 / 復活 / 能力) + `vote` (投票テーブル) + `dayFootsteps` (日別整形足音)
  - 既存 `VillageCoordinator.findVillageSituation` を経由するだけの薄いラッパー
  - spoiler 非公開時の `ability=[]` / 投票黒箱日除外は domain 側で既に処理済み
- frontend:
  - `SituationPanel.tsx` を新規追加 (`villages.\$id.tsx` のグリッドの後に配置)
  - `useVillageSituationQuery` を hooks に追加 (30s polling, SSR で initialData も渡す)
  - 選択中の `?day=N` 以下にテーブルを切り詰めてネタバレ防止 (旧画面踏襲)
  - `ability` 列は全行空ならヘッダごと省略 (= 旧 `dispSpoilerContent` 相当)

## 意図的スコープ外 (Step 12d / 12e 残)

- 発言フォーム拡張 (種別 / 大声 / 虹色 / アンカー自動入力 / 秘話宛先) → 12d
- 発言フィルタ / ページネーション / 村情報モーダル / 切り抜き → 12e

## 関連 issue

- `.issues/17-step-12c-vote-situation-summary.md`
- `HANDOFF.md` "次にやること: Step 12c"

## Test plan

- [x] `backend && ./gradlew test` passing
- [x] `frontend && pnpm typecheck` passing
- [x] `frontend && pnpm test` passing
- [x] `frontend && pnpm build` passing
- [x] `pnpm gen:api` で `VillageSituationView` 等の型生成を確認
- [ ] ローカル DB を初期化していないため UI 動作確認 (実村でのレイアウト / 黒箱日除外) は未実施。`pnpm gen:api` が成功し型整合性は確認できているが、render 時のレイアウト崩れ等は merge 後に手動確認推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)