### PR TITLE
fix: 新規村作成フォームのダミーキャラ dropdown 初期空問題を修正 (#18)

### DIFF
--- a/frontend/app/features/village/new/NewVillageForm.tsx
+++ b/frontend/app/features/village/new/NewVillageForm.tsx
@@ -31,6 +31,10 @@ export function NewVillageForm({ initial }: { initial: NewVillageFormView }) {
   // in-flight な charachip id (再 fetch 抑止用)。fetch 完了 / 失敗のどちらでも
   // 必ず delete して、unmount → 再 mount でも取得し直せるようにする。
   const fetchingRef = useRef<Set<number>>(new Set());
+  // 過去に取得失敗した id を保持。`charaListByChip` には載らないが、
+  // 他 id の成功で effect が再実行されるたびに同じ id を無限リトライしないよう
+  // ここで早期 return する (= 「黙って何もしない」というコメント通りの挙動を担保)。
+  const failedRef = useRef<Set<number>>(new Set());
   useEffect(() => {
     // 旧実装の `cancelled` フラグは React StrictMode の二重マウントで以下の
     // 死状態を作っていた (.issues/18 参照):
@@ -43,7 +47,12 @@ export function NewVillageForm({ initial }: { initial: NewVillageFormView }) {
     //       cleanup で書き込みを止める必要はない。
     const ids = body.characterSetId ?? [];
     ids.forEach((id) => {
-      if (charaListByChip.has(id) || fetchingRef.current.has(id)) return;
+      if (
+        charaListByChip.has(id) ||
+        fetchingRef.current.has(id) ||
+        failedRef.current.has(id)
+      )
+        return;
       fetchingRef.current.add(id);
       fetchCharachipDetail(id)
         .then((detail) => {
@@ -55,16 +64,20 @@ export function NewVillageForm({ initial }: { initial: NewVillageFormView }) {
           });
         })
         .catch(() => {
-          // 取得失敗時は黙って何もしない (UI 上は「キャラ選択肢なし」)
+          // 取得失敗時は黙って何もしない (UI 上は「キャラ選択肢なし」)。
+          // 他 id の成功による state 更新で effect が再実行されたときに、
+          // この id を無限リトライしないよう failedRef に記録する。
+          failedRef.current.add(id);
         })
         .finally(() => {
           fetchingRef.current.delete(id);
         });
     });
     // 依存は body.characterSetId (state 直参照、reference 安定) と charaListByChip
-    // (success 時の `has(id)` early return を新しい値で評価できるよう必要)。
-    // 以前の `characterSetId = body.characterSetId ?? []` (毎レンダー新規 array)
-    // を依存に入れると毎レンダー effect が走り、cancelled cleanup と race した。
+    // (= ある id の fetch 成功による state 更新をトリガーに、まだ未処理の id を
+    // 拾い直して fetch するため必要)。以前の
+    // `characterSetId = body.characterSetId ?? []` (毎レンダー新規 array) を
+    // 依存に入れると毎レンダー effect が走り、cancelled cleanup と race した。
   }, [body.characterSetId, charaListByChip]);
 
   const allCharas = useMemo(

--- a/frontend/app/features/village/new/NewVillageForm.tsx
+++ b/frontend/app/features/village/new/NewVillageForm.tsx
@@ -27,20 +27,28 @@ export function NewVillageForm({ initial }: { initial: NewVillageFormView }) {
   const [confirmOpen, setConfirmOpen] = useState(false);
 
   // 選択中キャラチップに含まれるキャラ一覧 (ダミーキャラ選択肢)
-  const characterSetId = body.characterSetId ?? [];
   const [charaListByChip, setCharaListByChip] = useState<Map<number, CharachipDetailView>>(new Map());
   // in-flight な charachip id (再 fetch 抑止用)。fetch 完了 / 失敗のどちらでも
   // 必ず delete して、unmount → 再 mount でも取得し直せるようにする。
   const fetchingRef = useRef<Set<number>>(new Set());
   useEffect(() => {
-    let cancelled = false;
-    characterSetId.forEach((id) => {
+    // 旧実装の `cancelled` フラグは React StrictMode の二重マウントで以下の
+    // 死状態を作っていた (.issues/18 参照):
+    //   #1 effect: id=1 で fetch 発射 → cleanup で cancelled_1=true
+    //   #2 effect (StrictMode 再マウント): fetchingRef.has(1) で skip
+    //   .then 解決: cancelled_1 が true なので setState skip
+    //   → setState されないまま fetch も二度と走らない
+    // 解決: cancelled を廃止し、`setCharaListByChip` 内で `prev.has(id)` の
+    //       idempotent guard を使う。同一 id に対する fetch 結果は不変なので、
+    //       cleanup で書き込みを止める必要はない。
+    const ids = body.characterSetId ?? [];
+    ids.forEach((id) => {
       if (charaListByChip.has(id) || fetchingRef.current.has(id)) return;
       fetchingRef.current.add(id);
       fetchCharachipDetail(id)
         .then((detail) => {
-          if (cancelled) return;
           setCharaListByChip((prev) => {
+            if (prev.has(id)) return prev;
             const next = new Map(prev);
             next.set(id, detail);
             return next;
@@ -53,14 +61,15 @@ export function NewVillageForm({ initial }: { initial: NewVillageFormView }) {
           fetchingRef.current.delete(id);
         });
     });
-    return () => {
-      cancelled = true;
-    };
-  }, [characterSetId, charaListByChip]);
+    // 依存は body.characterSetId (state 直参照、reference 安定) と charaListByChip
+    // (success 時の `has(id)` early return を新しい値で評価できるよう必要)。
+    // 以前の `characterSetId = body.characterSetId ?? []` (毎レンダー新規 array)
+    // を依存に入れると毎レンダー effect が走り、cancelled cleanup と race した。
+  }, [body.characterSetId, charaListByChip]);
 
   const allCharas = useMemo(
-    () => characterSetId.flatMap((id) => charaListByChip.get(id)?.charas ?? []),
-    [characterSetId, charaListByChip],
+    () => (body.characterSetId ?? []).flatMap((id) => charaListByChip.get(id)?.charas ?? []),
+    [body.characterSetId, charaListByChip],
   );
 
   const sayRestrictLabels = useMemo(


### PR DESCRIPTION
## Summary

\`/new-village\` 画面を初回表示したとき、ダミーキャラ dropdown が \"選択してください\" のみで
キャラ候補 32 件が表示されない問題を修正。チェックボックス toggle のワークアラウンドが
無いと村が建てられなかった。

## 原因

\`NewVillageForm.tsx\` の useEffect で:
- \`characterSetId = body.characterSetId ?? []\` を毎レンダーで新規 array として作って
  deps に入れていたため、毎レンダーで effect が再実行
- React StrictMode の二重マウントで初回 effect の cleanup で \`cancelled_1 = true\`
- 二度目の effect は \`fetchingRef.has(id)\` で fetch を skip
- 一度目の \`.then\` 解決時に \`cancelled_1 === true\` で setCharaListByChip skip
- 結果として fetch は成功するが state に反映されず、以降の effect も id が
  fetchingRef に残らないため再 fetch 不可、というデッドロック

## 修正

- deps を \`body.characterSetId\` (state 直参照、reference 安定) と \`charaListByChip\` に変更
- \`cancelled\` フラグと cleanup を廃止
- \`setCharaListByChip((prev) => prev.has(id) ? prev : ...)\` で idempotent guard を入れ、
  多重実行されても上書きにならないよう保護
- \`allCharas\` useMemo の deps も同様に \`body.characterSetId\` に揃え

## 動作確認

- \`/new-village\` 直接アクセスで dropdown に 33 options (人狼BBS 32 + placeholder) 表示 ✅
- 大神学園 toggle on → 79 options ✅
- toggle off → 33 options ✅

## Test plan

- [x] \`pnpm typecheck\` passing
- [x] \`pnpm test\` passing (11 tests)
- [x] \`pnpm build\` passing
- [x] Playwright で初期表示・toggle 動作を確認

## 関連

- Issue \`.issues/18-new-village-dummy-chara-dropdown-empty.md\` (PR #37 動作確認中に発覚)

🤖 Generated with [Claude Code](https://claude.com/claude-code)