### PR TITLE
Step 12d: 発言フォーム拡張 (種別 / 表情差分 / 装飾タグ / アンカー / 秘話 / 返信) (#19)

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/response/myself/MyselfSayView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/myself/MyselfSayView.kt
@@ -1,0 +1,94 @@
+package com.ort.app.api.response.myself
+
+import com.ort.app.domain.model.chara.Charachips
+import com.ort.app.domain.model.situation.participant.ParticipantSayMessageTypeSituation
+import com.ort.app.domain.model.situation.participant.ParticipantSaySituation
+import com.ort.app.domain.model.village.participant.VillageParticipant
+import com.ort.dbflute.allcommon.CDef
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 自分が今出せる発言の種別・表情差分・秘話宛先・制限情報をまとめて返す。
+ *
+ * 旧 Thymeleaf 版 `VillageFormContent.VillageSayFormContent` に対応 (発言フォーム表示用)。
+ * `availableMessageTypes` には各種別ごとの残回数 / 文字数制限を埋めており、フロントは
+ * 種別切替時にここから引いて UI を更新する。
+ *
+ * `availableMessageTypes` が空のとき (= 発言不可) は SayForm を出さない判定にも使える。
+ */
+@Schema(description = "自分視点の発言フォーム情報 (種別 / 表情差分 / 秘話宛先 / 制限)")
+data class MyselfSayView(
+    @field:Schema(description = "発言可能か (= availableMessageTypes が非空 + 村のステータスが発言可能)")
+    val isAvailableSay: Boolean,
+    @field:Schema(description = "選択可能な発言種別の一覧 (順序は domain 既定: 恋人/念話/囁き/共鳴/独り言/通常/呻き/見学/秘話/アクション)")
+    val availableMessageTypes: List<MyselfSayMessageTypeView>,
+    @field:Schema(description = "デフォルト選択する発言種別コード (発言不可なら null)")
+    val defaultMessageTypeCode: String?,
+    @field:Schema(description = "選択可能な表情差分 (発言時のキャラ画像切替用)")
+    val selectableFaceTypes: List<MyselfFaceTypeView>,
+    @field:Schema(description = "秘話の宛先候補。秘話が選べない村ステータス / 役職では空配列")
+    val secretSayTargets: List<MyselfSecretSayTargetView>,
+) {
+    constructor(situation: ParticipantSaySituation, charachips: Charachips) : this(
+        isAvailableSay = situation.isAvailableSay,
+        availableMessageTypes = situation.selectableMessageTypeList.map { MyselfSayMessageTypeView(it) },
+        defaultMessageTypeCode = situation.defaultMessageType?.code,
+        selectableFaceTypes = situation.selectableCharaImageList.map {
+            MyselfFaceTypeView(
+                code = it.faceType.code,
+                name = it.faceType.name,
+                url = it.url,
+                isDisplay = it.isDisplay,
+            )
+        },
+        secretSayTargets = situation.selectableMessageTypeList
+            .firstOrNull { it.messageType.code == CDef.MessageType.秘話.code() }
+            ?.targetList
+            ?.map { MyselfSecretSayTargetView(it, charachips) }
+            ?: emptyList(),
+    )
+}
+
+@Schema(description = "発言種別 1 件 (制限情報込み)")
+data class MyselfSayMessageTypeView(
+    @field:Schema(description = "種別コード (CDef.MessageType)")
+    val code: String,
+    @field:Schema(description = "種別表示名")
+    val name: String,
+    @field:Schema(description = "発言制限がかかっているか")
+    val isRestricted: Boolean,
+    @field:Schema(description = "1 日あたりの最大回数 (制限なしなら null)")
+    val maxCount: Int?,
+    @field:Schema(description = "残り回数 (制限なしなら null)")
+    val remainingCount: Int?,
+    @field:Schema(description = "1 発言あたりの最大文字数")
+    val maxLength: Int,
+    @field:Schema(description = "1 発言あたりの最大行数")
+    val maxLine: Int,
+) {
+    constructor(situation: ParticipantSayMessageTypeSituation) : this(
+        code = situation.messageType.code,
+        name = situation.messageType.name,
+        isRestricted = situation.restrict.isRestricted,
+        maxCount = situation.restrict.maxCount,
+        remainingCount = situation.restrict.remainingCount,
+        maxLength = situation.restrict.maxLength,
+        maxLine = situation.restrict.maxLine,
+    )
+}
+
+@Schema(description = "秘話の宛先候補 1 件")
+data class MyselfSecretSayTargetView(
+    @field:Schema(description = "キャラ ID")
+    val charaId: Int,
+    @field:Schema(description = "表示名 ([部屋番号略称] 名前)")
+    val name: String,
+    @field:Schema(description = "キャラ画像 URL (デフォルト顔)")
+    val imageUrl: String,
+) {
+    constructor(participant: VillageParticipant, charachips: Charachips) : this(
+        charaId = participant.charaId,
+        name = participant.name(),
+        imageUrl = charachips.chara(participant.charaId).defaultImage().url,
+    )
+}

--- a/backend/src/main/kotlin/com/ort/app/api/response/myself/MyselfView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/myself/MyselfView.kt
@@ -1,11 +1,13 @@
 package com.ort.app.api.response.myself
 
 import com.ort.app.api.response.skill.SkillView
+import com.ort.app.domain.model.chara.Charachips
 import com.ort.app.domain.model.situation.MyselfActionSituation
 import com.ort.app.domain.model.situation.ParticipantSituation
 import com.ort.app.domain.model.situation.participant.ParticipantAbilitySituation
 import com.ort.app.domain.model.situation.participant.ParticipantCommitSituation
 import com.ort.app.domain.model.situation.participant.ParticipantRpSituation
+import com.ort.app.domain.model.situation.participant.ParticipantSaySituation
 import com.ort.app.domain.model.situation.participant.ParticipantVoteSituation
 import com.ort.app.domain.model.village.participant.VillageParticipant
 import io.swagger.v3.oas.annotations.media.Schema
@@ -50,29 +52,37 @@ data class MyselfView(
     val ability: MyselfAbilityView,
     @field:Schema(description = "RP 状態 (キャラ名 / メモ / 表情差分の編集可否)")
     val rp: MyselfRpView,
+    @field:Schema(description = "発言フォーム情報 (種別 / 表情差分 / 秘話宛先 / 制限)")
+    val say: MyselfSayView,
 ) {
-    constructor(myself: VillageParticipant, situation: ParticipantSituation) : this(
+    constructor(myself: VillageParticipant, situation: ParticipantSituation, charachips: Charachips) : this(
         myself = myself,
+        charachips = charachips,
         commitSituation = situation.commit,
         voteSituation = situation.vote,
         abilitySituation = situation.ability,
         rpSituation = situation.rp,
+        saySituation = situation.say,
     )
 
-    constructor(myself: VillageParticipant, situation: MyselfActionSituation) : this(
+    constructor(myself: VillageParticipant, situation: MyselfActionSituation, charachips: Charachips) : this(
         myself = myself,
+        charachips = charachips,
         commitSituation = situation.commit,
         voteSituation = situation.vote,
         abilitySituation = situation.ability,
         rpSituation = situation.rp,
+        saySituation = situation.say,
     )
 
     private constructor(
         myself: VillageParticipant,
+        charachips: Charachips,
         commitSituation: ParticipantCommitSituation,
         voteSituation: ParticipantVoteSituation,
         abilitySituation: ParticipantAbilitySituation,
         rpSituation: ParticipantRpSituation,
+        saySituation: ParticipantSaySituation,
     ) : this(
         id = myself.id,
         charaId = myself.charaId,
@@ -90,5 +100,6 @@ data class MyselfView(
         vote = MyselfVoteView(voteSituation),
         ability = MyselfAbilityView(abilitySituation),
         rp = MyselfRpView(rpSituation),
+        say = MyselfSayView(saySituation, charachips),
     )
 }

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
@@ -191,13 +191,14 @@ class VillageDetailRestController(
         val situation = villageCoordinator.findMyselfActionSituation(
             village = ctx.village,
             myself = myself,
+            username = ctx.user?.username,
             votes = voteService.findVotes(ctx.village.id),
             abilities = abilityService.findAbilities(ctx.village.id),
             footsteps = footstepService.findFootsteps(ctx.village.id),
             charachips = ctx.charachips,
             day = ctx.village.latestDay(),
         )
-        return ResponseEntity.ok(MyselfView(myself, situation))
+        return ResponseEntity.ok(MyselfView(myself, situation, ctx.charachips))
     }
 
     /**

--- a/backend/src/main/kotlin/com/ort/app/application/coordinator/VillageCoordinator.kt
+++ b/backend/src/main/kotlin/com/ort/app/application/coordinator/VillageCoordinator.kt
@@ -411,18 +411,19 @@ class VillageCoordinator(
     }
 
     /**
-     * REST `/myself` 専用の軽量版。commit / vote / ability / rp の 4 サブ situation だけを構築し、
-     * `findParticipantSituation` が必要としていた以下の重い処理を行わない:
-     * - `playerService.findPlayer(username)` (myself 用)
-     * - `messageService.findParticipantDayMessageCount(...)` (say 用の発言数集計)
-     * - `playerService.findPlayer(creator)` (say の creatorPlayerId 用)
-     * - participate / skillRequest / say / admin / creator の各 sub-situation 構築
+     * REST `/myself` 専用版。commit / vote / ability / rp / say の 5 サブ situation を構築する。
      *
      * 旧 Thymeleaf 系 (`VillageControllerHelper`) は引き続き `findParticipantSituation` を使う。
+     * こちらは `participate / skillRequest / admin / creator` の各 sub-situation を持たないぶん
+     * 軽量だが、`say` を返すために以下の lookup は必要:
+     * - `playerService.findPlayer(username)` (player-aware な発言可否判定)
+     * - `messageService.findParticipantDayMessageCount(...)` (発言制限の残回数)
+     * - `playerService.findPlayer(creator)` (creator は発言制限の例外、その判定用)
      */
     fun findMyselfActionSituation(
         village: Village,
         myself: VillageParticipant,
+        username: String?,
         votes: Votes,
         abilities: Abilities,
         footsteps: Footsteps,
@@ -430,6 +431,9 @@ class VillageCoordinator(
         day: Int,
     ): MyselfActionSituation {
         val commits = commitService.findCommits(village.id)
+        val player: Player? = username?.let { playerService.findPlayer(it) }
+        val latestDayMessageCountMap = messageService.findParticipantDayMessageCount(village, village.latestDay(), myself)
+        val creator = playerService.findPlayer(village.createPlayerName)!!
         return MyselfActionSituation(
             commit = commitDomainService.convertToSituation(village, myself, commits),
             vote = voteDomainService.convertToParticipantSituation(village, myself, votes),
@@ -442,6 +446,15 @@ class VillageCoordinator(
                 day
             ),
             rp = rpDomainService.convertToSituation(village, myself, charachips, day),
+            say = sayDomainService.convertToSituation(
+                village = village,
+                myself = myself,
+                player = player,
+                charachips = charachips,
+                day = day,
+                latestDayMessageCountMap = latestDayMessageCountMap,
+                creatorPlayerId = creator.id,
+            ),
         )
     }
 

--- a/backend/src/main/kotlin/com/ort/app/domain/model/situation/MyselfActionSituation.kt
+++ b/backend/src/main/kotlin/com/ort/app/domain/model/situation/MyselfActionSituation.kt
@@ -3,6 +3,7 @@ package com.ort.app.domain.model.situation
 import com.ort.app.domain.model.situation.participant.ParticipantAbilitySituation
 import com.ort.app.domain.model.situation.participant.ParticipantCommitSituation
 import com.ort.app.domain.model.situation.participant.ParticipantRpSituation
+import com.ort.app.domain.model.situation.participant.ParticipantSaySituation
 import com.ort.app.domain.model.situation.participant.ParticipantVoteSituation
 
 data class MyselfActionSituation(
@@ -10,4 +11,5 @@ data class MyselfActionSituation(
     val vote: ParticipantVoteSituation,
     val ability: ParticipantAbilitySituation,
     val rp: ParticipantRpSituation,
+    val say: ParticipantSaySituation,
 )

--- a/backend/src/main/kotlin/com/ort/app/domain/service/SayDomainService.kt
+++ b/backend/src/main/kotlin/com/ort/app/domain/service/SayDomainService.kt
@@ -115,7 +115,7 @@ class SayDomainService(
                         maxLength = restrict?.length ?: MessageContent.defaultLengthMax,
                         maxLine = MessageContent.defaultLineMax
                     ),
-                    targetList = getSecretSayTargetList(it, village, creatorPlayerId, myself!!, player!!)
+                    targetList = getSecretSayTargetList(it, village, creatorPlayerId, myself!!, player)
                 )
             }
     }
@@ -161,9 +161,14 @@ class SayDomainService(
         village: Village,
         creatorPlayerId: Int,
         myself: VillageParticipant,
-        player: Player,
+        player: Player?,
     ): List<VillageParticipant> {
         if (messageType != CDef.MessageType.秘話) return emptyList()
+        // 呼び出し側 (`convertToSituation`) は `player: Player?` を受けて未認証等で
+        // null を渡しうるので、null のときは秘話宛先を取り出せない = 空を返す。
+        // 呼び出し側が `getSelectableMessageTypeList` 内で `player!!` していたのを
+        // ここでガードに寄せている。
+        player ?: return emptyList()
         val base = village.allParticipants().sortedByRoomNumber().list.filter { it.id != myself.id }
         // 管理者および村建ては全員
         return if (myself.isAdmin() || village.isCreator(player)) base

--- a/frontend/app/features/village/detail/MessageCard.tsx
+++ b/frontend/app/features/village/detail/MessageCard.tsx
@@ -1,4 +1,5 @@
 import type { MessageView, VillageParticipantView } from "./api";
+import { useSayFormRequester } from "./SayFormContext";
 
 /**
  * 1 発言ぶんのカード。`MessageView.typeCode` に応じて色 / 番号プレフィックスを出し分け、
@@ -7,8 +8,11 @@ import type { MessageView, VillageParticipantView } from "./api";
  * 旧 Thymeleaf 版 `.old-thymeleaf/templates/village-template/message-partial.html` の
  * 表示種別 (NORMAL_SAY / WEREWOLF_SAY / MASON_SAY / LOVERS_SAY / MONOLOGUE_SAY /
  * SECRET_SAY / GRAVE_SAY / SPECTATE_SAY / CREATOR_SAY / TELEPATHY / ACTION / 各種
- * PRIVATE_* / PUBLIC_SYSTEM / PARTICIPANTS) を一通りカバーする。表情差分 / 大声 /
- * 虹色 / 返信 / 秘話 ボタンは Step 12d で扱う。
+ * PRIVATE_* / PUBLIC_SYSTEM / PARTICIPANTS) を一通りカバーする。
+ *
+ * Step 12d 以降:
+ * - アンカー (`>>N` のラベル部分) をクリックすると SayForm の textarea に `>>N` を挿入
+ * - 各カードに [返信] を出し、SECRET_SAY なら宛先 auto-set 込みで反映
  */
 export function MessageCard({
   message,
@@ -21,6 +25,7 @@ export function MessageCard({
   const fromParticipant = message.fromParticipantId != null
     ? participantsById.get(message.fromParticipantId)
     : undefined;
+  const requestSay = useSayFormRequester();
 
   // PUBLIC_SYSTEM / PRIVATE_* / PARTICIPANTS 等は番号も発言者も持たない単純な
   // システム枠で出す (旧画面 message-public-system / message-private-* に対応)。
@@ -36,6 +41,27 @@ export function MessageCard({
   }
 
   const anchor = renderAnchor(style.anchorPrefix, message.number);
+  const isSecret = message.typeCode === "SECRET_SAY";
+
+  function handleAnchorClick() {
+    if (message.number == null) return;
+    requestSay({
+      anchorPrefix: style.anchorPrefix,
+      messageNumber: message.number,
+      isSecret: false,
+    });
+  }
+
+  function handleReplyClick() {
+    if (message.number == null) return;
+    requestSay({
+      anchorPrefix: style.anchorPrefix,
+      messageNumber: message.number,
+      isSecret,
+      // 秘話への返信: 元発言者のキャラ ID を宛先に
+      secretTargetCharaId: isSecret ? fromParticipant?.chara.id : undefined,
+    });
+  }
 
   return (
     <article
@@ -43,7 +69,16 @@ export function MessageCard({
       data-message-type={message.typeCode}
     >
       <header className="px-3 pt-2 text-xs text-slate-400 flex flex-wrap items-center gap-x-2 gap-y-0.5">
-        {anchor && <span className="font-mono">{anchor}</span>}
+        {anchor && (
+          <button
+            type="button"
+            onClick={handleAnchorClick}
+            className="font-mono text-slate-400 hover:text-indigo-300"
+            title="アンカーを発言フォームに挿入"
+          >
+            {anchor}
+          </button>
+        )}
         <span className="text-slate-200">{message.fromCharaName ?? style.fallbackFrom}</span>
         {message.toCharaName && (
           <span className="text-slate-400">→ {message.toCharaName}</span>
@@ -52,6 +87,16 @@ export function MessageCard({
           <span className="text-slate-500">[{fromParticipant.playerName}]</span>
         )}
         <span className="text-slate-500 ml-auto">{formatTime(message.datetime)}</span>
+        {message.number != null && (
+          <button
+            type="button"
+            onClick={handleReplyClick}
+            className="text-xs px-1.5 py-0.5 rounded border border-slate-600 text-slate-300 hover:border-slate-400"
+            title={isSecret ? "秘話で返信 (宛先 auto-set)" : "返信"}
+          >
+            返信
+          </button>
+        )}
       </header>
       <div className="px-3 pb-2 pt-1 flex gap-2">
         {fromParticipant && (

--- a/frontend/app/features/village/detail/SayForm.tsx
+++ b/frontend/app/features/village/detail/SayForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { MyselfSayMessageTypeView, MyselfView } from "./api";
 import { useSayMutation } from "./hooks";
 import { useSayAnchorSubscription } from "./SayFormContext";
@@ -43,6 +43,19 @@ export function SayForm({
   );
   const [convertDisable, setConvertDisable] = useState(false);
   const [secretTargetCharaId, setSecretTargetCharaId] = useState<number | "">("");
+  // テキスト挿入後にカーソル位置を確実に DOM へ反映するため、React の commit 後に
+  // 動く `useLayoutEffect` で setSelectionRange する。`requestAnimationFrame` だと
+  // concurrent mode 下で稀に setText の commit より前に走り、カーソル位置が
+  // ずれることがあるため避ける。
+  const [pendingCursor, setPendingCursor] = useState<number | null>(null);
+  useLayoutEffect(() => {
+    if (pendingCursor == null) return;
+    const el = textareaRef.current;
+    if (!el) return;
+    el.focus();
+    el.setSelectionRange(pendingCursor, pendingCursor);
+    setPendingCursor(null);
+  }, [pendingCursor, text]);
 
   // myself が更新されて (= 役職判明 / 死亡 等) 現在の messageTypeCode が消えたら
   // デフォルトに切り替える。発言種別を変えた選択は維持したいので、まだ available
@@ -70,7 +83,10 @@ export function SayForm({
       }
     }
     const anchorText = `${req.anchorPrefix}${req.messageNumber}\n`;
-    appendToTextarea(textareaRef.current, anchorText, setText);
+    const needsLeadingNewline = text.length > 0 && !text.endsWith("\n");
+    const newText = needsLeadingNewline ? `${text}\n${anchorText}` : text + anchorText;
+    setText(newText);
+    setPendingCursor(newText.length);
   });
 
   const currentTypeInfo = availableTypes.find((t) => t.code === messageTypeCode) ?? defaultType;
@@ -114,13 +130,9 @@ export function SayForm({
       inserted = `[[${tag}]]`;
       nextCursor = start + inserted.length;
     }
-    const next = before + inserted + after;
-    setText(next);
-    // setText は非同期、次フレームで selection を戻す
-    requestAnimationFrame(() => {
-      el.focus();
-      el.setSelectionRange(nextCursor, nextCursor);
-    });
+    setText(before + inserted + after);
+    // commit 後に確実に setSelectionRange するため useLayoutEffect 経由で位置反映
+    setPendingCursor(nextCursor);
   }
 
   function submit(e: React.FormEvent) {
@@ -393,27 +405,12 @@ function submitLabel(typeCode: string): string {
       return "呻く";
     case "SPECTATE_SAY":
       return "見学発言";
+    case "ACTION":
+      // アクション発言は専用 UI (旧 ActionPanel 相当) が未実装で、本 SayForm の
+      // 種別タブには通常出ない想定。万一 backend が含めて返した場合は汎用ラベルで動く
+      return "アクション";
     default:
       return "発言する";
   }
 }
 
-function appendToTextarea(
-  el: HTMLTextAreaElement | null,
-  insertText: string,
-  setText: (updater: (prev: string) => string) => void,
-) {
-  setText((prev) => {
-    // 末尾に改行が無ければ改行を 1 つ挟む (旧画面の `>>N` 挿入相当)。
-    // すでに `>>N\n` の形で入ってきている (anchorText) のでそのまま付ければ良い。
-    const needsLeadingNewline = prev.length > 0 && !prev.endsWith("\n");
-    return needsLeadingNewline ? `${prev}\n${insertText}` : prev + insertText;
-  });
-  // textarea にフォーカスを戻し末尾にカーソル移動
-  requestAnimationFrame(() => {
-    if (!el) return;
-    el.focus();
-    const end = el.value.length;
-    el.setSelectionRange(end, end);
-  });
-}

--- a/frontend/app/features/village/detail/SayForm.tsx
+++ b/frontend/app/features/village/detail/SayForm.tsx
@@ -1,0 +1,419 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { MyselfSayMessageTypeView, MyselfView } from "./api";
+import { useSayMutation } from "./hooks";
+import { useSayAnchorSubscription } from "./SayFormContext";
+
+const SECRET_SAY_CODE = "SECRET_SAY";
+
+/**
+ * 発言フォーム (Step 12d で旧 Thymeleaf `say-form.html` 相当を React に復元)。
+ *
+ * - 発言種別タブ (myself.say.availableMessageTypes)
+ * - 表情差分セレクタ (myself.say.selectableFaceTypes、選択中の画像をプレビュー)
+ * - 装飾タグボタン (二重タグ / 色タグ / 単発タグ)
+ * - アンカー自動入力 (MessageCard クリック → SayFormContext 経由で `>>N\n` 挿入)
+ * - 返信ボタン (秘話なら messageType=SECRET_SAY + 宛先 auto-set)
+ * - 秘話宛先セレクタ
+ * - 変換無効チェック
+ * - 残り回数 / 文字数表示 + submit ガード
+ *
+ * 表示判定 (= 親側で SayForm 自体を出すか) は `myself.say.isAvailableSay && availableMessageTypes 非空`
+ * を呼び出し側でチェックしてもらう前提。
+ */
+export function SayForm({
+  villageId,
+  myself,
+}: {
+  villageId: number;
+  myself: MyselfView;
+}) {
+  const sayMutation = useSayMutation(villageId);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const availableTypes = myself.say.availableMessageTypes;
+  const defaultType = useMemo(() => {
+    const code = myself.say.defaultMessageTypeCode;
+    return availableTypes.find((t) => t.code === code) ?? availableTypes[0];
+  }, [myself.say.defaultMessageTypeCode, availableTypes]);
+
+  const [messageTypeCode, setMessageTypeCode] = useState<string>(defaultType?.code ?? "NORMAL_SAY");
+  const [text, setText] = useState("");
+  const [faceTypeCode, setFaceTypeCode] = useState<string>(
+    () => myself.say.selectableFaceTypes[0]?.code ?? "",
+  );
+  const [convertDisable, setConvertDisable] = useState(false);
+  const [secretTargetCharaId, setSecretTargetCharaId] = useState<number | "">("");
+
+  // myself が更新されて (= 役職判明 / 死亡 等) 現在の messageTypeCode が消えたら
+  // デフォルトに切り替える。発言種別を変えた選択は維持したいので、まだ available
+  // ならそのまま残す。
+  useEffect(() => {
+    if (availableTypes.find((t) => t.code === messageTypeCode)) return;
+    setMessageTypeCode(defaultType?.code ?? "NORMAL_SAY");
+  }, [availableTypes, defaultType, messageTypeCode]);
+
+  // 表情差分も同様: 現選択が消えたら先頭に戻す
+  useEffect(() => {
+    if (myself.say.selectableFaceTypes.find((f) => f.code === faceTypeCode)) return;
+    setFaceTypeCode(myself.say.selectableFaceTypes[0]?.code ?? "");
+  }, [myself.say.selectableFaceTypes, faceTypeCode]);
+
+  // アンカー / 返信を受け取って textarea 末尾に挿入
+  useSayAnchorSubscription((req) => {
+    if (req.isSecret) {
+      // 秘話への返信: messageType を SECRET_SAY に切替、宛先も auto-set
+      if (availableTypes.find((t) => t.code === SECRET_SAY_CODE)) {
+        setMessageTypeCode(SECRET_SAY_CODE);
+        if (req.secretTargetCharaId != null) {
+          setSecretTargetCharaId(req.secretTargetCharaId);
+        }
+      }
+    }
+    const anchorText = `${req.anchorPrefix}${req.messageNumber}\n`;
+    appendToTextarea(textareaRef.current, anchorText, setText);
+  });
+
+  const currentTypeInfo = availableTypes.find((t) => t.code === messageTypeCode) ?? defaultType;
+  const isSecret = messageTypeCode === SECRET_SAY_CODE;
+  const secretSayTargets = myself.say.secretSayTargets;
+
+  // 残り回数: 制限ありで remainingCount == 0 のときは disable
+  const remainingCount = currentTypeInfo?.remainingCount ?? null;
+  const maxCount = currentTypeInfo?.maxCount ?? null;
+  const maxLength = currentTypeInfo?.maxLength ?? 400;
+  const maxLine = currentTypeInfo?.maxLine ?? 20;
+  const lineCount = text.length === 0 ? 0 : text.split("\n").length;
+  const isOverLength = text.length > maxLength;
+  const isOverLine = lineCount > maxLine;
+  const hasRemaining = remainingCount == null || remainingCount > 0;
+  const needsSecretTarget = isSecret && secretTargetCharaId === "";
+  const canSubmit =
+    !sayMutation.isPending &&
+    text.trim().length > 0 &&
+    !isOverLength &&
+    !isOverLine &&
+    hasRemaining &&
+    !needsSecretTarget;
+
+  function insertTag(tag: string, kind: "double" | "single") {
+    const el = textareaRef.current;
+    if (!el) return;
+    const start = el.selectionStart;
+    const end = el.selectionEnd;
+    const before = text.slice(0, start);
+    const selected = text.slice(start, end);
+    const after = text.slice(end);
+    let inserted: string;
+    let nextCursor: number;
+    if (kind === "double") {
+      inserted = `[[${tag}]]${selected}[[/${tag}]]`;
+      // 選択あり → 挿入後の選択範囲末尾、無し → 開きタグ直後
+      nextCursor = selected.length > 0 ? start + inserted.length : start + `[[${tag}]]`.length;
+    } else {
+      // 単発タグ ([[...]] を 1 つだけ挿入。`tag` が空なら `[[]]` を挿入する旧画面踏襲)
+      inserted = `[[${tag}]]`;
+      nextCursor = start + inserted.length;
+    }
+    const next = before + inserted + after;
+    setText(next);
+    // setText は非同期、次フレームで selection を戻す
+    requestAnimationFrame(() => {
+      el.focus();
+      el.setSelectionRange(nextCursor, nextCursor);
+    });
+  }
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    sayMutation.mutate(
+      {
+        message: text,
+        messageType: messageTypeCode,
+        faceType: faceTypeCode || undefined,
+        convertDisable: convertDisable || undefined,
+        secretSayTargetCharaId:
+          isSecret && typeof secretTargetCharaId === "number" ? secretTargetCharaId : undefined,
+      },
+      {
+        onSuccess: () => {
+          setText("");
+          // 秘話宛先は連続で同じ相手に送ることが多いので維持する (旧画面踏襲)
+        },
+      },
+    );
+  }
+
+  return (
+    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
+      <h2 className="text-sm text-slate-400 mb-2">発言</h2>
+
+      {/* 発言種別タブ */}
+      <div role="radiogroup" aria-label="発言種別" className="flex flex-wrap gap-1 mb-2">
+        {availableTypes.map((t) => (
+          <MessageTypeButton
+            key={t.code}
+            type={t}
+            active={t.code === messageTypeCode}
+            onSelect={() => setMessageTypeCode(t.code)}
+          />
+        ))}
+      </div>
+
+      {/* 秘話宛先 (秘話選択時のみ) */}
+      {isSecret && (
+        <div className="mb-2">
+          <label className="block text-xs text-slate-400 mb-1">秘話相手</label>
+          <select
+            value={secretTargetCharaId}
+            onChange={(e) =>
+              setSecretTargetCharaId(e.target.value === "" ? "" : Number(e.target.value))
+            }
+            className="w-full bg-slate-900 border border-slate-700 rounded px-2 py-1 text-sm text-slate-100"
+          >
+            <option value="">秘話相手を選択してください</option>
+            {secretSayTargets.map((t) => (
+              <option key={t.charaId} value={t.charaId}>
+                {t.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {/* 装飾タグ */}
+      <DecorationTagBar onInsert={insertTag} />
+
+      <form onSubmit={submit} className="space-y-2">
+        <div className="flex gap-2">
+          {/* キャラ画像プレビュー + 表情差分セレクタ */}
+          {myself.say.selectableFaceTypes.length > 0 && (
+            <div className="flex flex-col items-stretch shrink-0 w-32">
+              <img
+                src={
+                  myself.say.selectableFaceTypes.find((f) => f.code === faceTypeCode)?.url ??
+                  myself.say.selectableFaceTypes[0]?.url
+                }
+                alt={faceTypeCode}
+                loading="lazy"
+                className="rounded border border-slate-700 max-w-full"
+                style={{ maxHeight: 120, width: "auto", height: "auto" }}
+              />
+              <select
+                value={faceTypeCode}
+                onChange={(e) => setFaceTypeCode(e.target.value)}
+                className="mt-1 bg-slate-900 border border-slate-700 rounded px-1 py-0.5 text-xs text-slate-100"
+              >
+                {myself.say.selectableFaceTypes.map((f) => (
+                  <option key={f.code} value={f.code}>
+                    {f.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          <textarea
+            ref={textareaRef}
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            rows={6}
+            placeholder={`発言を入力 (${maxLength} 文字以内)`}
+            className="flex-1 bg-slate-900 border border-slate-700 rounded px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:outline-none focus:border-indigo-500"
+            disabled={sayMutation.isPending}
+          />
+        </div>
+
+        {/* 文字数 / 行数 / 残り回数 */}
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-400">
+          <span className={isOverLength ? "text-rose-300" : ""}>
+            文字数 {text.length} / {maxLength}
+          </span>
+          <span className={isOverLine ? "text-rose-300" : ""}>
+            行数 {lineCount} / {maxLine}
+          </span>
+          {remainingCount != null && maxCount != null && (
+            <span className={remainingCount === 0 ? "text-rose-300" : ""}>
+              残り {remainingCount} / {maxCount} 回
+            </span>
+          )}
+          <label className="ml-auto flex items-center gap-1 text-slate-300 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={convertDisable}
+              onChange={(e) => setConvertDisable(e.target.checked)}
+              className="accent-indigo-500"
+            />
+            装飾・変換無効
+          </label>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className="rounded bg-indigo-500 hover:bg-indigo-400 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium"
+          >
+            {sayMutation.isPending ? "送信中..." : submitLabel(messageTypeCode)}
+          </button>
+          {sayMutation.isError && (
+            <span className="text-xs text-rose-300">{sayMutation.error.message}</span>
+          )}
+        </div>
+      </form>
+    </section>
+  );
+}
+
+function MessageTypeButton({
+  type,
+  active,
+  onSelect,
+}: {
+  type: MyselfSayMessageTypeView;
+  active: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={active}
+      onClick={onSelect}
+      className={`px-2 py-1 rounded border text-xs ${
+        active
+          ? "bg-indigo-500 border-indigo-400 text-white"
+          : "bg-slate-900 border-slate-700 text-slate-300 hover:border-slate-500"
+      }`}
+    >
+      {type.name}
+    </button>
+  );
+}
+
+/**
+ * 旧 say-form.html の `data-tag-type=double / single` ボタン群を Tailwind に移植。
+ * クリックで textarea の選択範囲を `[[<tag>]]...[[/<tag>]]` でラップ (色タグは tag に
+ * `#ff0000` 等が入る)。`single` は `[[]]` を 1 つ挿入するだけ。
+ */
+function DecorationTagBar({
+  onInsert,
+}: {
+  onInsert: (tag: string, kind: "double" | "single") => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-1 mb-2">
+      <TagBtn label="B" tag="b" kind="double" onInsert={onInsert} bold />
+      <TagBtn label="S" tag="s" kind="double" onInsert={onInsert} strike />
+      <TagBtn label="大" tag="large" kind="double" onInsert={onInsert} />
+      <TagBtn label="小" tag="small" kind="double" onInsert={onInsert} />
+      <TagBtn label="rb" tag="ruby" kind="double" onInsert={onInsert} />
+      <TagBtn label="隠" tag="cw" kind="double" onInsert={onInsert} />
+      <TagBtn label="透" tag="tp" kind="double" onInsert={onInsert} />
+      {["#ff0000", "#ff8800", "#dddd00", "#00dd00", "#00dddd", "#0000ff", "#ee00ee"].map((c) => (
+        <ColorTagBtn key={c} color={c} onInsert={onInsert} />
+      ))}
+      {/* 単発 [[]] (旧画面の data-tag-type=single, data-tag-name=""): カーソル位置に
+          [[]] を挿入。ランダムタグ等を後から書く起点として使う */}
+      <button
+        type="button"
+        onClick={() => onInsert("", "single")}
+        className="px-2 py-0.5 rounded border bg-slate-900 border-slate-700 text-slate-300 hover:border-slate-500 text-xs"
+        title="[[]] を挿入"
+      >
+        [[]]
+      </button>
+    </div>
+  );
+}
+
+function TagBtn({
+  label,
+  tag,
+  kind,
+  onInsert,
+  bold,
+  strike,
+}: {
+  label: string;
+  tag: string;
+  kind: "double" | "single";
+  onInsert: (tag: string, kind: "double" | "single") => void;
+  bold?: boolean;
+  strike?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onInsert(tag, kind)}
+      className={`px-2 py-0.5 rounded border bg-slate-900 border-slate-700 text-slate-300 hover:border-slate-500 text-xs ${
+        bold ? "font-bold" : ""
+      } ${strike ? "line-through" : ""}`}
+      title={`[[${tag}]]...[[/${tag}]]`}
+    >
+      {label}
+    </button>
+  );
+}
+
+function ColorTagBtn({
+  color,
+  onInsert,
+}: {
+  color: string;
+  onInsert: (tag: string, kind: "double" | "single") => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onInsert(color, "double")}
+      className="w-6 h-6 rounded border border-slate-700 hover:border-slate-400"
+      style={{ backgroundColor: color }}
+      title={`[[${color}]]...[[/${color}]]`}
+      aria-label={`色タグ ${color}`}
+    />
+  );
+}
+
+function submitLabel(typeCode: string): string {
+  switch (typeCode) {
+    case "WEREWOLF_SAY":
+      return "囁く";
+    case "MASON_SAY":
+      return "発言する (共鳴)";
+    case "LOVERS_SAY":
+      return "発言する (恋人)";
+    case "TELEPATHY":
+      return "念話する";
+    case "MONOLOGUE_SAY":
+      return "つぶやく";
+    case "SECRET_SAY":
+      return "秘話する";
+    case "GRAVE_SAY":
+      return "呻く";
+    case "SPECTATE_SAY":
+      return "見学発言";
+    default:
+      return "発言する";
+  }
+}
+
+function appendToTextarea(
+  el: HTMLTextAreaElement | null,
+  insertText: string,
+  setText: (updater: (prev: string) => string) => void,
+) {
+  setText((prev) => {
+    // 末尾に改行が無ければ改行を 1 つ挟む (旧画面の `>>N` 挿入相当)。
+    // すでに `>>N\n` の形で入ってきている (anchorText) のでそのまま付ければ良い。
+    const needsLeadingNewline = prev.length > 0 && !prev.endsWith("\n");
+    return needsLeadingNewline ? `${prev}\n${insertText}` : prev + insertText;
+  });
+  // textarea にフォーカスを戻し末尾にカーソル移動
+  requestAnimationFrame(() => {
+    if (!el) return;
+    el.focus();
+    const end = el.value.length;
+    el.setSelectionRange(end, end);
+  });
+}

--- a/frontend/app/features/village/detail/SayFormContext.tsx
+++ b/frontend/app/features/village/detail/SayFormContext.tsx
@@ -1,0 +1,68 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef } from "react";
+
+/**
+ * MessageCard から SayForm に「アンカー挿入 / 返信開始」を伝えるための薄い context。
+ *
+ * 旧 Thymeleaf 画面は jQuery で global handler を貼っていたが、React では
+ * 親 component で provider を置き、SayForm が subscribe / MessageCard が trigger する
+ * 形にする。pub/sub にすることで provider 自体は state を持たず再 render しない。
+ */
+export interface SayAnchorRequest {
+  /** 旧画面の `>>` / `>>*` / `>>s` 等の prefix (MessageCard の typeCode → MESSAGE_STYLES から引く) */
+  anchorPrefix: string;
+  messageNumber: number;
+  /** secret-say 由来か (= 返信 UI から呼ばれたか)。true のとき SayForm は messageType=SECRET_SAY に切替 */
+  isSecret: boolean;
+  /** 秘話の宛先キャラ ID (返信元の発言者 charaId)。`isSecret=true` のときのみ意味あり */
+  secretTargetCharaId?: number;
+}
+
+type Listener = (req: SayAnchorRequest) => void;
+
+interface SayFormContextValue {
+  subscribe: (listener: Listener) => () => void;
+  request: (req: SayAnchorRequest) => void;
+}
+
+const SayFormContextImpl = createContext<SayFormContextValue | null>(null);
+
+export function SayFormProvider({ children }: { children: React.ReactNode }) {
+  const listenersRef = useRef<Set<Listener>>(new Set());
+
+  const subscribe = useCallback((listener: Listener) => {
+    listenersRef.current.add(listener);
+    return () => {
+      listenersRef.current.delete(listener);
+    };
+  }, []);
+
+  const request = useCallback((req: SayAnchorRequest) => {
+    listenersRef.current.forEach((l) => l(req));
+  }, []);
+
+  const value = useMemo<SayFormContextValue>(() => ({ subscribe, request }), [subscribe, request]);
+
+  return <SayFormContextImpl.Provider value={value}>{children}</SayFormContextImpl.Provider>;
+}
+
+/** SayForm 側で使う subscribe フック。listener が変わっても 1 subscribe で済む。 */
+export function useSayAnchorSubscription(listener: Listener) {
+  const ctx = useContext(SayFormContextImpl);
+  const listenerRef = useRef(listener);
+  listenerRef.current = listener;
+  useEffect(() => {
+    if (!ctx) return;
+    return ctx.subscribe((req) => listenerRef.current(req));
+  }, [ctx]);
+}
+
+/** MessageCard 側で使う dispatcher。provider が無いと no-op。 */
+export function useSayFormRequester(): (req: SayAnchorRequest) => void {
+  const ctx = useContext(SayFormContextImpl);
+  return useCallback(
+    (req: SayAnchorRequest) => {
+      ctx?.request(req);
+    },
+    [ctx],
+  );
+}

--- a/frontend/app/features/village/detail/api.ts
+++ b/frontend/app/features/village/detail/api.ts
@@ -40,6 +40,9 @@ export type VillageFaceTypeModifyBody = components["schemas"]["VillageFaceTypeMo
 export type MyselfRpView = components["schemas"]["MyselfRpView"];
 export type MyselfFaceTypeView = components["schemas"]["MyselfFaceTypeView"];
 export type MyselfFaceTypesView = components["schemas"]["MyselfFaceTypesView"];
+export type MyselfSayView = components["schemas"]["MyselfSayView"];
+export type MyselfSayMessageTypeView = components["schemas"]["MyselfSayMessageTypeView"];
+export type MyselfSecretSayTargetView = components["schemas"]["MyselfSecretSayTargetView"];
 export type VillageCreatorSayBody = components["schemas"]["VillageCreatorSayBody"];
 export type VillageKickBody = components["schemas"]["VillageKickBody"];
 export type VillageAdminLeaveBody = components["schemas"]["VillageAdminLeaveBody"];
@@ -100,8 +103,8 @@ export async function fetchVillageSituation(
 
 export type SayInput = {
   message: string;
-  /** CDef.MessageType の code。省略すると "NORMAL_SAY" (通常発言) 扱い。 */
-  messageType?: string;
+  /** CDef.MessageType の code (例: "NORMAL_SAY")。必須。 */
+  messageType: string;
   secretSayTargetCharaId?: number;
   faceType?: string;
   convertDisable?: boolean;
@@ -117,13 +120,9 @@ export async function postSay(
   input: SayInput,
   fetcher: ApiFetch = browserFetch,
 ): Promise<void> {
-  const body = {
-    messageType: "NORMAL_SAY",
-    ...input,
-  };
   const res = await fetcher(`/api/v1/villages/${villageId}/messages`, {
     method: "POST",
-    body: JSON.stringify(body),
+    body: JSON.stringify(input),
   });
   if (!res.ok) {
     // backend は WolfMansionBusinessException 等を ErrorResponse(message) で返す

--- a/frontend/app/routes/villages.$id.tsx
+++ b/frontend/app/routes/villages.$id.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { Link, useSearchParams } from "react-router";
 import type { Route } from "./+types/villages.$id";
 import {
@@ -15,7 +15,6 @@ import {
 } from "~/features/village/detail/api";
 import {
   useMyselfQuery,
-  useSayMutation,
   useVillageFootstepsQuery,
   useVillageMessagesQuery,
   useVillageQuery,
@@ -28,6 +27,8 @@ import { MessageCard } from "~/features/village/detail/MessageCard";
 import { ParticipateActions } from "~/features/village/detail/ParticipateActions";
 import { RoomGridPanel } from "~/features/village/detail/RoomGridPanel";
 import { RpActions } from "~/features/village/detail/RpActions";
+import { SayForm } from "~/features/village/detail/SayForm";
+import { SayFormProvider } from "~/features/village/detail/SayFormContext";
 import { SituationPanel } from "~/features/village/detail/SituationPanel";
 import { useMeQuery } from "~/features/auth/hooks";
 import { ssrFetch } from "~/lib/api/client";
@@ -142,95 +143,58 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
     [setParams, latestDay],
   );
 
+  // SayForm 表示判定: 最新日 + backend が「発言可能」と返している場合のみ。
+  // `availableMessageTypes` が空のときは backend が事前に「発言できる種別なし」と
+  // 判断しているので、フロント側で死亡 / 見学のフラグを別途確認しない。
+  // (見学者専用の `SPECTATE_SAY` 等も backend で availableMessageTypes に含まれるため)
+  const canShowSayForm =
+    myself != null &&
+    isViewingLatestDay &&
+    myself.say.isAvailableSay &&
+    myself.say.availableMessageTypes.length > 0;
+
   return (
     <main className="min-h-screen bg-slate-900 text-slate-100">
       <section className="max-w-4xl mx-auto px-6 py-10 space-y-6">
-        <VillageHeader village={village} />
+        <SayFormProvider>
+          <VillageHeader village={village} />
 
-        <DayTabs
-          days={village.days.list.map((d) => d.day)}
-          selectedDay={selectedDay}
-          onSelect={selectDay}
-        />
+          <DayTabs
+            days={village.days.list.map((d) => d.day)}
+            selectedDay={selectedDay}
+            onSelect={selectDay}
+          />
 
-        {myself && <MyselfPanel myself={myself} />}
+          {myself && <MyselfPanel myself={myself} />}
 
-        <ParticipateActions village={village} myself={myself} />
+          <ParticipateActions village={village} myself={myself} />
 
-        {myself && <RpActions village={village} myself={myself} />}
+          {myself && <RpActions village={village} myself={myself} />}
 
-        {myself && <ActionPanel village={village} myself={myself} />}
+          {myself && <ActionPanel village={village} myself={myself} />}
 
-        {canSeeCreatorPanel && <CreatorPanel village={village} />}
+          {canSeeCreatorPanel && <CreatorPanel village={village} />}
 
-        {isAdmin && <AdminPanel village={village} />}
+          {isAdmin && <AdminPanel village={village} />}
 
-        <RoomGridPanel village={village} day={selectedDay} />
+          <RoomGridPanel village={village} day={selectedDay} />
 
-        <ParticipantsPanel participants={village.participants.list} />
+          <ParticipantsPanel participants={village.participants.list} />
 
-        <SituationPanel situation={situation} selectedDay={selectedDay} />
+          <SituationPanel situation={situation} selectedDay={selectedDay} />
 
-        <MessagesPanel
-          messages={messages}
-          day={selectedDay}
-          participants={village.participants.list}
-        />
+          <MessagesPanel
+            messages={messages}
+            day={selectedDay}
+            participants={village.participants.list}
+          />
 
-        {myself && !myself.isSpectator && !myself.isDead && isViewingLatestDay && (
-          <SayForm villageId={villageId} />
-        )}
+          {canShowSayForm && <SayForm villageId={villageId} myself={myself!} />}
 
-        <FootstepsPanel footsteps={footsteps} />
+          <FootstepsPanel footsteps={footsteps} />
+        </SayFormProvider>
       </section>
     </main>
-  );
-}
-
-function SayForm({ villageId }: { villageId: number }) {
-  const [text, setText] = useState("");
-  const sayMutation = useSayMutation(villageId);
-
-  function submit(e: React.FormEvent) {
-    e.preventDefault();
-    const trimmed = text.trim();
-    if (!trimmed) return;
-    sayMutation.mutate(
-      { message: trimmed },
-      {
-        onSuccess: () => setText(""),
-      },
-    );
-  }
-
-  return (
-    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
-      <h2 className="text-sm text-slate-400 mb-2">発言</h2>
-      <form onSubmit={submit} className="space-y-2">
-        <textarea
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          rows={3}
-          maxLength={400}
-          placeholder="発言を入力 (400 文字以内)"
-          className="w-full bg-slate-900 border border-slate-700 rounded px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:outline-none focus:border-indigo-500"
-          disabled={sayMutation.isPending}
-        />
-        <div className="flex items-center gap-3">
-          <button
-            type="submit"
-            disabled={sayMutation.isPending || text.trim().length === 0}
-            className="rounded bg-indigo-500 hover:bg-indigo-400 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium"
-          >
-            {sayMutation.isPending ? "送信中..." : "発言する"}
-          </button>
-          <span className="text-xs text-slate-500">{text.length} / 400</span>
-          {sayMutation.isError && (
-            <span className="text-xs text-rose-300">{sayMutation.error.message}</span>
-          )}
-        </div>
-      </form>
-    </section>
   );
 }
 


### PR DESCRIPTION
closes `.issues/19-step-12d-say-form.md`

## 変更内容

旧 Thymeleaf `say-form.html` 相当の発言フォームを React 側に復元。

### backend

- `MyselfSayView` 新規追加: `availableMessageTypes (code/name/restrict)` /
  `defaultMessageTypeCode` / `selectableFaceTypes` / `secretSayTargets` を返す
- `MyselfActionSituation` に `say: ParticipantSaySituation` を追加
- `VillageCoordinator.findMyselfActionSituation` に `username` 引数を追加し
  `say` situation も構築するよう拡張 (PR #27 で軽量化していたが、12d で `say`
  が必要になるので player / messageCount / creator lookup を再導入)
- `VillageDetailRestController.myself` から `ctx.user?.username` と
  `ctx.charachips` を渡すように更新
- `MyselfView` 構築シグネチャに `charachips` を追加 (`MyselfSayView` 構築用)

### frontend

- `SayFormContext.tsx` 新規 — MessageCard から SayForm に「アンカー挿入 / 返信」を
  伝える pub/sub provider (Context)
- `SayForm.tsx` 新規 — 旧画面相当の発言フォーム:
  - 発言種別 radio タブ (`availableMessageTypes`)
  - 表情差分 select + キャラ画像プレビュー
  - 装飾タグボタン (`[[b]]` / `[[s]]` / `[[large]]` / `[[small]]` / `[[ruby]]` /
    `[[cw]]` / `[[tp]]` / 7 色 / `[[]]`)
  - アンカー自動入力 (textarea 末尾に `>>N` を挿入)
  - 秘話宛先 select (秘話選択時のみ表示)
  - 変換無効チェック
  - 文字数 / 行数 / 残り回数表示 + submit ガード
  - 秘話への返信は messageType=SECRET_SAY + 宛先 auto-set
- `MessageCard.tsx` — アンカー部分を button 化、`[返信]` ボタン追加。クリックで
  `useSayFormRequester()` 経由で SayForm に通知
- `routes/villages.\$id.tsx` — インライン `SayForm` 削除。`SayFormProvider` を
  `MessagesPanel` + `SayForm` を含む共通親に配置。表示判定を `myself.say.isAvailableSay
  && availableMessageTypes.length > 0` に変更 (= 死亡 / 見学者の墓下発言 / 見学発言
  にも対応)
- `features/village/detail/api.ts` — 新型 (`MyselfSayView` / `MyselfSayMessageTypeView`
  / `MyselfSecretSayTargetView`) を export、`SayInput.messageType` を必須化
- `pnpm gen:api` で OpenAPI 型再生成済 (`generated.ts` は gitignore)

### 意図的スコープ外 (= Step 12e 以降で対応)

- 投稿前確認 (preview) 画面 — 旧画面の 2-step submit はスキップ
- キャラ画像 modal (画像で表情選択 / 画像で秘話相手選択) — Step 13 で再導入予定
- 発言フィルタ / ページネーション / 村情報モーダル / 切り抜き — Step 12e
- アクション発言フォーム UI — `/actions` endpoint は既に存在、UI は Step 12e or 13

## 動作確認

- [x] backend `./gradlew test` (全 pass)
- [x] backend `./gradlew compileKotlin --rerun-tasks` (clean compile)
- [x] frontend `pnpm typecheck` (0 errors)
- [x] frontend `pnpm test` (11 passed)
- [x] frontend `pnpm build` (success)
- [ ] ユーザー手動確認: 進行中の村に test player で参加し以下を確認
  1. 発言種別タブが自分の出せる種別だけ並ぶ
  2. 表情差分 dropdown 切替で画像プレビュー更新
  3. 装飾タグボタンで textarea 内選択範囲を `[[b]]...[[/b]]` 等でラップ
  4. MessageCard のアンカー番号クリック → textarea 末尾に `>>N` 挿入
  5. MessageCard の \[返信\] クリック → アンカー挿入 (秘話なら宛先 auto-set)
  6. 秘話宛先 select → 宛先選択 → submit が通る
  7. convertDisable チェック ON で `[[b]]` 等が生で投稿される
  8. 残り N 回 / 文字数 / 行数表示 + 残 0 で submit ボタン disable
  9. 過去日タブで SayForm が消える
  10. 死亡時 (墓下発言可能) でも SayForm が出る (旧画面踏襲)