### PR TITLE
Step 12e: 発言フィルタ / ページネーション / 村情報モーダル / 切り抜き画面

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/response/village/VillageSettingsView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/village/VillageSettingsView.kt
@@ -1,6 +1,7 @@
 package com.ort.app.api.response.village
 
 import com.ort.app.domain.model.village.Village
+import com.ort.dbflute.allcommon.CDef
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
@@ -24,6 +25,40 @@ data class VillageSettingsView(
     val isSkillRequestAvailable: Boolean,
     @field:Schema(description = "見学参加が可能な村か")
     val isSpectateAvailable: Boolean,
+    @field:Schema(description = "募集範囲タグ名 (誰歓/身内)。未設定なら null。")
+    val welcomeRangeName: String?,
+    @field:Schema(description = "年齢制限タグ名 (R15/R18)。未設定なら null。")
+    val ageLimitName: String?,
+    @field:Schema(description = "投票形式 (公開投票か無記名投票か)")
+    val voteTypeName: String,
+    @field:Schema(description = "プロデューサー機能の有無")
+    val creatorIsProducer: Boolean,
+    @field:Schema(description = "同一人狼連続襲撃の可否")
+    val availableSameWolfAttack: Boolean,
+    @field:Schema(description = "狩人による連続護衛の可否")
+    val availableGuardSameTarget: Boolean,
+    @field:Schema(description = "突然死の有無")
+    val availableSuddenlyDeath: Boolean,
+    @field:Schema(description = "コミット機能の有無")
+    val availableCommit: Boolean,
+    @field:Schema(description = "アクション発言の可否")
+    val availableAction: Boolean,
+    @field:Schema(description = "墓下見学役職を公開するか")
+    val openSkillInGrave: Boolean,
+    @field:Schema(description = "墓下見学と地上の会話可否")
+    val visibleGraveSpectateMessage: Boolean,
+    @field:Schema(description = "秘話可能範囲 (NOTHING / ONLY_CREATOR / EVERYONE)")
+    val allowedSecretSayCode: String,
+    @field:Schema(description = "秘話可能範囲の表示名")
+    val allowedSecretSayName: String,
+    @field:Schema(description = "転生時の役職候補が全役職か (false なら編成に含まれるもののみ)")
+    val reincarnationSkillAll: Boolean,
+    @field:Schema(description = "ランダム編成 (闇鍋) か")
+    val isRandomOrganization: Boolean,
+    @field:Schema(description = "役職構成 (固定編成のテキスト表現)。ランダム編成なら空文字。")
+    val organization: String,
+    @field:Schema(description = "ダミーキャラ ID")
+    val dummyCharaId: Int,
 ) {
     constructor(village: Village) : this(
         personMin = village.setting.personMin,
@@ -35,5 +70,26 @@ data class VillageSettingsView(
         charachipIds = village.setting.chara.charachipIds,
         isSkillRequestAvailable = village.setting.rule.isPossibleSkillRequest,
         isSpectateAvailable = village.setting.rule.isAvailableSpectate,
+        welcomeRangeName = village.setting.tags.list.find {
+            it.toCdef() == CDef.VillageTagItem.誰歓 || it.toCdef() == CDef.VillageTagItem.身内
+        }?.name,
+        ageLimitName = village.setting.tags.list.find {
+            it.toCdef() == CDef.VillageTagItem.R15 || it.toCdef() == CDef.VillageTagItem.R18
+        }?.name,
+        voteTypeName = if (village.setting.rule.isOpenVote) "記名投票" else "無記名投票",
+        creatorIsProducer = village.setting.rule.isCreatorIsProducer,
+        availableSameWolfAttack = village.setting.rule.isAvailableSameWolfAttack,
+        availableGuardSameTarget = village.setting.rule.isAvailableGuardSameTarget,
+        availableSuddenlyDeath = village.setting.rule.isAvailableSuddenlyDeath,
+        availableCommit = village.setting.rule.isAvailableCommit,
+        availableAction = village.setting.rule.isAvailableAction,
+        openSkillInGrave = village.setting.rule.isOpenSkillInGrave,
+        visibleGraveSpectateMessage = village.setting.rule.isVisibleGraveSpectateMessage,
+        allowedSecretSayCode = village.setting.rule.secretSayRange.code,
+        allowedSecretSayName = village.setting.rule.secretSayRange.name,
+        reincarnationSkillAll = village.setting.rule.isReincarnationSkillAll,
+        isRandomOrganization = village.setting.rule.isRandomOrganization,
+        organization = village.setting.organize.fixedOrganization,
+        dummyCharaId = village.setting.chara.dummyCharaId,
     )
 }

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
@@ -20,6 +20,8 @@ import com.ort.app.application.service.VoteApplicationService
 import com.ort.app.domain.model.chara.Chara
 import com.ort.app.domain.model.chara.Charachips
 import com.ort.app.domain.model.message.MessageQuery
+import com.ort.app.domain.model.message.MessageType
+import com.ort.dbflute.allcommon.CDef
 import com.ort.app.domain.model.player.Players
 import com.ort.app.domain.model.village.Village
 import com.ort.app.domain.model.village.participant.VillageParticipant
@@ -81,26 +83,50 @@ class VillageDetailRestController(
     @GetMapping("/{villageId}/messages")
     @Operation(
         summary = "発言一覧取得",
-        description = "指定された日の閲覧可能な発言を返す。閲覧権限は閲覧者の参加状況 + 役職 + 村ステータスで決まる。",
+        description = "指定された日の閲覧可能な発言を返す。閲覧権限は閲覧者の参加状況 + 役職 + 村ステータスで決まる。" +
+            " filter / paging クエリを指定できる (`messageType` 等で絞り込み、`page` で順次表示)。",
     )
     fun messages(
         @PathVariable villageId: Int,
         @Parameter(description = "何日目か。未指定なら最新日。", required = false)
         @RequestParam(required = false) day: Int?,
+        @Parameter(description = "1 ページあたりの件数。指定するとページング ON。", required = false)
+        @RequestParam(required = false) pageSize: Int?,
+        @Parameter(description = "1 始まりのページ番号。pageSize 必須。", required = false)
+        @RequestParam(required = false) pageNum: Int?,
+        @Parameter(description = "絞り込み対象発言種別の code (複数指定で OR)。未指定なら全種別。", required = false)
+        @RequestParam(required = false) messageType: List<String>?,
+        @Parameter(description = "発言者 participantId (複数で OR)。", required = false)
+        @RequestParam(required = false) fromParticipantId: List<Int>?,
+        @Parameter(description = "宛先 participantId (複数で OR、秘話宛先で使用)。", required = false)
+        @RequestParam(required = false) toParticipantId: List<Int>?,
+        @Parameter(description = "本文キーワード (スペース区切りで AND)。", required = false)
+        @RequestParam(required = false) keyword: String?,
     ): MessagesView {
         val ctx = loadContext(villageId)
         val targetDay = day ?: ctx.village.latestDay()
+        // pageSize が指定されていればページング ON。pageNum 未指定なら 1 ページ目。
+        val isPaging = pageSize != null
+        // 旧 `VillageGetMessageListForm.typeMap` 互換: ユーザに見せている発言種別 (例:
+        // `GRAVE_SPECTATE_SAY`, `PRIVATE_SYSTEM`) は内部では複数 CDef.MessageType を束ねている。
+        // フィルタ未指定 (== messageType が null) のときは空リスト = 全種別扱いで通す。
+        val requestTypes = messageType.orEmpty()
+            .flatMap { MESSAGE_FILTER_TYPE_MAP[it] ?: emptyList() }
+            .distinctBy { it.code() }
+            .map { MessageType(it) }
         val query = MessageQuery(
             village = ctx.village,
             day = targetDay,
-            pageSize = null,
-            pageNum = null,
-            fromParticipantIds = emptyList(),
-            toParticipantIds = emptyList(),
-            requestTypes = emptyList(),
-            keywords = null,
-            isPaging = false,
-            isDispLatest = true,
+            pageSize = pageSize,
+            pageNum = if (isPaging) pageNum ?: 1 else null,
+            fromParticipantIds = fromParticipantId.orEmpty(),
+            toParticipantIds = toParticipantId.orEmpty(),
+            requestTypes = requestTypes,
+            keywords = keyword?.takeIf { it.isNotBlank() },
+            isPaging = isPaging,
+            // 最終ページ判定: 未指定 or pageNum 指定なしのときは最新表示扱い。
+            // 旧 Thymeleaf の `isDispLatest` ロジックを踏襲。
+            isDispLatest = !isPaging || pageNum == null,
         )
         val viewerPlayer = ctx.user?.let { playerService.findPlayer(it.username) }
         val messages = messageService.findMeesages(ctx.village, ctx.myself, viewerPlayer, query)
@@ -291,4 +317,39 @@ class VillageDetailRestController(
         val myself: VillageParticipant?,
         val charachips: Charachips,
     )
+
+    companion object {
+        // フィルタ UI 上で「1 項目」として見せる発言種別を、検索クエリ用の CDef.MessageType
+        // (複数) に展開するためのマップ。旧 `VillageGetMessageListForm.typeMap` 互換。
+        // 例: `GRAVE_SPECTATE_SAY` (墓下見学) は内部では 死者の呻き + 見学発言 の 2 種別を覆う。
+        private val MESSAGE_FILTER_TYPE_MAP: Map<String, List<CDef.MessageType>> = mapOf(
+            CDef.MessageType.通常発言.code() to listOf(CDef.MessageType.通常発言),
+            CDef.MessageType.村建て発言.code() to listOf(CDef.MessageType.村建て発言),
+            CDef.MessageType.人狼の囁き.code() to listOf(CDef.MessageType.人狼の囁き),
+            CDef.MessageType.恋人発言.code() to listOf(CDef.MessageType.恋人発言),
+            CDef.MessageType.念話.code() to listOf(CDef.MessageType.念話),
+            CDef.MessageType.共鳴発言.code() to listOf(CDef.MessageType.共鳴発言),
+            "GRAVE_SPECTATE_SAY" to listOf(CDef.MessageType.死者の呻き, CDef.MessageType.見学発言),
+            CDef.MessageType.独り言.code() to listOf(CDef.MessageType.独り言),
+            CDef.MessageType.秘話.code() to listOf(CDef.MessageType.秘話),
+            CDef.MessageType.アクション.code() to listOf(CDef.MessageType.アクション),
+            CDef.MessageType.公開システムメッセージ.code() to listOf(
+                CDef.MessageType.公開システムメッセージ,
+                CDef.MessageType.参加者一覧,
+            ),
+            CDef.MessageType.非公開システムメッセージ.code() to listOf(
+                CDef.MessageType.非公開システムメッセージ,
+                CDef.MessageType.白黒占い結果,
+                CDef.MessageType.役職占い結果,
+                CDef.MessageType.白黒霊視結果,
+                CDef.MessageType.役職霊視結果,
+                CDef.MessageType.検死結果,
+                CDef.MessageType.襲撃結果,
+                CDef.MessageType.足音調査結果,
+                CDef.MessageType.恋人メッセージ,
+                CDef.MessageType.妖狐メッセージ,
+                CDef.MessageType.能力行使メッセージ,
+            ),
+        )
+    }
 }

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
@@ -27,6 +27,7 @@ import com.ort.app.domain.model.village.Village
 import com.ort.app.domain.model.village.participant.VillageParticipant
 import com.ort.app.domain.service.SpoilerDomainService
 import com.ort.app.domain.service.footstep.FootstepRevealDomainService
+import com.ort.app.fw.exception.WolfMansionBusinessException
 import com.ort.app.fw.exception.WolfMansionRecordNotFoundException
 import com.ort.app.fw.util.WolfMansionUserInfoUtil
 import io.swagger.v3.oas.annotations.Operation
@@ -90,7 +91,7 @@ class VillageDetailRestController(
         @PathVariable villageId: Int,
         @Parameter(description = "何日目か。未指定なら最新日。", required = false)
         @RequestParam(required = false) day: Int?,
-        @Parameter(description = "1 ページあたりの件数。指定するとページング ON。", required = false)
+        @Parameter(description = "1 ページあたりの件数 (1 以上)。指定するとページング ON。", required = false)
         @RequestParam(required = false) pageSize: Int?,
         @Parameter(description = "1 始まりのページ番号。pageSize 必須。", required = false)
         @RequestParam(required = false) pageNum: Int?,
@@ -100,9 +101,17 @@ class VillageDetailRestController(
         @RequestParam(required = false) fromParticipantId: List<Int>?,
         @Parameter(description = "宛先 participantId (複数で OR、秘話宛先で使用)。", required = false)
         @RequestParam(required = false) toParticipantId: List<Int>?,
-        @Parameter(description = "本文キーワード (スペース区切りで AND)。", required = false)
+        @Parameter(description = "本文キーワード (スペース区切りで OR)。", required = false)
         @RequestParam(required = false) keyword: String?,
     ): MessagesView {
+        // ページング系の数値は DBFlute の `paging(pageSize, pageNum)` に渡る。
+        // 0 / 負値だと実行時例外 or 全件取得などで挙動が崩れるので、ここで 400 に正規化。
+        if (pageSize != null && pageSize < 1) {
+            throw WolfMansionBusinessException("pageSize は 1 以上を指定してください")
+        }
+        if (pageNum != null && pageNum < 1) {
+            throw WolfMansionBusinessException("pageNum は 1 以上を指定してください")
+        }
         val ctx = loadContext(villageId)
         val targetDay = day ?: ctx.village.latestDay()
         // pageSize が指定されていればページング ON。pageNum 未指定なら 1 ページ目。
@@ -124,8 +133,9 @@ class VillageDetailRestController(
             requestTypes = requestTypes,
             keywords = keyword?.takeIf { it.isNotBlank() },
             isPaging = isPaging,
-            // 最終ページ判定: 未指定 or pageNum 指定なしのときは最新表示扱い。
-            // 旧 Thymeleaf の `isDispLatest` ロジックを踏襲。
+            // ページング OFF または pageNum 未指定 (= 1 ページ目を求めている) を「最新を表示」扱いにする。
+            // 旧 `VillageGetMessageListForm` ではこのフラグは JS 側から明示的に渡されていたが、
+            // REST 化後は GET param を簡潔にするため pageNum の有無から自動で導出している。
             isDispLatest = !isPaging || pageNum == null,
         )
         val viewerPlayer = ctx.user?.let { playerService.findPlayer(it.username) }

--- a/frontend/app/features/village/detail/MessageFilter.tsx
+++ b/frontend/app/features/village/detail/MessageFilter.tsx
@@ -1,0 +1,276 @@
+import { useEffect, useState } from "react";
+import type { VillageParticipantView } from "./api";
+
+/**
+ * UI 上で「1 つの絞り込み単位」として扱う発言種別。backend 側の
+ * `MESSAGE_FILTER_TYPE_MAP` と 1:1 対応する。`GRAVE_SPECTATE_SAY` (墓下見学)
+ * のような合成 code は frontend にだけ存在する別名扱い。
+ */
+export type FilterMessageType = {
+  code: string;
+  label: string;
+};
+
+export const MESSAGE_FILTER_TYPES: FilterMessageType[] = [
+  { code: "NORMAL_SAY", label: "通常" },
+  { code: "CREATOR_SAY", label: "村建て" },
+  { code: "WEREWOLF_SAY", label: "囁き" },
+  { code: "MASON_SAY", label: "共鳴" },
+  { code: "LOVERS_SAY", label: "恋人" },
+  { code: "TELEPATHY", label: "念話" },
+  { code: "GRAVE_SPECTATE_SAY", label: "墓下/見学" },
+  { code: "MONOLOGUE_SAY", label: "独り言" },
+  { code: "SECRET_SAY", label: "秘話" },
+  { code: "ACTION", label: "アクション" },
+  { code: "PUBLIC_SYSTEM", label: "公開シスメ" },
+  { code: "PRIVATE_SYSTEM", label: "非公開シスメ" },
+];
+
+/**
+ * 発言フィルタの値。`messageType` / 参加者 ID は「未絞り込み = 全件」を意味する
+ * 空配列で表現する (= 旧 Thymeleaf の挙動踏襲)。
+ */
+export type MessageFilterValue = {
+  messageType: string[];
+  fromParticipantId: number[];
+  toParticipantId: number[];
+  keyword: string;
+};
+
+export const EMPTY_FILTER: MessageFilterValue = {
+  messageType: [],
+  fromParticipantId: [],
+  toParticipantId: [],
+  keyword: "",
+};
+
+export function isEmptyFilter(v: MessageFilterValue): boolean {
+  return (
+    v.messageType.length === 0 &&
+    v.fromParticipantId.length === 0 &&
+    v.toParticipantId.length === 0 &&
+    v.keyword.trim() === ""
+  );
+}
+
+export function MessageFilterModal({
+  open,
+  value,
+  participants,
+  onApply,
+  onClose,
+}: {
+  open: boolean;
+  value: MessageFilterValue;
+  participants: VillageParticipantView[];
+  onApply: (v: MessageFilterValue) => void;
+  onClose: () => void;
+}) {
+  const [draft, setDraft] = useState<MessageFilterValue>(value);
+  // モーダルを開くたびに親の最新値で初期化する。閉じている間は不要な再 render を避ける。
+  useEffect(() => {
+    if (open) setDraft(value);
+  }, [open, value]);
+
+  if (!open) return null;
+
+  const toggleType = (code: string) => {
+    setDraft((d) => ({
+      ...d,
+      messageType: d.messageType.includes(code)
+        ? d.messageType.filter((x) => x !== code)
+        : [...d.messageType, code],
+    }));
+  };
+  const toggleFrom = (id: number) => {
+    setDraft((d) => ({
+      ...d,
+      fromParticipantId: d.fromParticipantId.includes(id)
+        ? d.fromParticipantId.filter((x) => x !== id)
+        : [...d.fromParticipantId, id],
+    }));
+  };
+  const toggleTo = (id: number) => {
+    setDraft((d) => ({
+      ...d,
+      toParticipantId: d.toParticipantId.includes(id)
+        ? d.toParticipantId.filter((x) => x !== id)
+        : [...d.toParticipantId, id],
+    }));
+  };
+
+  // 退村済以外を選択候補にする (= 旧画面踏襲)。
+  const selectable = participants.filter((p) => !p.isGone);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="発言フィルタ"
+      className="fixed inset-0 z-40 flex items-center justify-center bg-black/60 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-3xl max-h-[90vh] overflow-y-auto rounded-xl bg-slate-900 border border-slate-700 p-5 space-y-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="text-base font-semibold">発言抽出</h3>
+
+        <section>
+          <div className="flex items-center justify-between">
+            <h4 className="text-sm text-slate-300">発言種別</h4>
+            <div className="text-xs space-x-2">
+              <button
+                type="button"
+                className="text-slate-300 hover:text-slate-100"
+                onClick={() => setDraft((d) => ({ ...d, messageType: [] }))}
+              >
+                クリア
+              </button>
+              <button
+                type="button"
+                className="text-slate-300 hover:text-slate-100"
+                onClick={() =>
+                  setDraft((d) => ({ ...d, messageType: MESSAGE_FILTER_TYPES.map((t) => t.code) }))
+                }
+              >
+                全選択
+              </button>
+            </div>
+          </div>
+          <div className="mt-2 grid grid-cols-2 sm:grid-cols-4 gap-1">
+            {MESSAGE_FILTER_TYPES.map((t) => {
+              const active = draft.messageType.includes(t.code);
+              return (
+                <label
+                  key={t.code}
+                  className={
+                    "flex items-center gap-2 text-xs cursor-pointer rounded px-2 py-1 border " +
+                    (active
+                      ? "bg-indigo-600/30 border-indigo-400 text-indigo-50"
+                      : "bg-slate-800/40 border-slate-700 text-slate-300 hover:bg-slate-700/40")
+                  }
+                >
+                  <input
+                    type="checkbox"
+                    checked={active}
+                    onChange={() => toggleType(t.code)}
+                    className="accent-indigo-500"
+                  />
+                  {t.label}
+                </label>
+              );
+            })}
+          </div>
+        </section>
+
+        <ParticipantSelector
+          title="発言者"
+          selectable={selectable}
+          selected={draft.fromParticipantId}
+          onToggle={toggleFrom}
+          onClear={() => setDraft((d) => ({ ...d, fromParticipantId: [] }))}
+        />
+
+        <ParticipantSelector
+          title="宛先 (秘話)"
+          selectable={selectable}
+          selected={draft.toParticipantId}
+          onToggle={toggleTo}
+          onClear={() => setDraft((d) => ({ ...d, toParticipantId: [] }))}
+        />
+
+        <section>
+          <h4 className="text-sm text-slate-300">キーワード</h4>
+          <input
+            type="text"
+            value={draft.keyword}
+            onChange={(e) => setDraft((d) => ({ ...d, keyword: e.target.value }))}
+            placeholder="スペース区切りで AND"
+            className="mt-2 w-full rounded bg-slate-800 border border-slate-700 px-3 py-1.5 text-sm"
+          />
+        </section>
+
+        <div className="flex justify-end gap-2 pt-2 border-t border-slate-700">
+          <button
+            type="button"
+            className="rounded border border-slate-600 px-3 py-1.5 text-sm text-slate-200 hover:bg-slate-800"
+            onClick={() => setDraft(EMPTY_FILTER)}
+          >
+            リセット
+          </button>
+          <button
+            type="button"
+            className="rounded border border-slate-600 px-3 py-1.5 text-sm text-slate-200 hover:bg-slate-800"
+            onClick={onClose}
+          >
+            閉じる
+          </button>
+          <button
+            type="button"
+            className="rounded bg-indigo-500 hover:bg-indigo-400 px-3 py-1.5 text-sm text-white"
+            onClick={() => {
+              onApply(draft);
+              onClose();
+            }}
+          >
+            抽出
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ParticipantSelector({
+  title,
+  selectable,
+  selected,
+  onToggle,
+  onClear,
+}: {
+  title: string;
+  selectable: VillageParticipantView[];
+  selected: number[];
+  onToggle: (id: number) => void;
+  onClear: () => void;
+}) {
+  return (
+    <section>
+      <div className="flex items-center justify-between">
+        <h4 className="text-sm text-slate-300">{title}</h4>
+        <button
+          type="button"
+          className="text-xs text-slate-300 hover:text-slate-100"
+          onClick={onClear}
+        >
+          クリア
+        </button>
+      </div>
+      <div className="mt-2 grid grid-cols-2 sm:grid-cols-3 gap-1">
+        {selectable.map((p) => {
+          const active = selected.includes(p.id);
+          return (
+            <label
+              key={p.id}
+              className={
+                "flex items-center gap-2 text-xs cursor-pointer rounded px-2 py-1 border " +
+                (active
+                  ? "bg-indigo-600/30 border-indigo-400 text-indigo-50"
+                  : "bg-slate-800/40 border-slate-700 text-slate-300 hover:bg-slate-700/40")
+              }
+            >
+              <input
+                type="checkbox"
+                checked={active}
+                onChange={() => onToggle(p.id)}
+                className="accent-indigo-500"
+              />
+              <span className="truncate">{p.name}</span>
+            </label>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/features/village/detail/MessageFilter.tsx
+++ b/frontend/app/features/village/detail/MessageFilter.tsx
@@ -186,7 +186,7 @@ export function MessageFilterModal({
             type="text"
             value={draft.keyword}
             onChange={(e) => setDraft((d) => ({ ...d, keyword: e.target.value }))}
-            placeholder="スペース区切りで AND"
+            placeholder="スペース区切りで OR"
             className="mt-2 w-full rounded bg-slate-800 border border-slate-700 px-3 py-1.5 text-sm"
           />
         </section>

--- a/frontend/app/features/village/detail/VillageInfoModal.tsx
+++ b/frontend/app/features/village/detail/VillageInfoModal.tsx
@@ -1,0 +1,153 @@
+import type { VillageView } from "./api";
+
+/**
+ * 旧 .old-thymeleaf/templates/village/modal-village-info.html 相当の村情報モーダル。
+ *
+ * 設定変更ボタンは creator のみ表示。設定値の表示だけ行うので backend は
+ * 既存の `VillageView.settings` (= VillageSettingsView) をそのまま使う。
+ */
+export function VillageInfoModal({
+  open,
+  village,
+  onClose,
+}: {
+  open: boolean;
+  village: VillageView;
+  onClose: () => void;
+}) {
+  if (!open) return null;
+  const s = village.settings;
+  const intervalText = formatInterval(s.dayChangeIntervalSeconds);
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="村情報"
+      className="fixed inset-0 z-40 flex items-center justify-center bg-black/60 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-xl bg-slate-900 border border-slate-700 p-5 space-y-3"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between">
+          <h3 className="text-base font-semibold">村情報</h3>
+          <button
+            type="button"
+            className="text-slate-400 hover:text-slate-200 text-sm"
+            onClick={onClose}
+            aria-label="閉じる"
+          >
+            ×
+          </button>
+        </div>
+        <dl className="text-xs grid grid-cols-[10rem_1fr] gap-y-1 gap-x-3">
+          {s.welcomeRangeName && <Row label="募集範囲" value={s.welcomeRangeName} />}
+          <Row label="最少開始人数" value={s.personMin} />
+          <Row label="定員" value={s.personMax} />
+          <Row label="開始日時" value={formatDateTime(s.startDatetime)} />
+          <Row label="更新間隔" value={intervalText} />
+          <Row label="投票形式" value={s.voteTypeName} />
+          <Row
+            label="役職希望"
+            value={s.isSkillRequestAvailable ? "可能" : "不可"}
+          />
+          <Row
+            label="見学入村"
+            value={s.isSpectateAvailable ? "可能" : "不可"}
+          />
+          <Row
+            label="プロデューサー機能"
+            value={s.creatorIsProducer ? "あり" : "なし"}
+          />
+          <Row
+            label="同一人狼連続襲撃"
+            value={s.availableSameWolfAttack ? "可能" : "不可"}
+          />
+          <Row
+            label="狩人連続護衛"
+            value={s.availableGuardSameTarget ? "可能" : "不可"}
+          />
+          <Row
+            label="転生時役職候補"
+            value={s.reincarnationSkillAll ? "全役職" : "編成に含まれる役職のみ"}
+          />
+          <Row
+            label="墓下見学役職公開"
+            value={s.openSkillInGrave ? "公開" : "非公開"}
+          />
+          <Row
+            label="墓下/地上の会話"
+            value={s.visibleGraveSpectateMessage ? "可能" : "不可"}
+          />
+          <Row label="秘話" value={s.allowedSecretSayName} />
+          <Row label="突然死" value={s.availableSuddenlyDeath ? "あり" : "なし"} />
+          <Row label="コミット" value={s.availableCommit ? "あり" : "なし"} />
+          <Row label="アクション発言" value={s.availableAction ? "可能" : "不可"} />
+          {s.ageLimitName && <Row label="年齢制限" value={s.ageLimitName} />}
+          <Row label="入村パスワード" value={s.joinPasswordRequired ? "あり" : "なし"} />
+          <Row label="館を建てたプレイヤー" value={village.createPlayerName} />
+          {!s.isRandomOrganization && s.organization && (
+            <Row
+              label="役職構成"
+              value={
+                <pre className="whitespace-pre-wrap font-sans text-xs">{s.organization}</pre>
+              }
+            />
+          )}
+          {s.isRandomOrganization && (
+            <Row label="役職構成" value="ランダム編成 (闇鍋)" />
+          )}
+        </dl>
+        <div className="flex justify-end gap-2 pt-2 border-t border-slate-700">
+          {village.isCreator && (
+            <a
+              href={`/wolf-mansion/villages/${village.id}/settings`}
+              className="rounded bg-emerald-600 hover:bg-emerald-500 px-3 py-1.5 text-sm text-white"
+            >
+              設定変更
+            </a>
+          )}
+          <button
+            type="button"
+            className="rounded border border-slate-600 px-3 py-1.5 text-sm text-slate-200 hover:bg-slate-800"
+            onClick={onClose}
+          >
+            閉じる
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <>
+      <dt className="text-slate-400">{label}</dt>
+      <dd className="text-slate-100 break-all">{value}</dd>
+    </>
+  );
+}
+
+function formatInterval(totalSeconds: number): string {
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+  const parts: string[] = [];
+  if (h > 0) parts.push(`${h}時間`);
+  if (m > 0) parts.push(`${m}分`);
+  if (s > 0) parts.push(`${s}秒`);
+  return parts.length > 0 ? parts.join("") : "0秒";
+}
+
+function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mi = String(d.getMinutes()).padStart(2, "0");
+  return `${yyyy}/${mm}/${dd} ${hh}:${mi}`;
+}

--- a/frontend/app/features/village/detail/api.ts
+++ b/frontend/app/features/village/detail/api.ts
@@ -68,12 +68,40 @@ export async function fetchVillage(
   return res.json();
 }
 
+/**
+ * フィルタ + ページング込みの messages クエリ。
+ *
+ * - `messageType`: UI 上の「1 項目」分の code (例: `GRAVE_SPECTATE_SAY`)。
+ *   backend 側で内部 CDef 種別の集合に展開される。空配列 / 未指定なら絞り込みなし。
+ * - `pageSize` を指定するとページング ON。`pageNum` 未指定なら最新ページ扱い。
+ */
+export type MessagesQuery = {
+  day?: number;
+  pageSize?: number;
+  pageNum?: number;
+  messageType?: string[];
+  fromParticipantId?: number[];
+  toParticipantId?: number[];
+  keyword?: string;
+};
+
 export async function fetchVillageMessages(
   villageId: number,
-  day: number | undefined,
+  query: number | MessagesQuery | undefined,
   fetcher: ApiFetch = browserFetch,
 ): Promise<MessagesView> {
-  const qs = typeof day === "number" ? `?day=${day}` : "";
+  // 後方互換: 旧シグネチャ (day: number) も受け付ける。
+  const q: MessagesQuery =
+    typeof query === "number" ? { day: query } : (query ?? {});
+  const params = new URLSearchParams();
+  if (typeof q.day === "number") params.set("day", String(q.day));
+  if (typeof q.pageSize === "number") params.set("pageSize", String(q.pageSize));
+  if (typeof q.pageNum === "number") params.set("pageNum", String(q.pageNum));
+  q.messageType?.forEach((m) => params.append("messageType", m));
+  q.fromParticipantId?.forEach((id) => params.append("fromParticipantId", String(id)));
+  q.toParticipantId?.forEach((id) => params.append("toParticipantId", String(id)));
+  if (q.keyword && q.keyword.trim() !== "") params.set("keyword", q.keyword);
+  const qs = params.toString() ? `?${params.toString()}` : "";
   const res = await fetcher(`/api/v1/villages/${villageId}/messages${qs}`);
   if (!res.ok) throw new Error(`messages fetch failed: ${res.status}`);
   return res.json();

--- a/frontend/app/features/village/detail/hooks.ts
+++ b/frontend/app/features/village/detail/hooks.ts
@@ -41,6 +41,7 @@ import {
   putMemo,
   putSettings,
   type CharaView,
+  type MessagesQuery,
   type MessagesView,
   type MyselfFaceTypesView,
   type MyselfView,
@@ -81,14 +82,32 @@ export function useVillageQuery(
   });
 }
 
+/**
+ * messages query を filter / paging 付きで取得する。queryKey に query 全体の
+ * stable representation を含めるので、フィルタや page が変わると自動で refetch される。
+ *
+ * 後方互換: 第二引数に number (day) を渡したら `{ day }` と等価に扱う。
+ */
 export function useVillageMessagesQuery(
   villageId: number,
-  day: number | undefined,
+  query: number | MessagesQuery | undefined,
   initialData?: MessagesView,
 ): UseQueryResult<MessagesView> {
+  const q: MessagesQuery =
+    typeof query === "number" ? { day: query } : (query ?? {});
+  // 配列やオプショナルを stable な形に揃える (順序ずれで queryKey が変わるのを防ぐ)。
+  const keyPart = {
+    day: q.day ?? "latest",
+    pageSize: q.pageSize ?? null,
+    pageNum: q.pageNum ?? null,
+    messageType: [...(q.messageType ?? [])].sort(),
+    fromParticipantId: [...(q.fromParticipantId ?? [])].sort((a, b) => a - b),
+    toParticipantId: [...(q.toParticipantId ?? [])].sort((a, b) => a - b),
+    keyword: q.keyword?.trim() || null,
+  };
   return useQuery<MessagesView>({
-    queryKey: ["village", villageId, "messages", day ?? "latest"],
-    queryFn: () => fetchVillageMessages(villageId, day),
+    queryKey: ["village", villageId, "messages", keyPart],
+    queryFn: () => fetchVillageMessages(villageId, q),
     initialData,
     initialDataUpdatedAt: initialData ? Date.now() : undefined,
     refetchInterval: POLL_INTERVAL_MS,

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -6,6 +6,7 @@ export default [
   route("villages", "routes/villages._index.tsx"),
   route("villages/:id", "routes/villages.$id.tsx"),
   route("villages/:id/settings", "routes/villages.$id.settings.tsx"),
+  route("villages/:id/scrap", "routes/villages.$id.scrap.tsx"),
   route("players", "routes/players._index.tsx"),
   // NOTE: 認証不要。`isSelf=true` のときだけ編集 UI が出る (backend が viewer JWT を読んで判定)。
   route("players/:userName", "routes/players.$userName.tsx"),

--- a/frontend/app/routes/villages.$id.scrap.tsx
+++ b/frontend/app/routes/villages.$id.scrap.tsx
@@ -1,0 +1,180 @@
+import { useMemo } from "react";
+import { Link } from "react-router";
+import type { Route } from "./+types/villages.$id.scrap";
+import {
+  fetchVillage,
+  fetchVillageMessages,
+  type MessagesQuery,
+  type MessageView,
+  type VillageParticipantView,
+} from "~/features/village/detail/api";
+import { MessageCard } from "~/features/village/detail/MessageCard";
+import { SayFormProvider } from "~/features/village/detail/SayFormContext";
+import { ssrFetch } from "~/lib/api/client";
+
+/**
+ * 旧 .old-thymeleaf/templates/scrap.html 相当の "切り抜き" 画面。
+ *
+ * 村画面に対して header / 入力 / 操作系を全て削いだ read-only ビュー。URL クエリで
+ * `day` `type` `from` `to` `kw` `page` を受け、印刷 / 別タブ共有用途を意図する。
+ *
+ * クエリパラメータの命名 / 解釈は villages.$id.tsx と揃える (同じ実装をモジュール化
+ * せずコピーしているのは、scrap は静的な共有用なので import 関係を増やしたくないため)。
+ */
+function parseDay(raw: string | null): number | undefined {
+  if (raw == null || raw === "") return undefined;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 0) return undefined;
+  return n;
+}
+
+function parsePage(raw: string | null): number | undefined {
+  if (raw == null || raw === "") return undefined;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1) return undefined;
+  return n;
+}
+
+function parseCsv(raw: string | null): string[] {
+  return (raw ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function parseCsvInt(raw: string | null): number[] {
+  return parseCsv(raw)
+    .map((s) => Number(s))
+    .filter((n) => Number.isInteger(n) && n > 0);
+}
+
+export function meta({ data }: Route.MetaArgs) {
+  const name = data?.village?.name ?? "切り抜き";
+  return [{ title: `${name} - 切り抜き - wolf-mansion` }];
+}
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const villageId = Number(params.id);
+  if (!Number.isFinite(villageId)) {
+    throw new Response("invalid village id", { status: 400 });
+  }
+  const url = new URL(request.url);
+  const api = ssrFetch(request);
+  const village = await fetchVillage(villageId, api).catch(() => null);
+  if (!village) throw new Response("village not found", { status: 404 });
+  const day = parseDay(url.searchParams.get("day")) ?? village.time.latestDay;
+  const page = parsePage(url.searchParams.get("page"));
+  const messageType = parseCsv(url.searchParams.get("type"));
+  const fromParticipantId = parseCsvInt(url.searchParams.get("from"));
+  const toParticipantId = parseCsvInt(url.searchParams.get("to"));
+  const keyword = url.searchParams.get("kw") ?? "";
+  const query: MessagesQuery = {
+    day,
+    pageSize: typeof page === "number" ? 100 : undefined,
+    pageNum: page,
+    messageType: messageType.length > 0 ? messageType : undefined,
+    fromParticipantId: fromParticipantId.length > 0 ? fromParticipantId : undefined,
+    toParticipantId: toParticipantId.length > 0 ? toParticipantId : undefined,
+    keyword: keyword.trim() || undefined,
+  };
+  const messages = await fetchVillageMessages(villageId, query, api).catch(
+    () => null,
+  );
+  return {
+    villageId,
+    village,
+    day,
+    messages,
+    filterSummary: { messageType, fromParticipantId, toParticipantId, keyword },
+  };
+}
+
+export default function VillageScrap({ loaderData }: Route.ComponentProps) {
+  const { villageId, village, day, messages, filterSummary } = loaderData;
+  const participantsById = useMemo(
+    () => new Map(village.participants.list.map((p) => [p.id, p])),
+    [village.participants.list],
+  );
+  const list: MessageView[] = messages?.list ?? [];
+
+  const filterSummaryText = useMemo(
+    () => buildFilterSummary(village.participants.list, filterSummary),
+    [village.participants.list, filterSummary],
+  );
+
+  return (
+    <main className="min-h-screen bg-slate-50 text-slate-900 print:bg-white">
+      <section className="max-w-3xl mx-auto px-6 py-6 space-y-4">
+        <header className="space-y-1">
+          <div className="flex items-baseline gap-3">
+            <span className="font-mono text-slate-500 text-sm">
+              #{village.number}
+            </span>
+            <h1 className="text-xl font-bold">{village.name}</h1>
+          </div>
+          <p className="text-xs text-slate-500">
+            {day === 0 ? "プロローグ" : `${day}日目`} · {list.length}件
+            {filterSummaryText && ` · ${filterSummaryText}`}
+          </p>
+          <div className="flex gap-2 pt-1 text-xs print:hidden">
+            <Link
+              to={`/villages/${villageId}?day=${day}`}
+              className="text-slate-600 hover:text-slate-900 underline"
+            >
+              ← 村に戻る
+            </Link>
+            <button
+              type="button"
+              className="text-slate-600 hover:text-slate-900 underline"
+              onClick={() => window.print()}
+            >
+              印刷
+            </button>
+          </div>
+        </header>
+
+        {list.length === 0 ? (
+          <p className="text-slate-500 text-sm py-2">
+            条件に該当する発言はありません
+          </p>
+        ) : (
+          // MessageCard はアンカー / 返信ボタンが SayFormContext を必要とするため
+          // 表示専用でも provider で包む。scrap には SayForm 自体は出さない。
+          <SayFormProvider>
+            <ul className="space-y-2">
+              {list.map((m, i) => (
+                <li key={`${m.typeCode}-${m.number ?? i}`}>
+                  <MessageCard message={m} participantsById={participantsById} />
+                </li>
+              ))}
+            </ul>
+          </SayFormProvider>
+        )}
+      </section>
+    </main>
+  );
+}
+
+function buildFilterSummary(
+  participants: VillageParticipantView[],
+  s: {
+    messageType: string[];
+    fromParticipantId: number[];
+    toParticipantId: number[];
+    keyword: string;
+  },
+): string {
+  const parts: string[] = [];
+  if (s.messageType.length > 0) parts.push(`種別 ${s.messageType.length}`);
+  if (s.fromParticipantId.length > 0) {
+    const names = s.fromParticipantId
+      .map((id) => participants.find((p) => p.id === id)?.name)
+      .filter(Boolean)
+      .join(", ");
+    parts.push(`発言者: ${names || s.fromParticipantId.length + "件"}`);
+  }
+  if (s.toParticipantId.length > 0) parts.push(`宛先 ${s.toParticipantId.length}`);
+  if (s.keyword.trim()) parts.push(`「${s.keyword.trim()}」`);
+  return parts.join(" / ");
+}
+

--- a/frontend/app/routes/villages.$id.scrap.tsx
+++ b/frontend/app/routes/villages.$id.scrap.tsx
@@ -68,6 +68,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   const fromParticipantId = parseCsvInt(url.searchParams.get("from"));
   const toParticipantId = parseCsvInt(url.searchParams.get("to"));
   const keyword = url.searchParams.get("kw") ?? "";
+  // scrap は印刷 / 共有想定の固定 URL なので、本編 (villages.$id) より大きめの
+  // ページサイズを使い、1 ページに収まりやすくする。意図的に村画面の PAGE_SIZE=50
+  // とは別値。
   const query: MessagesQuery = {
     day,
     pageSize: typeof page === "number" ? 100 : undefined,

--- a/frontend/app/routes/villages.$id.tsx
+++ b/frontend/app/routes/villages.$id.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Link, useSearchParams } from "react-router";
 import type { Route } from "./+types/villages.$id";
 import {
@@ -7,6 +7,7 @@ import {
   fetchVillageFootsteps,
   fetchVillageMessages,
   fetchVillageSituation,
+  type MessagesQuery,
   type MessagesView,
   type MyselfView,
   type VillageFootstepsView,
@@ -30,8 +31,17 @@ import { RpActions } from "~/features/village/detail/RpActions";
 import { SayForm } from "~/features/village/detail/SayForm";
 import { SayFormProvider } from "~/features/village/detail/SayFormContext";
 import { SituationPanel } from "~/features/village/detail/SituationPanel";
+import {
+  EMPTY_FILTER,
+  isEmptyFilter,
+  MessageFilterModal,
+  type MessageFilterValue,
+} from "~/features/village/detail/MessageFilter";
+import { VillageInfoModal } from "~/features/village/detail/VillageInfoModal";
 import { useMeQuery } from "~/features/auth/hooks";
 import { ssrFetch } from "~/lib/api/client";
+
+const PAGE_SIZE = 50;
 
 export function meta({ data }: Route.MetaArgs) {
   const name = data?.village?.name ?? "村詳細";
@@ -51,6 +61,65 @@ function parseDayParam(raw: string | null): number | undefined {
   return n;
 }
 
+function parsePageParam(raw: string | null): number | undefined {
+  if (raw == null || raw === "") return undefined;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1) return undefined;
+  return n;
+}
+
+/**
+ * URL クエリ (`?type=A,B` `&from=1,2` `&to=3` `&kw=...`) を MessageFilterValue にパース。
+ * 旧 Thymeleaf 互換ではなく URL を短く保つため、カンマ区切り 1 パラメータ + 短いキー名にした。
+ */
+function parseFilterFromParams(p: URLSearchParams): MessageFilterValue {
+  const messageType = (p.get("type") ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const fromParticipantId = (p.get("from") ?? "")
+    .split(",")
+    .map((s) => Number(s.trim()))
+    .filter((n) => Number.isInteger(n) && n > 0);
+  const toParticipantId = (p.get("to") ?? "")
+    .split(",")
+    .map((s) => Number(s.trim()))
+    .filter((n) => Number.isInteger(n) && n > 0);
+  const keyword = p.get("kw") ?? "";
+  return { messageType, fromParticipantId, toParticipantId, keyword };
+}
+
+function applyFilterToParams(p: URLSearchParams, v: MessageFilterValue) {
+  if (v.messageType.length > 0) p.set("type", v.messageType.join(","));
+  else p.delete("type");
+  if (v.fromParticipantId.length > 0)
+    p.set("from", v.fromParticipantId.join(","));
+  else p.delete("from");
+  if (v.toParticipantId.length > 0) p.set("to", v.toParticipantId.join(","));
+  else p.delete("to");
+  if (v.keyword.trim() !== "") p.set("kw", v.keyword.trim());
+  else p.delete("kw");
+}
+
+function buildMessagesQuery(
+  day: number,
+  filter: MessageFilterValue,
+  page: number | undefined,
+): MessagesQuery {
+  const q: MessagesQuery = { day };
+  if (filter.messageType.length > 0) q.messageType = filter.messageType;
+  if (filter.fromParticipantId.length > 0)
+    q.fromParticipantId = filter.fromParticipantId;
+  if (filter.toParticipantId.length > 0)
+    q.toParticipantId = filter.toParticipantId;
+  if (filter.keyword.trim() !== "") q.keyword = filter.keyword.trim();
+  if (typeof page === "number") {
+    q.pageSize = PAGE_SIZE;
+    q.pageNum = page;
+  }
+  return q;
+}
+
 export async function loader({ request, params }: Route.LoaderArgs) {
   const villageId = Number(params.id);
   if (!Number.isFinite(villageId)) {
@@ -58,6 +127,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   }
   const url = new URL(request.url);
   const dayParam = parseDayParam(url.searchParams.get("day"));
+  const initialFilter = parseFilterFromParams(url.searchParams);
+  const initialPage = parsePageParam(url.searchParams.get("page"));
   const api = ssrFetch(request);
   // 村の存在確認を先行させる。村が無い場合に messages / footsteps / myself へ
   // 無駄な API コール (backend で同じく 404 になる) が走るのを避けるため。
@@ -66,15 +137,27 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   // 初期表示日: ?day= があればそれ、無ければ最新日 (= backend で `day` 未指定時と同じ)。
   // 「latest」をクエリキーに乗せる都合で、ここでは明示的に number に正規化して渡す。
   const initialDay = dayParam ?? village.time.latestDay;
+  // フィルタ / ページ指定があれば SSR でも反映 (URL 共有時の見た目を一致させる)。
+  const messagesQuery = buildMessagesQuery(initialDay, initialFilter, initialPage);
   const [messages, footsteps, myself, situation] = await Promise.all([
-    fetchVillageMessages(villageId, initialDay, api).catch(() => null),
+    fetchVillageMessages(villageId, messagesQuery, api).catch(() => null),
     fetchVillageFootsteps(villageId, api).catch(() => null),
     fetchMyself(villageId, api).catch(() => null),
     // situation は day を渡さなくても backend 側で latestDay を採用するため未指定で OK。
     // CSR でも `useVillageSituationQuery` は day なしで叩く想定。
     fetchVillageSituation(villageId, undefined, api).catch(() => null),
   ]);
-  return { villageId, village, initialDay, messages, footsteps, myself, situation };
+  return {
+    villageId,
+    village,
+    initialDay,
+    initialFilter,
+    initialPage,
+    messages,
+    footsteps,
+    myself,
+    situation,
+  };
 }
 
 export default function VillageDetail({ loaderData }: Route.ComponentProps) {
@@ -82,6 +165,8 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
     villageId,
     village: initialVillage,
     initialDay,
+    initialFilter,
+    initialPage,
     messages: initialMessages,
     footsteps: initialFootsteps,
     myself: initialMyself,
@@ -91,15 +176,25 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
   const [params, setParams] = useSearchParams();
   // ?day を最優先で使い、無ければ loader で求めた initialDay (= latest) にフォールバック。
   const selectedDay = parseDayParam(params.get("day")) ?? initialDay;
+  const filter = useMemo(() => parseFilterFromParams(params), [params]);
+  const page = parsePageParam(params.get("page"));
+  const isFiltered = !isEmptyFilter(filter);
+  const isPaging = typeof page === "number";
+
+  const [showFilter, setShowFilter] = useState(false);
+  const [showInfo, setShowInfo] = useState(false);
 
   const villageQuery = useVillageQuery(villageId, initialVillage);
-  // 表示日が初期と一致するときだけ SSR の initialMessages を渡す。タブ切替後は
-  // initial を使い回すと別日のデータを掴むため必ず再 fetch させる。
-  const messagesInitialData =
-    selectedDay === initialDay ? initialMessages ?? undefined : undefined;
+  // SSR initialData: 日 / フィルタ / ページが loader と一致するときだけ使う。
+  // どれかが変われば別データなので initial を渡すと不整合になる。
+  const isInitialView =
+    selectedDay === initialDay &&
+    JSON.stringify(filter) === JSON.stringify(initialFilter) &&
+    page === initialPage;
+  const messagesInitialData = isInitialView ? initialMessages ?? undefined : undefined;
   const messagesQuery = useVillageMessagesQuery(
     villageId,
-    selectedDay,
+    buildMessagesQuery(selectedDay, filter, page),
     messagesInitialData,
   );
   const footstepsQuery = useVillageFootstepsQuery(villageId, initialFootsteps ?? undefined);
@@ -135,12 +230,45 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
           // 最新日に戻すときは ?day= を消して URL を綺麗に保つ。
           if (day === latestDay) next.delete("day");
           else next.set("day", String(day));
+          // 日付を切り替えたらページ番号はリセット (異なる日のページ位置は意味なし)。
+          next.delete("page");
           return next;
         },
         { replace: true },
       );
     },
     [setParams, latestDay],
+  );
+
+  const applyFilter = useCallback(
+    (v: MessageFilterValue) => {
+      setParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          applyFilterToParams(next, v);
+          // フィルタ変更でページ番号はリセット (件数が変わるため意味が変わる)。
+          next.delete("page");
+          return next;
+        },
+        { replace: false },
+      );
+    },
+    [setParams],
+  );
+
+  const setPage = useCallback(
+    (p: number) => {
+      setParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (p <= 1) next.delete("page");
+          else next.set("page", String(p));
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setParams],
   );
 
   // SayForm 表示判定: 最新日 + backend が「発言可能」と返している場合のみ。
@@ -157,7 +285,14 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
     <main className="min-h-screen bg-slate-900 text-slate-100">
       <section className="max-w-4xl mx-auto px-6 py-10 space-y-6">
         <SayFormProvider>
-          <VillageHeader village={village} />
+          <VillageHeader
+            village={village}
+            onOpenInfo={() => setShowInfo(true)}
+            onOpenFilter={() => setShowFilter(true)}
+            isFiltered={isFiltered}
+            villageId={villageId}
+            selectedDay={selectedDay}
+          />
 
           <DayTabs
             days={village.days.list.map((d) => d.day)}
@@ -187,12 +322,29 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
             messages={messages}
             day={selectedDay}
             participants={village.participants.list}
+            isPaging={isPaging}
+            onSetPage={setPage}
           />
 
-          {canShowSayForm && <SayForm villageId={villageId} myself={myself!} />}
+          {canShowSayForm && !isFiltered && !isPaging && (
+            <SayForm villageId={villageId} myself={myself!} />
+          )}
 
           <FootstepsPanel footsteps={footsteps} />
         </SayFormProvider>
+
+        <MessageFilterModal
+          open={showFilter}
+          value={filter}
+          participants={village.participants.list}
+          onApply={applyFilter}
+          onClose={() => setShowFilter(false)}
+        />
+        <VillageInfoModal
+          open={showInfo}
+          village={village}
+          onClose={() => setShowInfo(false)}
+        />
       </section>
     </main>
   );
@@ -200,7 +352,21 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
 
 // ---------- 部品 ----------
 
-function VillageHeader({ village }: { village: VillageView }) {
+function VillageHeader({
+  village,
+  villageId,
+  selectedDay,
+  onOpenInfo,
+  onOpenFilter,
+  isFiltered,
+}: {
+  village: VillageView;
+  villageId: number;
+  selectedDay: number;
+  onOpenInfo: () => void;
+  onOpenFilter: () => void;
+  isFiltered: boolean;
+}) {
   return (
     <header className="space-y-2">
       <div className="flex items-center justify-between">
@@ -228,6 +394,36 @@ function VillageHeader({ village }: { village: VillageView }) {
         村建て: {village.createPlayerName} / {village.participants.count}人
         {village.participants.spectatorCount > 0 ? ` (見学${village.participants.spectatorCount})` : ""}
       </p>
+      <div className="flex flex-wrap gap-2 pt-1">
+        <button
+          type="button"
+          className="rounded border border-slate-600 px-2.5 py-1 text-xs text-slate-200 hover:bg-slate-800"
+          onClick={onOpenInfo}
+        >
+          村情報
+        </button>
+        <button
+          type="button"
+          className={
+            "rounded border px-2.5 py-1 text-xs " +
+            (isFiltered
+              ? "border-indigo-400 bg-indigo-600/30 text-indigo-50"
+              : "border-slate-600 text-slate-200 hover:bg-slate-800")
+          }
+          onClick={onOpenFilter}
+          aria-pressed={isFiltered}
+        >
+          発言抽出{isFiltered ? " (絞り込み中)" : ""}
+        </button>
+        <Link
+          to={`/villages/${villageId}/scrap?day=${selectedDay}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="rounded border border-slate-600 px-2.5 py-1 text-xs text-slate-200 hover:bg-slate-800"
+        >
+          切り抜き ↗
+        </Link>
+      </div>
     </header>
   );
 }
@@ -391,10 +587,14 @@ function MessagesPanel({
   messages,
   day,
   participants,
+  isPaging,
+  onSetPage,
 }: {
   messages: MessagesView | null;
   day: number;
   participants: VillageParticipantView[];
+  isPaging: boolean;
+  onSetPage: (page: number) => void;
 }) {
   // fromParticipantId → VillageParticipantView の逆引きマップを 1 回だけ作る。
   // useMemo で participants 配列の identity が変わったときのみ作り直す。
@@ -403,11 +603,31 @@ function MessagesPanel({
     [participants],
   );
   const count = messages?.list.length ?? 0;
+  const currentPage = messages?.currentPageNum ?? null;
+  const totalPages = messages?.allPageCount ?? 0;
+  // backend 側 `isExistPrePage` / `isExistNextPage` を信頼する (フィルタ込で正確に出ている)。
+  const hasPrev = messages?.isExistPrePage ?? false;
+  const hasNext = messages?.isExistNextPage ?? false;
   return (
     <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
-      <h2 className="text-sm text-slate-400 mb-3">
-        発言 ({day === 0 ? "プロローグ" : `${day}日目`} · {count}件)
-      </h2>
+      <div className="flex flex-wrap items-center justify-between mb-3 gap-2">
+        <h2 className="text-sm text-slate-400">
+          発言 ({day === 0 ? "プロローグ" : `${day}日目`} · {count}件)
+          {isPaging && totalPages > 0 && currentPage != null && (
+            <span className="ml-2 text-slate-500">
+              ({currentPage} / {totalPages} ページ)
+            </span>
+          )}
+        </h2>
+        <Pagination
+          isPaging={isPaging}
+          currentPage={currentPage}
+          totalPages={totalPages}
+          hasPrev={hasPrev}
+          hasNext={hasNext}
+          onSetPage={onSetPage}
+        />
+      </div>
       {!messages || count === 0 ? (
         <p className="text-slate-400 text-sm py-2">この日の閲覧可能な発言はありません</p>
       ) : (
@@ -419,7 +639,73 @@ function MessagesPanel({
           ))}
         </ul>
       )}
+      {(hasPrev || hasNext) && (
+        <div className="flex justify-end mt-3">
+          <Pagination
+            isPaging={isPaging}
+            currentPage={currentPage}
+            totalPages={totalPages}
+            hasPrev={hasPrev}
+            hasNext={hasNext}
+            onSetPage={onSetPage}
+          />
+        </div>
+      )}
     </section>
+  );
+}
+
+function Pagination({
+  isPaging,
+  currentPage,
+  totalPages,
+  hasPrev,
+  hasNext,
+  onSetPage,
+}: {
+  isPaging: boolean;
+  currentPage: number | null;
+  totalPages: number;
+  hasPrev: boolean;
+  hasNext: boolean;
+  onSetPage: (page: number) => void;
+}) {
+  // 全件 1 ページに収まる (ページング ON で次/前なし) または paging OFF で表示が長すぎる
+  // ケースで "分割" ボタンを出す。`?page=1` を付けると backend が pageSize=50 で paging を ON にする。
+  if (!isPaging) {
+    return (
+      <button
+        type="button"
+        className="rounded border border-slate-600 px-2 py-0.5 text-xs text-slate-300 hover:bg-slate-800"
+        onClick={() => onSetPage(1)}
+      >
+        分割表示
+      </button>
+    );
+  }
+  const cur = currentPage ?? 1;
+  return (
+    <div className="flex items-center gap-1 text-xs">
+      <button
+        type="button"
+        className="rounded border border-slate-600 px-2 py-0.5 text-slate-200 disabled:opacity-40 hover:bg-slate-800"
+        onClick={() => onSetPage(cur - 1)}
+        disabled={!hasPrev || cur <= 1}
+      >
+        ‹ 前
+      </button>
+      <span className="px-1 text-slate-400">
+        {cur}/{totalPages || cur}
+      </span>
+      <button
+        type="button"
+        className="rounded border border-slate-600 px-2 py-0.5 text-slate-200 disabled:opacity-40 hover:bg-slate-800"
+        onClick={() => onSetPage(cur + 1)}
+        disabled={!hasNext}
+      >
+        次 ›
+      </button>
+    </div>
   );
 }
 

--- a/frontend/app/routes/villages.$id.tsx
+++ b/frontend/app/routes/villages.$id.tsx
@@ -101,6 +101,34 @@ function applyFilterToParams(p: URLSearchParams, v: MessageFilterValue) {
   else p.delete("kw");
 }
 
+function sortedNumbers(arr: number[]): number[] {
+  return [...arr].sort((a, b) => a - b);
+}
+function sortedStrings(arr: string[]): string[] {
+  return [...arr].sort();
+}
+
+/**
+ * フィルタの等価判定。配列の順序差を吸収するため sort 後に比較する。
+ * useVillageMessagesQuery 側の queryKey 生成と同じ正規化方針。
+ */
+function isFilterEqual(a: MessageFilterValue, b: MessageFilterValue): boolean {
+  if (a.keyword.trim() !== b.keyword.trim()) return false;
+  const aType = sortedStrings(a.messageType);
+  const bType = sortedStrings(b.messageType);
+  if (aType.length !== bType.length) return false;
+  for (let i = 0; i < aType.length; i++) if (aType[i] !== bType[i]) return false;
+  const aFrom = sortedNumbers(a.fromParticipantId);
+  const bFrom = sortedNumbers(b.fromParticipantId);
+  if (aFrom.length !== bFrom.length) return false;
+  for (let i = 0; i < aFrom.length; i++) if (aFrom[i] !== bFrom[i]) return false;
+  const aTo = sortedNumbers(a.toParticipantId);
+  const bTo = sortedNumbers(b.toParticipantId);
+  if (aTo.length !== bTo.length) return false;
+  for (let i = 0; i < aTo.length; i++) if (aTo[i] !== bTo[i]) return false;
+  return true;
+}
+
 function buildMessagesQuery(
   day: number,
   filter: MessageFilterValue,
@@ -187,10 +215,12 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
   const villageQuery = useVillageQuery(villageId, initialVillage);
   // SSR initialData: 日 / フィルタ / ページが loader と一致するときだけ使う。
   // どれかが変われば別データなので initial を渡すと不整合になる。
+  // フィルタ比較は配列の順序差で initial を捨てないよう、useVillageMessagesQuery
+  // 側の queryKey と同じく sort 後比較で揃える。
   const isInitialView =
     selectedDay === initialDay &&
-    JSON.stringify(filter) === JSON.stringify(initialFilter) &&
-    page === initialPage;
+    page === initialPage &&
+    isFilterEqual(filter, initialFilter);
   const messagesInitialData = isInitialView ? initialMessages ?? undefined : undefined;
   const messagesQuery = useVillageMessagesQuery(
     villageId,


### PR DESCRIPTION
## Summary

Step 12 (機能 / 視覚的復元) の最終サブブロック。旧 Thymeleaf 画面の主要な閲覧支援機能を React 側に揃え、Step 13 (デザインモダナイズ) に渡せる状態にする。

### backend

- `/messages` エンドポイントに filter / paging クエリパラメータを追加: `messageType` / `fromParticipantId` / `toParticipantId` / `keyword` / `pageSize` / `pageNum`
- 旧 `VillageGetMessageListForm.typeMap` 互換の発言種別グルーピングを Controller に内蔵 (`GRAVE_SPECTATE_SAY` / `PUBLIC_SYSTEM` / `PRIVATE_SYSTEM` は内部複数 CDef の合成 code)
- `VillageSettingsView` を公開設定フィールド (welcomeRangeName / ageLimitName / voteTypeName / 各種ルール bool / organization / dummyCharaId 等) で拡張。すでに旧 Thymeleaf 画面で公開されていたものなのでスポイラーなし

### frontend

- `MessageFilterModal`: 種別 / 発言者 / 宛先 / キーワードのチェックボックス UI、リセット / 抽出ボタン
- `VillageInfoModal`: 拡張済の `VillageSettingsView` を read-only で表示。creator は「設定変更」リンクを併設
- 村画面ヘッダに「村情報」「発言抽出」「切り抜き」ボタン
- `MessagesPanel` にページネーション (Pagination component、prev / next / 分割表示)
- フィルタ / ページ番号は URL クエリ (`?type=&from=&to=&kw=&page=`) で同期
- `/villages/:id/scrap` 新設: フィルタ条件を URL で受ける read-only ビュー (印刷 / 共有用途)

### 意図的スコープ外 (Step 13 へ持ち越し)

- 発言の **preview 確認画面** (2-step submit): SayForm は単発 POST のままで運用上問題なし、デザインモダナイズと一緒に
- **アクション発言フォーム UI** (旧 ActionPanel の ACTION 種別フォーム部分): 現 ActionPanel は能力 / 投票 / commit のみ。ACTION 発言は SayForm の messageType=ACTION で代替可能なので必須ではない
- **キャラ画像で表情選択 / 秘話相手選択 modal**: Step 13 のビジュアル文脈で

## Test plan

- [x] `./gradlew test` (backend) → SUCCESS
- [x] `pnpm typecheck` / `pnpm test` / `pnpm build` (frontend) → PASS
- [x] `curl /messages?messageType=NORMAL_SAY&pageSize=10&pageNum=1&keyword=test` → 200 OK + 期待 schema
- [x] 村画面で「村情報」「発言抽出」「切り抜き」ボタンが表示される
- [x] `/villages/:id/scrap?day=N` が独立ページとして開く
- [ ] フィルタを適用すると messages が絞り込まれる (手動 UI 確認)
- [ ] ページネーションで前 / 次が動く (手動 UI 確認)
- [ ] 村情報モーダルが各設定値を正しく表示する (手動 UI 確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)