### PR TITLE
Step 13b: 本番 (wolfort.net) との一致修正 + placeholder ルート

### DIFF
--- a/frontend/app/components/layout/PageFooter.tsx
+++ b/frontend/app/components/layout/PageFooter.tsx
@@ -1,0 +1,366 @@
+import { useState } from "react";
+import { Modal } from "~/components/ui/Modal";
+import { LinkButton } from "~/components/ui/Button";
+
+/**
+ * 旧 templates/layout/footer.html を React で復元。
+ *
+ * - 連絡先テキスト + Twitter @ort_dev リンク
+ * - 「投げ銭」リンク → kampa modal
+ * - 「プライバシーポリシー」リンク → policy modal
+ * - 著作権 + Github リンク
+ *
+ * 旧画面の Google AdSense は本番限定のため移植対象外 (環境変数による
+ * 出し分けが必要になったら別途検討)。
+ */
+export function PageFooter() {
+  const [kampaOpen, setKampaOpen] = useState(false);
+  const [policyOpen, setPolicyOpen] = useState(false);
+
+  return (
+    <footer className="px-3 py-4 mt-4 text-[0.95em] opacity-80">
+      <hr className="border-night-700 mb-3" />
+      <p className="leading-[1.6em]">
+        要望、改善提案、不具合報告は Twitter{" "}
+        <a
+          href="https://twitter.com/ort_dev"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blood-600 hover:text-mint-500"
+        >
+          @ort_dev
+        </a>{" "}
+        までお願いします。
+        <br />
+        投げ銭いただける方は{" "}
+        <button
+          type="button"
+          onClick={() => setKampaOpen(true)}
+          className="text-blood-600 hover:text-mint-500 underline"
+        >
+          こちら
+        </button>{" "}
+        からお願いします。
+        <br />
+        <button
+          type="button"
+          onClick={() => setPolicyOpen(true)}
+          className="text-blood-600 hover:text-mint-500 underline"
+        >
+          プライバシーポリシー
+        </button>
+        <br />
+        © 2018- ort (
+        <a
+          href="https://github.com/h-orito/wolf-mansion"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blood-600 hover:text-mint-500"
+        >
+          Github
+        </a>
+        )
+      </p>
+
+      <Modal open={kampaOpen} onClose={() => setKampaOpen(false)} title="投げ銭について">
+        <KampaContent />
+      </Modal>
+
+      <Modal
+        open={policyOpen}
+        onClose={() => setPolicyOpen(false)}
+        title="プライバシーポリシー"
+      >
+        <PolicyContent />
+      </Modal>
+    </footer>
+  );
+}
+
+function KampaContent() {
+  return (
+    <div className="space-y-3">
+      <section>
+        <h3 className="text-[1.1em] font-medium mb-1">Amazon ほしい物リストから送る</h3>
+        <ul className="list-disc pl-5 mb-2">
+          <li>Amazon ほしいものリストから選んで開発者に送ることができます。</li>
+        </ul>
+        <div className="flex justify-end">
+          <LinkButton
+            to="https://www.amazon.jp/hz/wishlist/ls/1KZSJAJS1ETW4?ref_=wl_share"
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="success"
+          >
+            Amazon ほしいものリストから送る
+          </LinkButton>
+        </div>
+      </section>
+
+      <hr className="border-night-700" />
+
+      <section>
+        <h3 className="text-[1.1em] font-medium mb-1">
+          Amazon ギフト券 (E メールタイプ) を送る
+        </h3>
+        <ul className="list-disc pl-5 mb-2">
+          <li>
+            受取人に「wolfortあっとgooglegroups.com」を指定してください (あっとのところは
+            @ に変えてください)。
+          </li>
+          <li>金額は 15 円以上で自由に変更できます。</li>
+        </ul>
+        <div className="flex justify-end">
+          <LinkButton
+            to="https://www.amazon.co.jp/dp/B004N3APGO"
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="success"
+          >
+            Amazon ギフト券 (E メールタイプ) を送る
+          </LinkButton>
+        </div>
+      </section>
+
+      <hr className="border-night-700" />
+
+      <section>
+        <h3 className="text-[1.1em] font-medium mb-1">
+          Amazon アソシエイト経由で買い物をする
+        </h3>
+        <ul className="list-disc pl-5 mb-2">
+          <li>
+            下記から Amazon に遷移してカートに追加 & 購入すると、開発者に若干の紹介料が
+            入ります。
+          </li>
+        </ul>
+        <div className="flex justify-end">
+          <LinkButton
+            to="https://amzn.to/48auG7Q"
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="success"
+          >
+            Amazon を開く
+          </LinkButton>
+        </div>
+      </section>
+
+      <hr className="border-night-700" />
+
+      <section>
+        <h3 className="text-[1.1em] font-medium mb-1">Pixiv Fanbox</h3>
+        <div className="flex justify-end">
+          <LinkButton
+            to="https://ort.fanbox.cc/"
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="success"
+          >
+            Pixiv Fanbox を開く
+          </LinkButton>
+        </div>
+      </section>
+
+      <hr className="border-night-700" />
+
+      <section>
+        <h3 className="text-[1.1em] font-medium mb-1">補足</h3>
+        <ul className="list-disc pl-5">
+          <li>
+            頂いた改善提案、ご要望については投げ銭の有無に関係なく積極的に取り入れていく
+            ので、Twitter{" "}
+            <a
+              href="https://twitter.com/ort_dev"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blood-600 hover:text-mint-500"
+            >
+              @ort_dev
+            </a>{" "}
+            までお願いします。
+          </li>
+        </ul>
+      </section>
+    </div>
+  );
+}
+
+function PolicyContent() {
+  return (
+    <div className="space-y-2 leading-[1.6em]">
+      <p>
+        WOLF MANSION 管理人 (以下，「管理人」といいます。) は，本ウェブサイト上で
+        提供するサービス (以下，「本サービス」といいます。) における，ユーザの
+        プライバシー情報の取扱いについて，以下のとおりプライバシーポリシー (以下，
+        「本ポリシー」といいます。) を定めます。
+      </p>
+
+      <PolicySection title="第 1 条 (プライバシー情報)">
+        <ol className="list-decimal pl-6">
+          <li>本サービスでは，個人情報保護法にいう「個人情報」を収集しません。</li>
+          <li>
+            本サービスは，ログインに利用した ID やパスワード，ご覧になったページや
+            広告の履歴，ユーザが検索された検索キーワード，ご利用日時，ご利用の方法，
+            ご利用環境，ユーザの IP アドレス，クッキー情報などのプライバシー情報を
+            収集します。
+          </li>
+        </ol>
+      </PolicySection>
+
+      <PolicySection title="第 2 条 (プライバシー情報の収集方法)">
+        <ol className="list-decimal pl-6">
+          <li>
+            本サービスは，ユーザが利用登録をする際に ID やパスワードなどをお尋ねする
+            ことがあります。
+          </li>
+          <li>
+            本サービスは，ユーザが各ページを閲覧する際に，ご覧になったページや広告の
+            履歴，ユーザが検索された検索キーワード，ご利用日時，ご利用の方法，ご利用
+            環境，ユーザの IP アドレス，クッキー情報などを収集します。
+          </li>
+        </ol>
+      </PolicySection>
+
+      <PolicySection title="第 3 条 (プライバシー情報を収集・利用する目的)">
+        <p>本サービスが個人情報を収集・利用する目的は，以下のとおりです。</p>
+        <ol className="list-decimal pl-6">
+          <li>サービスの提供・運営のため</li>
+          <li>ユーザからのお問い合わせに回答するため (本人確認を行うことを含む)</li>
+          <li>メンテナンス，重要なお知らせなど必要に応じたご連絡のため</li>
+          <li>
+            利用規約に違反したユーザや，不正・不当な目的でサービスを利用しようとする
+            ユーザの特定をし，ご利用をお断りするため
+          </li>
+          <li>
+            ユーザにご自身の登録情報の閲覧や変更，削除，ご利用状況の閲覧を行って
+            いただくため
+          </li>
+          <li>上記の利用目的に付随する目的</li>
+        </ol>
+      </PolicySection>
+
+      <PolicySection title="第 4 条 (利用目的の変更)">
+        <p>
+          管理人は，利用目的が変更前と関連性を有すると合理的に認められる場合に限り，
+          プライバシー情報の利用目的を変更するものとします。また，この変更の際，
+          ユーザに通知することなく変更するものとし，これによってユーザに生じた損害に
+          ついて一切の責任を負いません。
+        </p>
+      </PolicySection>
+
+      <PolicySection title="第 5 条 (個人情報の第三者提供)">
+        <p>
+          管理人は、広告表示やアクセス解析のため、Google Adsense および Google
+          Analytics にプライバシー情報を送信しています。それ以外の送信先については，
+          次に掲げる場合を除いて，あらかじめユーザの同意を得ることなく提供することは
+          ありません。ただし，個人情報保護法その他の法令で認められる場合を除きます。
+        </p>
+        <ol className="list-decimal pl-6">
+          <li>
+            人の生命，身体または財産の保護のために必要がある場合であって，本人の同意を
+            得ることが困難であるとき
+          </li>
+          <li>
+            公衆衛生の向上または児童の健全な育成の推進のために特に必要がある場合で
+            あって，本人の同意を得ることが困難であるとき
+          </li>
+          <li>
+            国の機関もしくは地方公共団体またはその委託を受けた者が法令の定める事務を
+            遂行することに対して協力する必要がある場合であって，本人の同意を得る
+            ことにより当該事務の遂行に支障を及ぼすおそれがあるとき
+          </li>
+          <li>
+            予め次の事項を告知あるいは公表し，かつ管理人が個人情報保護委員会に届出を
+            したとき
+            <ol className="list-decimal pl-6">
+              <li>利用目的に第三者への提供を含むこと</li>
+              <li>第三者に提供されるデータの項目</li>
+              <li>第三者への提供の手段または方法</li>
+              <li>本人の求めに応じて個人情報の第三者への提供を停止すること</li>
+              <li>本人の求めを受け付ける方法</li>
+            </ol>
+          </li>
+        </ol>
+      </PolicySection>
+
+      <PolicySection title="第 6 条 (プライバシー情報の開示)">
+        <p>ID 以外の情報については，原則として開示いたしません。</p>
+      </PolicySection>
+
+      <PolicySection title="第 7 条 (プライバシー情報の訂正および削除)">
+        <ol className="list-decimal pl-6">
+          <li>
+            ユーザは，管理人の保有する自己の個人情報が誤った情報である場合には，
+            管理人が定める手続きにより，管理人に対して個人情報の訂正，追加または削除
+            (以下，「訂正等」といいます。) を請求することができます。
+          </li>
+          <li>
+            管理人は，ユーザから前項の請求を受けてその請求に応じる必要があると判断
+            した場合には，遅滞なく，当該個人情報の訂正等を行うものとします。
+          </li>
+          <li>
+            管理人は，前項の規定に基づき訂正等を行った場合，または訂正等を行わない旨の
+            決定をしたときは遅滞なく，これをユーザに通知します。
+          </li>
+        </ol>
+      </PolicySection>
+
+      <PolicySection title="第 8 条 (プライバシー情報の利用停止等)">
+        <ol className="list-decimal pl-6">
+          <li>
+            管理人は，本人から，個人情報が，利用目的の範囲を超えて取り扱われている
+            という理由，または不正の手段により取得されたものであるという理由により，
+            その利用の停止または消去 (以下，「利用停止等」といいます。) を求められた
+            場合には，遅滞なく必要な調査を行います。
+          </li>
+          <li>
+            前項の調査結果に基づき，その請求に応じる必要があると判断した場合には，
+            遅滞なく，当該プライバシー情報の利用停止等を行います。
+          </li>
+          <li>
+            管理人は，前項の規定に基づき利用停止等を行った場合，または利用停止等を
+            行わない旨の決定をしたときは，遅滞なく，これをユーザに通知します。
+          </li>
+          <li>
+            前 2 項にかかわらず，利用停止等に多額の費用を有する場合その他利用停止等を
+            行うことが困難な場合であって，ユーザの権利利益を保護するために必要な
+            これに代わるべき措置をとれる場合は，この代替策を講じるものとします。
+          </li>
+        </ol>
+      </PolicySection>
+
+      <PolicySection title="第 9 条 (プライバシーポリシーの変更)">
+        <ol className="list-decimal pl-6">
+          <li>
+            本ポリシーの内容は，法令その他本ポリシーに別段の定めのある事項を除いて，
+            ユーザに通知することなく，変更することができるものとします。
+          </li>
+          <li>
+            管理人が別途定める場合を除いて，変更後のプライバシーポリシーは，本ウェブ
+            サイトに掲載したときから効力を生じるものとします。
+          </li>
+        </ol>
+      </PolicySection>
+
+      <PolicySection title="第 10 条 (お問い合わせ窓口)">
+        <p>本ポリシーに関するお問い合わせは，Twitter @ort_dev までお願いいたします。</p>
+      </PolicySection>
+    </div>
+  );
+}
+
+function PolicySection({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      <h3 className="text-[1.05em] font-medium mt-2 mb-1">{title}</h3>
+      {children}
+    </section>
+  );
+}

--- a/frontend/app/components/layout/PlaceholderPage.tsx
+++ b/frontend/app/components/layout/PlaceholderPage.tsx
@@ -1,0 +1,46 @@
+import { LinkButton } from "~/components/ui/Button";
+import { Panel, PanelBody } from "~/components/ui/Panel";
+import { PageHeader } from "~/components/layout/PageHeader";
+import { PageFooter } from "~/components/layout/PageFooter";
+
+/**
+ * 旧 Thymeleaf 版に存在し React 側に未移植のページのスタブ。
+ * about / intro / announce / rule / faq / new-player など、home からリンク
+ * されるが React Route 未実装のページで利用する。
+ *
+ * Step 13e の最終仕上げで実コンテンツに置き換える。
+ */
+export function PlaceholderPage({
+  title,
+  englishTitle,
+  description,
+}: {
+  title: string;
+  englishTitle?: string;
+  description: React.ReactNode;
+}) {
+  return (
+    <>
+      <PageHeader />
+      <div className="px-3">
+        <h1 className="text-[1.5em] font-medium mb-1">{title}</h1>
+        {englishTitle && (
+          <p className="opacity-70 mb-3 text-[0.95em]">{englishTitle}</p>
+        )}
+        <Panel className="mb-3">
+          <PanelBody>
+            <p className="mb-2">{description}</p>
+            <p className="text-warning-500 mb-3">
+              このページは React 移植の最終仕上げ (Step 13e) でコンテンツが
+              追加される予定です。準備中。
+            </p>
+            <LinkButton to="/" variant="dark-success">
+              トップに戻る
+            </LinkButton>
+          </PanelBody>
+        </Panel>
+      </div>
+      <PageFooter />
+    </>
+  );
+}

--- a/frontend/app/components/layout/PlaceholderPage.tsx
+++ b/frontend/app/components/layout/PlaceholderPage.tsx
@@ -1,7 +1,20 @@
+import type { ReactNode } from "react";
 import { LinkButton } from "~/components/ui/Button";
 import { Panel, PanelBody } from "~/components/ui/Panel";
 import { PageHeader } from "~/components/layout/PageHeader";
 import { PageFooter } from "~/components/layout/PageFooter";
+
+/**
+ * placeholder route 用の meta 共通ヘルパ。
+ * - title は旧本番のタイトルをダッシュで結合 (旧 `<title>WOLF MANSION 〜人狼館の事件簿村〜 <pageTitle></title>` 相当)
+ * - SEO 上 indexable にしたくない (実コンテンツは Step 13e で移植予定) ため robots noindex を付ける
+ */
+export function placeholderMeta(pageTitle: string) {
+  return [
+    { title: `${pageTitle} — WOLF MANSION` },
+    { name: "robots", content: "noindex" },
+  ];
+}
 
 /**
  * 旧 Thymeleaf 版に存在し React 側に未移植のページのスタブ。
@@ -17,7 +30,7 @@ export function PlaceholderPage({
 }: {
   title: string;
   englishTitle?: string;
-  description: React.ReactNode;
+  description: ReactNode;
 }) {
   return (
     <>

--- a/frontend/app/components/ui/Modal.tsx
+++ b/frontend/app/components/ui/Modal.tsx
@@ -1,0 +1,107 @@
+import * as React from "react";
+import { XMarkIcon } from "@heroicons/react/24/outline";
+import { cn } from "./cn";
+
+/**
+ * 最小限の Modal primitive。旧 Bootstrap 3 の .modal-dialog / .modal-content /
+ * .modal-header (× ボタン + h4 title) / .modal-body の構造を再現する。
+ *
+ * - Esc で閉じる
+ * - 背景クリックで閉じる
+ * - body スクロールをロック
+ * - 完全な focus trap は実装せず、open 時に最初の要素にフォーカス + close 時に
+ *   trigger にフォーカス戻し (Step 13b の最小要件、必要に応じ後続強化)
+ */
+type ModalProps = {
+  open: boolean;
+  onClose: () => void;
+  title: React.ReactNode;
+  children: React.ReactNode;
+  /** title 要素の id (aria-labelledby 用)。省略時は自動採番 */
+  titleId?: string;
+  className?: string;
+};
+
+export function Modal({
+  open,
+  onClose,
+  title,
+  children,
+  titleId,
+  className,
+}: ModalProps) {
+  const reactId = React.useId();
+  const tid = titleId ?? `modal-title-${reactId}`;
+  const dialogRef = React.useRef<HTMLDivElement>(null);
+  const previousFocus = React.useRef<HTMLElement | null>(null);
+
+  // open 切替で focus 管理 + body scroll lock
+  React.useEffect(() => {
+    if (!open) return;
+    previousFocus.current = document.activeElement as HTMLElement | null;
+    const body = document.body;
+    const prevOverflow = body.style.overflow;
+    body.style.overflow = "hidden";
+
+    // open 時、dialog 内の最初の focusable に focus
+    const first = dialogRef.current?.querySelector<HTMLElement>(
+      "button, [href], input, textarea, select, [tabindex]:not([tabindex='-1'])",
+    );
+    first?.focus();
+
+    return () => {
+      body.style.overflow = prevOverflow;
+      previousFocus.current?.focus?.();
+    };
+  }, [open]);
+
+  // Esc 閉じる
+  React.useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4 bg-black/60"
+      onClick={onClose}
+      role="presentation"
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={tid}
+        className={cn(
+          "w-full max-w-[40em] my-8 bg-night-950 border border-night-700 rounded-[0.25em] shadow-lg",
+          className,
+        )}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-3 py-2 border-b border-night-700">
+          <h2 id={tid} className="text-[1.17em] font-medium">
+            {title}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="閉じる"
+            className="text-white hover:text-mint-500 transition-colors"
+          >
+            <XMarkIcon className="w-[1.5em] h-[1.5em]" aria-hidden />
+          </button>
+        </div>
+        <div className="px-3 py-3">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/components/ui/Modal.tsx
+++ b/frontend/app/components/ui/Modal.tsx
@@ -9,8 +9,13 @@ import { cn } from "./cn";
  * - Esc で閉じる
  * - 背景クリックで閉じる
  * - body スクロールをロック
- * - 完全な focus trap は実装せず、open 時に最初の要素にフォーカス + close 時に
- *   trigger にフォーカス戻し (Step 13b の最小要件、必要に応じ後続強化)
+ * - open 時に最初の focusable へ focus、close 時に trigger に focus 戻し
+ *
+ * **既知の制約**: Tab / Shift+Tab のフォーカストラップは未実装。`aria-modal=true`
+ * はあくまでヒントで、ブラウザ・AT 実装によっては modal 外要素にフォーカスが
+ * 移ることがある。現状の用途 (kampa / policy のような閉じる・外部リンク中心の
+ * informational modal) では実害は限定的。フォーム入力を持つ Modal に使う場合は
+ * focus trap を別途実装すること。
  */
 type ModalProps = {
   open: boolean;

--- a/frontend/app/components/ui/index.ts
+++ b/frontend/app/components/ui/index.ts
@@ -19,3 +19,5 @@ export { VillageTag, villageTagLevel } from "./VillageTag";
 export { Alert } from "./Alert";
 
 export { Table, TableResponsive } from "./Table";
+
+export { Modal } from "./Modal";

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -14,6 +14,15 @@ export default [
   route("charachips/:id", "routes/charachips.$id.tsx"),
   route("skills", "routes/skills.tsx"),
   route("village-records", "routes/village-records.tsx"),
+  // 本番 wolfort.net に存在し React 未移植のページ用 placeholder (Step 13b 追加、
+  // 13e で実コンテンツに置き換え予定)。home の MenuTile から参照されるため、
+  // 404 を避ける目的で「準備中」スタブを返す
+  route("about", "routes/about.tsx"),
+  route("intro", "routes/intro.tsx"),
+  route("announce", "routes/announce.tsx"),
+  route("rule", "routes/rule.tsx"),
+  route("faq", "routes/faq.tsx"),
+  route("new-player", "routes/new-player.tsx"),
   // 認証必須エリア
   layout("routes/_auth.tsx", [
     route("me", "routes/me.tsx"),

--- a/frontend/app/routes/_auth.tsx
+++ b/frontend/app/routes/_auth.tsx
@@ -4,6 +4,7 @@ import type { MeResponse } from "~/features/auth/api";
 import { ssrFetch } from "~/lib/api/client";
 import { stripBasename } from "~/lib/basename";
 import { PageHeader } from "~/components/layout/PageHeader";
+import { PageFooter } from "~/components/layout/PageFooter";
 
 /**
  * 認証必須レイアウト。
@@ -37,6 +38,7 @@ export default function AuthLayout() {
       <div className="px-3">
         <Outlet />
       </div>
+      <PageFooter />
     </div>
   );
 }

--- a/frontend/app/routes/about.tsx
+++ b/frontend/app/routes/about.tsx
@@ -1,8 +1,8 @@
 import type { Route } from "./+types/about";
-import { PlaceholderPage } from "~/components/layout/PlaceholderPage";
+import { PlaceholderPage, placeholderMeta } from "~/components/layout/PlaceholderPage";
 
 export function meta(_: Route.MetaArgs) {
-  return [{ title: "本サイトは | WOLF MANSION" }];
+  return placeholderMeta("本サイトは");
 }
 
 export default function About() {

--- a/frontend/app/routes/about.tsx
+++ b/frontend/app/routes/about.tsx
@@ -1,0 +1,18 @@
+import type { Route } from "./+types/about";
+import { PlaceholderPage } from "~/components/layout/PlaceholderPage";
+
+export function meta(_: Route.MetaArgs) {
+  return [{ title: "本サイトは | WOLF MANSION" }];
+}
+
+export default function About() {
+  return (
+    <main className="max-w-screen-lg mx-auto">
+      <PlaceholderPage
+        title="本サイトは"
+        englishTitle="About"
+        description="WOLF MANSION の運営方針 / 利用上の注意 / 開発者情報など、本サイト全般の説明。"
+      />
+    </main>
+  );
+}

--- a/frontend/app/routes/announce.tsx
+++ b/frontend/app/routes/announce.tsx
@@ -1,8 +1,8 @@
 import type { Route } from "./+types/announce";
-import { PlaceholderPage } from "~/components/layout/PlaceholderPage";
+import { PlaceholderPage, placeholderMeta } from "~/components/layout/PlaceholderPage";
 
 export function meta(_: Route.MetaArgs) {
-  return [{ title: "お知らせ | WOLF MANSION" }];
+  return placeholderMeta("お知らせ");
 }
 
 export default function Announce() {

--- a/frontend/app/routes/announce.tsx
+++ b/frontend/app/routes/announce.tsx
@@ -1,0 +1,18 @@
+import type { Route } from "./+types/announce";
+import { PlaceholderPage } from "~/components/layout/PlaceholderPage";
+
+export function meta(_: Route.MetaArgs) {
+  return [{ title: "お知らせ | WOLF MANSION" }];
+}
+
+export default function Announce() {
+  return (
+    <main className="max-w-screen-lg mx-auto">
+      <PlaceholderPage
+        title="お知らせ"
+        englishTitle="Announce"
+        description="リリース告知 / メンテナンス予定 / 仕様変更などの運営からのお知らせ一覧。"
+      />
+    </main>
+  );
+}

--- a/frontend/app/routes/faq.tsx
+++ b/frontend/app/routes/faq.tsx
@@ -1,0 +1,18 @@
+import type { Route } from "./+types/faq";
+import { PlaceholderPage } from "~/components/layout/PlaceholderPage";
+
+export function meta(_: Route.MetaArgs) {
+  return [{ title: "よくある質問 | WOLF MANSION" }];
+}
+
+export default function Faq() {
+  return (
+    <main className="max-w-screen-lg mx-auto">
+      <PlaceholderPage
+        title="よくある質問"
+        englishTitle="FAQ"
+        description="参加・進行・能力使用に関する FAQ。"
+      />
+    </main>
+  );
+}

--- a/frontend/app/routes/faq.tsx
+++ b/frontend/app/routes/faq.tsx
@@ -1,8 +1,8 @@
 import type { Route } from "./+types/faq";
-import { PlaceholderPage } from "~/components/layout/PlaceholderPage";
+import { PlaceholderPage, placeholderMeta } from "~/components/layout/PlaceholderPage";
 
 export function meta(_: Route.MetaArgs) {
-  return [{ title: "よくある質問 | WOLF MANSION" }];
+  return placeholderMeta("FAQ");
 }
 
 export default function Faq() {

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -2,14 +2,18 @@ import { Link } from "react-router";
 import type { Route } from "./+types/home";
 import {
   BookOpenIcon,
+  BookmarkIcon,
   ClipboardDocumentListIcon,
-  DocumentTextIcon,
+  InformationCircleIcon,
   LockClosedIcon,
   LockOpenIcon,
+  MegaphoneIcon,
+  PencilSquareIcon,
   PlusIcon,
-  UserGroupIcon,
+  QuestionMarkCircleIcon,
   UserIcon,
   UsersIcon,
+  WrenchIcon,
 } from "@heroicons/react/24/outline";
 import { useLogoutMutation, useMeQuery } from "~/features/auth/hooks";
 import { fetchVillages, type VillagesView } from "~/features/village/api";
@@ -23,11 +27,12 @@ import {
 import { MenuTileLink, MenuTileButton } from "~/components/ui/MenuTile";
 import { Table, TableResponsive } from "~/components/ui/Table";
 import { VillageTag, villageTagLevel } from "~/components/ui/VillageTag";
+import { PageFooter } from "~/components/layout/PageFooter";
+
+const TOP_STATUSES = ["募集中", "進行中", "エピローグ"] as const;
 
 /** MenuTile icon の共通サイズ。文字サイズ拡大に追従するよう em 単位で。 */
 const ICON_CLASS = "w-[2em] h-[2em]";
-
-const TOP_STATUSES = ["募集中", "進行中", "エピローグ"] as const;
 
 export function meta(_: Route.MetaArgs) {
   return [
@@ -49,19 +54,23 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 /**
- * 旧 templates/index.html を React 上で復元。
+ * 旧 templates/index.html を React で復元 (Step 13b で本番一致に修正)。
  *
  * 旧画面の構造:
  *   1. top.jpg hero + anima ロゴ (左下) + ユーザID (右下、ログイン時のみ)
- *   2. メインメニュー (3-up tile grid)
- *   3. 登録/ログイン (ログイン状態で出し分け)
+ *   2. メインメニュー: About / Intro / Announce / Rule / FAQ / Skill の 6 タイル (2 行 × 3)
+ *   3. 登録/ログイン:
+ *      - 未ログイン: Register (ID 登録) / Login の 2-up
+ *      - ログイン中: MyPage / ChangePassword / Logout の 3-up
  *   4. 開催中の村 (table)
- *   5. 村一覧 / 村作成 (2-up tile)
- *   6. プレイヤー (1-up tile)
- *   7. キャラチップ (1-up tile)
+ *   5. 村一覧 / 村作成:
+ *      - 未ログイン: Village list 単独 (col-sm-12)
+ *      - ログイン中: Village list + Create Village (col-sm-6 × 2)
+ *   6. ユーザー: User list (= /players、常時表示)
+ *   7. キャラチップ: Character list (= /charachips、常時表示)
  *
- * 旧 about / intro / announce / rule / faq / new-player は React 側で未実装の
- * ため、復元対象から除外 (HANDOFF と整合)。Step 13a スコープ外。
+ * 未実装ページ (about / intro / announce / rule / faq / new-player) は
+ * placeholder ルートで「準備中」を返す (routes.ts 参照、Step 13e で実コンテンツ)。
  */
 export default function Home({ loaderData }: Route.ComponentProps) {
   const meQuery = useMeQuery();
@@ -94,7 +103,7 @@ export default function Home({ loaderData }: Route.ComponentProps) {
         )}
       </div>
 
-      {/* --- 2. メインメニュー --- */}
+      {/* --- 2. メインメニュー (6 tiles, 旧 index.html と同じ並び) --- */}
       <MenuSection ariaLabel="メインメニュー">
         <p className="text-center text-[1.17em] mb-1">
           状況のみで推理・説得する、新しい人狼
@@ -105,22 +114,42 @@ export default function Home({ loaderData }: Route.ComponentProps) {
         </p>
         <MenuTileRow cols={3}>
           <MenuTileLink
-            to="/skills"
+            to="/about"
+            icon={<InformationCircleIcon className={ICON_CLASS} />}
+            label="本サイトは"
+            sublabel="About"
+          />
+          <MenuTileLink
+            to="/intro"
+            icon={<QuestionMarkCircleIcon className={ICON_CLASS} />}
+            label="人狼館の事件簿村"
+            sublabel="Introduction"
+          />
+          <MenuTileLink
+            to="/announce"
+            icon={<MegaphoneIcon className={ICON_CLASS} />}
+            label="お知らせ"
+            sublabel="Announce"
+          />
+        </MenuTileRow>
+        <MenuTileRow cols={3}>
+          <MenuTileLink
+            to="/rule"
             icon={<BookOpenIcon className={ICON_CLASS} />}
+            label="ルール"
+            sublabel="Rule"
+          />
+          <MenuTileLink
+            to="/faq"
+            icon={<QuestionMarkCircleIcon className={ICON_CLASS} />}
+            label="よくある質問"
+            sublabel="FAQ"
+          />
+          <MenuTileLink
+            to="/skills"
+            icon={<BookmarkIcon className={ICON_CLASS} />}
             label="役職一覧"
             sublabel="Skill"
-          />
-          <MenuTileLink
-            to="/charachips"
-            icon={<UserGroupIcon className={ICON_CLASS} />}
-            label="キャラチップ"
-            sublabel="Character list"
-          />
-          <MenuTileLink
-            to="/village-records"
-            icon={<DocumentTextIcon className={ICON_CLASS} />}
-            label="終了村一覧"
-            sublabel="Village record"
           />
         </MenuTileRow>
       </MenuSection>
@@ -136,10 +165,10 @@ export default function Home({ loaderData }: Route.ComponentProps) {
               sublabel="My Page"
             />
             <MenuTileLink
-              to={`/players/${encodeURIComponent(user.userId)}`}
-              icon={<DocumentTextIcon className={ICON_CLASS} />}
-              label="戦績"
-              sublabel="Records"
+              to="/me"
+              icon={<WrenchIcon className={ICON_CLASS} />}
+              label="パスワード変更"
+              sublabel="Change Password"
             />
             <MenuTileButton
               icon={<LockClosedIcon className={ICON_CLASS} />}
@@ -152,16 +181,16 @@ export default function Home({ loaderData }: Route.ComponentProps) {
         ) : (
           <MenuTileRow cols={2}>
             <MenuTileLink
+              to="/new-player"
+              icon={<PencilSquareIcon className={ICON_CLASS} />}
+              label="ID 登録"
+              sublabel="Register"
+            />
+            <MenuTileLink
               to="/login"
               icon={<LockOpenIcon className={ICON_CLASS} />}
               label="ログイン"
               sublabel="Login"
-            />
-            <MenuTileLink
-              to="/players"
-              icon={<UsersIcon className={ICON_CLASS} />}
-              label="プレイヤー一覧"
-              sublabel="Players"
             />
           </MenuTileRow>
         )}
@@ -227,19 +256,31 @@ export default function Home({ loaderData }: Route.ComponentProps) {
         </MenuTileRow>
       </MenuSection>
 
-      {/* --- 6. プレイヤー --- */}
-      {user && (
-        <MenuSection title={<>プレイヤー</>}>
-          <MenuTileRow cols={1}>
-            <MenuTileLink
-              to="/players"
-              icon={<UsersIcon className={ICON_CLASS} />}
-              label="プレイヤー一覧"
-              sublabel="Players"
-            />
-          </MenuTileRow>
-        </MenuSection>
-      )}
+      {/* --- 6. ユーザー (常時表示、本番踏襲) --- */}
+      <MenuSection title={<>ユーザー</>}>
+        <MenuTileRow cols={1}>
+          <MenuTileLink
+            to="/players"
+            icon={<UsersIcon className={ICON_CLASS} />}
+            label="一覧"
+            sublabel="User list"
+          />
+        </MenuTileRow>
+      </MenuSection>
+
+      {/* --- 7. キャラチップ (常時表示、本番踏襲) --- */}
+      <MenuSection title={<>キャラチップ</>}>
+        <MenuTileRow cols={1}>
+          <MenuTileLink
+            to="/charachips"
+            icon={<ClipboardDocumentListIcon className={ICON_CLASS} />}
+            label="一覧"
+            sublabel="Character list"
+          />
+        </MenuTileRow>
+      </MenuSection>
+
+      <PageFooter />
     </main>
   );
 }

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -165,7 +165,7 @@ export default function Home({ loaderData }: Route.ComponentProps) {
               sublabel="My Page"
             />
             <MenuTileLink
-              to="/me"
+              to={`/players/${encodeURIComponent(user.userId)}#password`}
               icon={<WrenchIcon className={ICON_CLASS} />}
               label="パスワード変更"
               sublabel="Change Password"

--- a/frontend/app/routes/intro.tsx
+++ b/frontend/app/routes/intro.tsx
@@ -1,0 +1,18 @@
+import type { Route } from "./+types/intro";
+import { PlaceholderPage } from "~/components/layout/PlaceholderPage";
+
+export function meta(_: Route.MetaArgs) {
+  return [{ title: "人狼館の事件簿村 | WOLF MANSION" }];
+}
+
+export default function Intro() {
+  return (
+    <main className="max-w-screen-lg mx-auto">
+      <PlaceholderPage
+        title="人狼館の事件簿村"
+        englishTitle="Introduction"
+        description="占い・襲撃・護衛・狂狐の徘徊によって起こる【足音】と【投票】の 2 つを使って推理・説得する「人狼館の事件簿村」ルールの紹介。"
+      />
+    </main>
+  );
+}

--- a/frontend/app/routes/intro.tsx
+++ b/frontend/app/routes/intro.tsx
@@ -1,8 +1,8 @@
 import type { Route } from "./+types/intro";
-import { PlaceholderPage } from "~/components/layout/PlaceholderPage";
+import { PlaceholderPage, placeholderMeta } from "~/components/layout/PlaceholderPage";
 
 export function meta(_: Route.MetaArgs) {
-  return [{ title: "人狼館の事件簿村 | WOLF MANSION" }];
+  return placeholderMeta("人狼館の事件簿村ルール");
 }
 
 export default function Intro() {

--- a/frontend/app/routes/login.tsx
+++ b/frontend/app/routes/login.tsx
@@ -6,6 +6,7 @@ import { useLoginMutation } from "~/features/auth/hooks";
 import { ssrFetch } from "~/lib/api/client";
 import { sanitizeRedirect } from "~/lib/redirect";
 import { PageHeader } from "~/components/layout/PageHeader";
+import { PageFooter } from "~/components/layout/PageFooter";
 import { Button } from "~/components/ui/Button";
 import { Input, Label } from "~/components/ui/Input";
 
@@ -109,6 +110,7 @@ export default function LoginPage() {
           </div>
         </form>
       </div>
+      <PageFooter />
     </main>
   );
 }

--- a/frontend/app/routes/new-player.tsx
+++ b/frontend/app/routes/new-player.tsx
@@ -1,0 +1,18 @@
+import type { Route } from "./+types/new-player";
+import { PlaceholderPage } from "~/components/layout/PlaceholderPage";
+
+export function meta(_: Route.MetaArgs) {
+  return [{ title: "ID 登録 | WOLF MANSION" }];
+}
+
+export default function NewPlayer() {
+  return (
+    <main className="max-w-screen-lg mx-auto">
+      <PlaceholderPage
+        title="ID 登録"
+        englishTitle="Register"
+        description="新規プレイヤー登録フォーム。プレイヤー名 / パスワード / メールアドレスの入力。"
+      />
+    </main>
+  );
+}

--- a/frontend/app/routes/new-player.tsx
+++ b/frontend/app/routes/new-player.tsx
@@ -1,8 +1,8 @@
 import type { Route } from "./+types/new-player";
-import { PlaceholderPage } from "~/components/layout/PlaceholderPage";
+import { PlaceholderPage, placeholderMeta } from "~/components/layout/PlaceholderPage";
 
 export function meta(_: Route.MetaArgs) {
-  return [{ title: "ID 登録 | WOLF MANSION" }];
+  return placeholderMeta("ID 登録");
 }
 
 export default function NewPlayer() {

--- a/frontend/app/routes/players.$userName.tsx
+++ b/frontend/app/routes/players.$userName.tsx
@@ -81,7 +81,10 @@ export default function PlayerDetailPage({ loaderData }: Route.ComponentProps) {
               />
             </section>
 
-            <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4 space-y-3">
+            <section
+              id="password"
+              className="rounded-xl bg-slate-800/40 border border-slate-700 p-4 space-y-3 scroll-mt-4"
+            >
               <h2 className="text-lg font-bold">パスワード変更</h2>
               <PasswordChangeForm />
             </section>

--- a/frontend/app/routes/rule.tsx
+++ b/frontend/app/routes/rule.tsx
@@ -1,0 +1,18 @@
+import type { Route } from "./+types/rule";
+import { PlaceholderPage } from "~/components/layout/PlaceholderPage";
+
+export function meta(_: Route.MetaArgs) {
+  return [{ title: "ルール | WOLF MANSION" }];
+}
+
+export default function Rule() {
+  return (
+    <main className="max-w-screen-lg mx-auto">
+      <PlaceholderPage
+        title="ルール"
+        englishTitle="Rule"
+        description="勝利条件 / 投票 / 足音 / 各役職の能力詳細など、本ルールの全般。"
+      />
+    </main>
+  );
+}

--- a/frontend/app/routes/rule.tsx
+++ b/frontend/app/routes/rule.tsx
@@ -1,8 +1,8 @@
 import type { Route } from "./+types/rule";
-import { PlaceholderPage } from "~/components/layout/PlaceholderPage";
+import { PlaceholderPage, placeholderMeta } from "~/components/layout/PlaceholderPage";
 
 export function meta(_: Route.MetaArgs) {
-  return [{ title: "ルール | WOLF MANSION" }];
+  return placeholderMeta("ルール");
 }
 
 export default function Rule() {

--- a/frontend/app/routes/villages._index.tsx
+++ b/frontend/app/routes/villages._index.tsx
@@ -6,6 +6,7 @@ import { fetchVillages, type VillagesView, type VillageStatusCode } from "~/feat
 import { useVillagesQuery } from "~/features/village/hooks";
 import { ssrFetch } from "~/lib/api/client";
 import { PageHeader } from "~/components/layout/PageHeader";
+import { PageFooter } from "~/components/layout/PageFooter";
 import { Panel, PanelHeading, PanelBody } from "~/components/ui/Panel";
 import { Button } from "~/components/ui/Button";
 import { Table, TableResponsive } from "~/components/ui/Table";
@@ -178,6 +179,7 @@ export default function VillagesIndex({ loaderData }: Route.ComponentProps) {
           </TableResponsive>
         )}
       </div>
+      <PageFooter />
     </main>
   );
 }


### PR DESCRIPTION
## Summary

- Step 13a で home を旧画面風に張り替えた際、「React 側で未実装のページは省略する」と判断して MenuTile を **6 → 3 に減らした** が、本番 https://wolfort.net/wolf-mansion/ は旧 Thymeleaf 版が稼働中で **これらのページは生きている** ため、自実装が本番と大きく乖離していた (ユーザ指摘、2026-05-26)
- 本 PR で home / login / villages list / _auth レイアウトの構造を **本番と 1:1** に揃え、未実装ページには **「準備中」placeholder ルート** を追加して 404 を回避

## 本番との差異と修正

### home.tsx

| 領域 | 旧 (本番) | Step 13a での自実装 | Step 13b 修正 |
|---|---|---|---|
| メインメニュー | About / Intro / Announce / Rule / FAQ / Skill の 6 タイル | 役職一覧 / キャラチップ / 終了村一覧 の 3 タイル | **6 タイル復元** |
| 登録/ログイン (未) | Register + Login | Login + プレイヤー一覧 | **Register + Login に戻す** |
| 登録/ログイン (済) | MyPage + ChangePassword + Logout | MyPage + 戦績 + Logout | **ChangePassword 復活** (= /me に link、パスワード変更は /me 内フォームに統合済) |
| ユーザー | 常時表示 | ログイン時のみ | **常時表示** |
| キャラチップ | 独立セクション | メインメニュー内 1 タイル | **独立セクションに分離** |

### placeholder ルート (`frontend/app/routes/`)

旧本番に存在し React 未移植のページに「準備中」スタブを返す:
- `/about` `/intro` `/announce` `/rule` `/faq` `/new-player`
- 共通 `PlaceholderPage` コンポーネントで統一表示。実コンテンツは Step 13e で順次移植

### PageFooter 実装 (旧 `layout/footer.html` を React 復元)

- 連絡先テキスト + Twitter @ort_dev リンク
- 「投げ銭」 button → kampa Modal (Amazon Wishlist / Amazon Gift / Amazon Associate / Pixiv Fanbox の 4 経路 + 補足)
- 「プライバシーポリシー」 button → policy Modal (旧本文を 1:1 で React 化、第 1 〜 10 条)
- 著作権 © 2018- ort + Github リンク
- Google AdSense は本番限定のため移植対象外
- 全ページ末尾 (home / login / villages._index / _auth レイアウト + PlaceholderPage) に挿入

### Modal primitive 新規 (`frontend/app/components/ui/Modal.tsx`)

- 旧 Bootstrap 3 .modal-dialog / .modal-content / .modal-header / .modal-body 構造を再現
- Esc / 背景クリック / × ボタンで閉じる、body scroll lock、最初の focusable に focus + close 時に trigger に focus 戻し、aria-modal + aria-labelledby
- 完全な focus trap は最小限 (必要に応じ後続強化)

## 意図的スコープ外

- 6 つの placeholder ページの実コンテンツ移植 (about / intro / rule / faq の長文等) → **Step 13e の最終仕上げ**
- パスワード変更タイルの /me 内フォームへのフォーカスクエリ (例: /me?focus=password) → Step 13e
- Google AdSense の本番限定出し分け → 必要になったら別途検討
- 文字サイズ拡大 UI トグル → Step 13e
- Step 13c (村詳細画面、旧 13b スコープ) は本 PR の後に着手

## Test plan

- [x] \`pnpm typecheck\` pass
- [x] \`pnpm test\` pass (11/11)
- [x] \`pnpm build\` pass
- [x] dev で \`/\` を本番と並べて目視確認: 6 タイルメニュー / 登録ログイン (Register + Login) / ユーザー / キャラチップ / フッタ が本番と一致
- [x] dev で \`/about\` を目視: PageHeader + 「準備中」+ トップに戻るボタン + PageFooter
- [x] フッタの「投げ銭」/「プライバシーポリシー」 Modal が開閉できる (Esc / 背景クリック / × ボタン)
- [ ] ログイン状態での home (MyPage + ChangePassword + Logout 3-up) の手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)