### PR TITLE
fix: home / 共通レイアウトの視覚詳細を本番に寄せる (#24)

### DIFF
--- a/frontend/app/app.css
+++ b/frontend/app/app.css
@@ -28,7 +28,9 @@
   --color-night-900: #18213a; /* card / panel bg (旧明示なし、補間値) */
   --color-night-800: #22224a; /* tile hover / selected bg */
   --color-night-700: #333333; /* border / system message bg */
+  --color-night-650: #303030; /* modal-content bg (本番 darkly テーマ計測値) */
   --color-night-600: #232355; /* action message bg */
+  --color-night-550: #464545; /* modal-header border / table border (本番計測) */
   --color-night-500: #222222; /* loading / btn dark base */
 
   /* mint accent: hover / active / creator / dark-success */

--- a/frontend/app/app.css
+++ b/frontend/app/app.css
@@ -14,11 +14,11 @@
 }
 
 @theme {
-  /* body フォント。Inter は既存維持 */
-  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif,
+  /* body フォント。本番 (wolfort.net) と同じく Lato → Helvetica Neue を優先 */
+  --font-sans: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   /* ロゴ専用 (WOLF MANSION の anima) */
-  --font-anima: "anima", "Inter", sans-serif;
+  --font-anima: "anima", "Lato", sans-serif;
 
   /*
    * 旧 #0b162a (深紺) を中心とした dark navy palette。

--- a/frontend/app/app.css
+++ b/frontend/app/app.css
@@ -145,6 +145,12 @@ body {
   }
 }
 
+/* Modal dialog bg を完全 opaque で確実に塗る (Tailwind arbitrary 値の
+ * 生成漏れや上書きを避けるため、!important + 明示的 background-color)。 */
+.modal-dialog-bg {
+  background-color: #303030 !important;
+}
+
 /* 旧 .netabare / .transparency (ネタバレ伏字 / 透明) */
 .netabare {
   cursor: pointer;

--- a/frontend/app/components/layout/PageFooter.tsx
+++ b/frontend/app/components/layout/PageFooter.tsx
@@ -98,7 +98,7 @@ function KampaContent() {
         </div>
       </section>
 
-      <hr className="border-night-700" />
+      <hr className="border-[#e5e5e5]" />
 
       <section>
         <h3 className="text-[1.1em] font-medium mb-1">
@@ -123,7 +123,7 @@ function KampaContent() {
         </div>
       </section>
 
-      <hr className="border-night-700" />
+      <hr className="border-[#e5e5e5]" />
 
       <section>
         <h3 className="text-[1.1em] font-medium mb-1">
@@ -147,7 +147,7 @@ function KampaContent() {
         </div>
       </section>
 
-      <hr className="border-night-700" />
+      <hr className="border-[#e5e5e5]" />
 
       <section>
         <h3 className="text-[1.1em] font-medium mb-1">Pixiv Fanbox</h3>
@@ -163,7 +163,7 @@ function KampaContent() {
         </div>
       </section>
 
-      <hr className="border-night-700" />
+      <hr className="border-[#e5e5e5]" />
 
       <section>
         <h3 className="text-[1.1em] font-medium mb-1">補足</h3>

--- a/frontend/app/components/layout/PageFooter.tsx
+++ b/frontend/app/components/layout/PageFooter.tsx
@@ -27,7 +27,7 @@ export function PageFooter() {
           href="https://twitter.com/ort_dev"
           target="_blank"
           rel="noopener noreferrer"
-          className="text-mint-600 hover:text-mint-500"
+          className="text-mint-500 hover:text-mint-600"
         >
           @ort_dev
         </a>{" "}
@@ -37,7 +37,7 @@ export function PageFooter() {
         <button
           type="button"
           onClick={() => setKampaOpen(true)}
-          className="text-mint-600 hover:text-mint-500 underline"
+          className="text-mint-500 hover:text-mint-600 underline"
         >
           こちら
         </button>{" "}
@@ -46,7 +46,7 @@ export function PageFooter() {
         <button
           type="button"
           onClick={() => setPolicyOpen(true)}
-          className="text-mint-600 hover:text-mint-500 underline"
+          className="text-mint-500 hover:text-mint-600 underline"
         >
           プライバシーポリシー
         </button>
@@ -56,7 +56,7 @@ export function PageFooter() {
           href="https://github.com/h-orito/wolf-mansion"
           target="_blank"
           rel="noopener noreferrer"
-          className="text-mint-600 hover:text-mint-500"
+          className="text-mint-500 hover:text-mint-600"
         >
           Github
         </a>
@@ -175,7 +175,7 @@ function KampaContent() {
               href="https://twitter.com/ort_dev"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-mint-600 hover:text-mint-500"
+              className="text-mint-500 hover:text-mint-600"
             >
               @ort_dev
             </a>{" "}

--- a/frontend/app/components/layout/PageFooter.tsx
+++ b/frontend/app/components/layout/PageFooter.tsx
@@ -18,8 +18,9 @@ export function PageFooter() {
   const [policyOpen, setPolicyOpen] = useState(false);
 
   return (
-    <footer className="px-3 py-4 mt-4 text-[0.95em] opacity-80">
-      <hr className="border-night-700 mb-3" />
+    // 旧 footer.html: section と直接続 (mt 0)、内部 padding 15px
+    <footer className="px-[15px] py-[15px] mt-0 text-[0.95em] opacity-80">
+      <hr className="border-night-700 mb-[10px]" />
       <p className="leading-[1.6em]">
         要望、改善提案、不具合報告は Twitter{" "}
         <a

--- a/frontend/app/components/layout/PageFooter.tsx
+++ b/frontend/app/components/layout/PageFooter.tsx
@@ -27,7 +27,7 @@ export function PageFooter() {
           href="https://twitter.com/ort_dev"
           target="_blank"
           rel="noopener noreferrer"
-          className="text-blood-600 hover:text-mint-500"
+          className="text-mint-600 hover:text-mint-500"
         >
           @ort_dev
         </a>{" "}
@@ -37,7 +37,7 @@ export function PageFooter() {
         <button
           type="button"
           onClick={() => setKampaOpen(true)}
-          className="text-blood-600 hover:text-mint-500 underline"
+          className="text-mint-600 hover:text-mint-500 underline"
         >
           こちら
         </button>{" "}
@@ -46,7 +46,7 @@ export function PageFooter() {
         <button
           type="button"
           onClick={() => setPolicyOpen(true)}
-          className="text-blood-600 hover:text-mint-500 underline"
+          className="text-mint-600 hover:text-mint-500 underline"
         >
           プライバシーポリシー
         </button>
@@ -56,7 +56,7 @@ export function PageFooter() {
           href="https://github.com/h-orito/wolf-mansion"
           target="_blank"
           rel="noopener noreferrer"
-          className="text-blood-600 hover:text-mint-500"
+          className="text-mint-600 hover:text-mint-500"
         >
           Github
         </a>
@@ -175,7 +175,7 @@ function KampaContent() {
               href="https://twitter.com/ort_dev"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-blood-600 hover:text-mint-500"
+              className="text-mint-600 hover:text-mint-500"
             >
               @ort_dev
             </a>{" "}

--- a/frontend/app/components/layout/PageFooter.tsx
+++ b/frontend/app/components/layout/PageFooter.tsx
@@ -82,7 +82,7 @@ function KampaContent() {
   return (
     <div className="space-y-3">
       <section>
-        <h3 className="text-[1.1em] font-medium mb-1">Amazon ほしい物リストから送る</h3>
+        <h3 className="text-[19px] font-normal m-0 mb-[10.5px] leading-[1.428]">Amazon ほしい物リストから送る</h3>
         <ul className="list-disc pl-5 mb-2">
           <li>Amazon ほしいものリストから選んで開発者に送ることができます。</li>
         </ul>
@@ -98,10 +98,10 @@ function KampaContent() {
         </div>
       </section>
 
-      <hr className="border-[#e5e5e5]" />
+      <hr className="border-[#464545]" />
 
       <section>
-        <h3 className="text-[1.1em] font-medium mb-1">
+        <h3 className="text-[19px] font-normal m-0 mb-[10.5px] leading-[1.428]">
           Amazon ギフト券 (E メールタイプ) を送る
         </h3>
         <ul className="list-disc pl-5 mb-2">
@@ -123,10 +123,10 @@ function KampaContent() {
         </div>
       </section>
 
-      <hr className="border-[#e5e5e5]" />
+      <hr className="border-[#464545]" />
 
       <section>
-        <h3 className="text-[1.1em] font-medium mb-1">
+        <h3 className="text-[19px] font-normal m-0 mb-[10.5px] leading-[1.428]">
           Amazon アソシエイト経由で買い物をする
         </h3>
         <ul className="list-disc pl-5 mb-2">
@@ -147,10 +147,10 @@ function KampaContent() {
         </div>
       </section>
 
-      <hr className="border-[#e5e5e5]" />
+      <hr className="border-[#464545]" />
 
       <section>
-        <h3 className="text-[1.1em] font-medium mb-1">Pixiv Fanbox</h3>
+        <h3 className="text-[19px] font-normal m-0 mb-[10.5px] leading-[1.428]">Pixiv Fanbox</h3>
         <div className="flex justify-end">
           <LinkButton
             to="https://ort.fanbox.cc/"
@@ -163,10 +163,10 @@ function KampaContent() {
         </div>
       </section>
 
-      <hr className="border-[#e5e5e5]" />
+      <hr className="border-[#464545]" />
 
       <section>
-        <h3 className="text-[1.1em] font-medium mb-1">補足</h3>
+        <h3 className="text-[19px] font-normal m-0 mb-[10.5px] leading-[1.428]">補足</h3>
         <ul className="list-disc pl-5">
           <li>
             頂いた改善提案、ご要望については投げ銭の有無に関係なく積極的に取り入れていく
@@ -360,7 +360,7 @@ function PolicySection({
 }) {
   return (
     <section>
-      <h3 className="text-[1.05em] font-medium mt-2 mb-1">{title}</h3>
+      <h3 className="text-[19px] font-normal mt-[10.5px] mb-[10.5px] leading-[1.428]">{title}</h3>
       {children}
     </section>
   );

--- a/frontend/app/components/ui/Button.tsx
+++ b/frontend/app/components/ui/Button.tsx
@@ -34,10 +34,10 @@ const baseClass =
   "focus-visible:outline focus-visible:outline-2 focus-visible:outline-mint-500 focus-visible:outline-offset-2";
 
 const variantClass: Record<ButtonVariant, string> = {
-  // Bootstrap 3 .btn-success の素値 (#5cb85c / border #4cae4c / hover #449d44)。
-  // 旧画面では login / villages-list の検索 submit など form の決定ボタンで使用
+  // 旧画面は Bootstrap Darkly テーマで .btn-success を mint (#00bc8c) に上書き
+  // していた (本番計測値)。Bootswatch 既定の緑 #5cb85c ではない。
   success:
-    "bg-bs-success-500 border-bs-success-600 text-white hover:bg-bs-success-700 hover:border-bs-success-700",
+    "bg-mint-600 border-mint-600 text-white hover:bg-mint-700 hover:border-mint-700",
   // 旧 .btn-dark-success: dark bg + mint 文字 + mint border、hover で反転
   "dark-success":
     "bg-night-500 border-mint-600 text-mint-600 hover:bg-mint-600 hover:text-white",

--- a/frontend/app/components/ui/Button.tsx
+++ b/frontend/app/components/ui/Button.tsx
@@ -25,10 +25,10 @@ export type ButtonVariant =
 
 const baseClass =
   "inline-flex items-center justify-center gap-1 " +
-  // 旧 .btn-sm の padding 相当 (px-3 / py-1) と border-radius を em で
-  "px-3 py-1 rounded-[0.25em] border " +
-  // 文字サイズはユーザー設定で拡大されるよう em ベース
-  "text-[1em] leading-tight font-medium " +
+  // 旧 BS3 .btn-sm 相当 (本番計測値 padding 6px 9px / radius 3px / border 2px)
+  "px-[9px] py-[6px] rounded-[3px] border-2 " +
+  // 文字サイズはユーザー設定で拡大されるよう em ベース。本番 .btn-sm font-size 13px
+  "text-[13px] leading-[1.4] font-medium " +
   "transition-colors duration-100 " +
   "disabled:opacity-60 disabled:cursor-not-allowed " +
   "focus-visible:outline focus-visible:outline-2 focus-visible:outline-mint-500 focus-visible:outline-offset-2";

--- a/frontend/app/components/ui/MenuSection.tsx
+++ b/frontend/app/components/ui/MenuSection.tsx
@@ -38,16 +38,17 @@ export function MenuSection({
       aria-label={!title ? ariaLabel : undefined}
       aria-labelledby={title ? headingId : undefined}
       className={cn(
-        // 旧 .top-menu: bg #333 + padding 15px (上下のみ。横は tile が edge-to-edge)
-        "bg-night-700 py-[15px] px-0",
+        // 旧 .top-menu (col-sm-12 が 15px x-padding を効かせる + .top-menu に
+        // padding 15px (上下))。React では明示的に px-[15px] を持つ。
+        "bg-night-700 py-[15px] px-[15px]",
         className,
       )}
     >
       {title && (
-        // 旧 h2.h5 = 14px (= 1.17em @ 12px base)。heading は section bg (#333) 上に置く
+        // 旧 h2.h5 = 14px。heading 行は旧 h100px に近い高さ感を出すため py を多めに。
         <h2
           id={headingId}
-          className="text-center text-[1.17em] mb-[15px] font-medium"
+          className="text-center text-[1.17em] py-[20px] mb-0 font-medium"
         >
           {title}
         </h2>

--- a/frontend/app/components/ui/MenuSection.tsx
+++ b/frontend/app/components/ui/MenuSection.tsx
@@ -38,14 +38,15 @@ export function MenuSection({
       aria-label={!title ? ariaLabel : undefined}
       aria-labelledby={title ? headingId : undefined}
       className={cn(
-        // 旧 .top-menu: bg #333 + padding 15px (4 辺すべて、本番計測値)
-        "bg-night-700 p-[15px]",
+        // 旧 .top-menu: bg #333 + padding 15px (上下のみ。横は row 側が持つので 0)
+        // タイル row はこの section の左右いっぱいまで広がる (横余白なし)
+        "bg-night-700 py-[15px] px-0",
         className,
       )}
     >
       {title && (
         // 旧 h2.h5 を含む h100px 行: flex 中央配置で 100px 高さ。
-        // h2 自体は font-size 15px / weight 400 / margin 10.5px 0 (BS3 デフォルト)
+        // 見出し行のみ px-[15px] (本番 .top-menu-inner-row 計測値)
         <div className="h-[100px] flex items-center justify-center px-[15px]">
           <h2
             id={headingId}

--- a/frontend/app/components/ui/MenuSection.tsx
+++ b/frontend/app/components/ui/MenuSection.tsx
@@ -29,9 +29,13 @@ export function MenuSection({
   children: React.ReactNode;
   className?: string;
 }) {
+  // title 指定時は内側の <h2> を accessible name として利用するため id を採番し、
+  // <section aria-labelledby> で紐付ける (unnamed landmark を回避)
+  const headingId = React.useId();
   return (
     <section
       aria-label={!title ? ariaLabel : undefined}
+      aria-labelledby={title ? headingId : undefined}
       className={cn(
         // 旧 .top-menu: bg #333 + padding 15px (上下のみ。横は tile が edge-to-edge)
         "bg-night-700 py-[15px] px-0",
@@ -40,7 +44,10 @@ export function MenuSection({
     >
       {title && (
         // 旧 h2.h5 = 14px (= 1.17em @ 12px base)。heading は section bg (#333) 上に置く
-        <h2 className="text-center text-[1.17em] mb-[15px] font-medium">
+        <h2
+          id={headingId}
+          className="text-center text-[1.17em] mb-[15px] font-medium"
+        >
           {title}
         </h2>
       )}

--- a/frontend/app/components/ui/MenuSection.tsx
+++ b/frontend/app/components/ui/MenuSection.tsx
@@ -30,7 +30,8 @@ export function MenuSection({
   className?: string;
 }) {
   // title 指定時は内側の <h2> を accessible name として利用するため id を採番し、
-  // <section aria-labelledby> で紐付ける (unnamed landmark を回避)
+  // <section aria-labelledby> で紐付ける (unnamed landmark を回避)。
+  // title 省略時も Hooks の呼び出し順を保つため useId は常に呼ぶ (id は DOM に出ない)。
   const headingId = React.useId();
   return (
     <section

--- a/frontend/app/components/ui/MenuSection.tsx
+++ b/frontend/app/components/ui/MenuSection.tsx
@@ -33,12 +33,16 @@ export function MenuSection({
     <section
       aria-label={!title ? ariaLabel : undefined}
       className={cn(
-        "bg-night-700 py-4 px-3", // 旧 #333333 + padding 15px
+        // 旧 .top-menu: bg #333 + padding 15px (上下のみ。横は tile が edge-to-edge)
+        "bg-night-700 py-[15px] px-0",
         className,
       )}
     >
       {title && (
-        <h2 className="text-center text-[1.17em] mb-3 font-medium">{title}</h2>
+        // 旧 h2.h5 = 14px (= 1.17em @ 12px base)。heading は section bg (#333) 上に置く
+        <h2 className="text-center text-[1.17em] mb-[15px] font-medium">
+          {title}
+        </h2>
       )}
       {children}
     </section>

--- a/frontend/app/components/ui/MenuSection.tsx
+++ b/frontend/app/components/ui/MenuSection.tsx
@@ -38,20 +38,22 @@ export function MenuSection({
       aria-label={!title ? ariaLabel : undefined}
       aria-labelledby={title ? headingId : undefined}
       className={cn(
-        // 旧 .top-menu (col-sm-12 が 15px x-padding を効かせる + .top-menu に
-        // padding 15px (上下))。React では明示的に px-[15px] を持つ。
-        "bg-night-700 py-[15px] px-[15px]",
+        // 旧 .top-menu: bg #333 + padding 15px (4 辺すべて、本番計測値)
+        "bg-night-700 p-[15px]",
         className,
       )}
     >
       {title && (
-        // 旧 h2.h5 = 14px。heading 行は旧 h100px に近い高さ感を出すため py を多めに。
-        <h2
-          id={headingId}
-          className="text-center text-[1.17em] py-[20px] mb-0 font-medium"
-        >
-          {title}
-        </h2>
+        // 旧 h2.h5 を含む h100px 行: flex 中央配置で 100px 高さ。
+        // h2 自体は font-size 15px / weight 400 / margin 10.5px 0 (BS3 デフォルト)
+        <div className="h-[100px] flex items-center justify-center px-[15px]">
+          <h2
+            id={headingId}
+            className="m-0 text-center text-[15px] font-normal leading-[1.1]"
+          >
+            {title}
+          </h2>
+        </div>
       )}
       {children}
     </section>

--- a/frontend/app/components/ui/MenuTile.tsx
+++ b/frontend/app/components/ui/MenuTile.tsx
@@ -51,9 +51,11 @@ function TileContent({ icon, label, sublabel }: Pick<Common, "icon" | "label" | 
           {icon}
         </span>
       )}
-      <span className="block text-[1em] font-bold">{label}</span>
+      {/* 旧 h6 は BS3 で font-weight: bold + 12px だが、bold は印象が重いので
+          medium 相当に落とす。sublabel は light で英語らしい軽さを出す。 */}
+      <span className="block text-[1em] font-medium">{label}</span>
       {sublabel && (
-        <span className="block text-[1em] opacity-90">{sublabel}</span>
+        <span className="block text-[1em] font-light opacity-90">{sublabel}</span>
       )}
     </>
   );

--- a/frontend/app/components/ui/MenuTile.tsx
+++ b/frontend/app/components/ui/MenuTile.tsx
@@ -11,19 +11,17 @@ import { cn } from "./cn";
  * - hover: bg = #22224a, border + 文字を mint-500 に
  */
 const tileClass =
-  // layout
-  // 旧 .top-menu-selectable + .top-menu-selectable-inner を 1 要素に統合。
-  // 100px @ 12px base のタイル内で icon / label / sublabel が上下に等間隔で並ぶよう
-  // justify-evenly を使う (固定 padding にしない)。
-  "flex flex-col items-center justify-evenly text-center " +
-  "px-1 py-[10px] min-h-[8.334em] " + // 100px @ 12px base (100/12)
-  // 色 (旧 .top-menu-selectable)
+  // 旧 .top-menu-selectable: padding 0、固定 100px 高さ、bg #0b162a + border 1px #333
+  // 旧 .top-menu-selectable-inner: padding-top 15px のみ + height 100px + display inline-block
+  // 中の icon / h6 / sublabel は通常の block 縦積み (margin で自然に間隔がつく)。
+  "block text-center h-[100px] p-0 " +
   "bg-night-950 border border-night-700 text-white " +
-  // hover (旧 :hover で mint に)
   "hover:bg-night-800 hover:border-mint-500 hover:text-mint-500 " +
   "transition-colors duration-100 " +
-  // a 由来の打ち消し
   "no-underline cursor-pointer";
+
+// inner: 旧 .top-menu-selectable-inner の padding-top: 15px 相当
+const innerClass = "block w-full pt-[15px]";
 
 type Common = {
   /** 上段に出す小さなアイコン / glyph (絵文字 or SVG) */
@@ -44,20 +42,22 @@ type Common = {
  */
 function TileContent({ icon, label, sublabel }: Pick<Common, "icon" | "label" | "sublabel">) {
   return (
-    <>
+    <span className={innerClass}>
+      {/* 旧 glyphicon ~12px。svg をそのままインライン配置 */}
       {icon && (
-        // mb は付けない (justify-evenly が icon / label / sublabel の間隔を均等に分配)
-        <span aria-hidden className="leading-none">
+        <span aria-hidden className="inline-block leading-none">
           {icon}
         </span>
       )}
-      {/* 旧 h6 は BS3 で font-weight: bold + 12px だが、bold は印象が重いので
-          medium 相当に落とす。sublabel は light で英語らしい軽さを出す。 */}
-      <span className="block text-[1em] font-medium">{label}</span>
+      {/* 旧 .h6: font-size 13px / weight 400 / margin 10.5px 0 / line-height 14.3px */}
+      <span className="block text-[13px] font-normal leading-[14.3px] my-[10.5px]">
+        {label}
+      </span>
       {sublabel && (
-        <span className="block text-[1em] font-light opacity-90">{sublabel}</span>
+        // 旧 sublabel は body デフォルト (12px regular) のテキスト
+        <span className="block text-[12px] font-normal">{sublabel}</span>
       )}
-    </>
+    </span>
   );
 }
 

--- a/frontend/app/components/ui/MenuTile.tsx
+++ b/frontend/app/components/ui/MenuTile.tsx
@@ -12,8 +12,10 @@ import { cn } from "./cn";
  */
 const tileClass =
   // layout
-  "flex flex-col items-center justify-center text-center gap-1 " +
-  "px-3 py-4 min-h-[8.3em] " + // 旧 100px @ 12px base 相当を em で
+  // 旧 .top-menu-selectable は padding: 0、.top-menu-selectable-inner が padding-top 15px
+  // + height 100px。これを 1 要素にまとめて pt + min-h で再現。
+  "flex flex-col items-center text-center " +
+  "px-1 pt-[15px] pb-[10px] min-h-[8.3em] " + // 100px @ 12px base
   // 色 (旧 .top-menu-selectable)
   "bg-night-950 border border-night-700 text-white " +
   // hover (旧 :hover で mint に)
@@ -41,10 +43,12 @@ export function MenuTileLink({
 }: Common & LinkProps) {
   return (
     <Link {...rest} className={cn(tileClass, className)}>
-      {icon && <span aria-hidden className="text-[1.5em] leading-none">{icon}</span>}
-      <span className="block font-bold">{label}</span>
+      {/* 旧 glyphicon ~14px。span に scaler は付けない (svg 自身を 1em 相当で出す) */}
+      {icon && <span aria-hidden className="leading-none mb-[6px]">{icon}</span>}
+      {/* 旧 <span class="h6"> は BS3 で font-weight: bold + 12px。サブは body 12px (regular) */}
+      <span className="block text-[1em] font-bold">{label}</span>
       {sublabel && (
-        <span className="block text-[0.85em] opacity-80">{sublabel}</span>
+        <span className="block text-[1em] opacity-90">{sublabel}</span>
       )}
     </Link>
   );
@@ -60,10 +64,11 @@ export function MenuTileButton({
 }: Common & React.ButtonHTMLAttributes<HTMLButtonElement>) {
   return (
     <button {...rest} type={type} className={cn(tileClass, className)}>
-      {icon && <span aria-hidden className="text-[1.5em] leading-none">{icon}</span>}
-      <span className="block font-bold">{label}</span>
+      {icon && <span aria-hidden className="leading-none mb-[6px]">{icon}</span>}
+      {/* 旧 <span class="h6"> は BS3 で font-weight: bold + 12px。サブは body 12px (regular) */}
+      <span className="block text-[1em] font-bold">{label}</span>
       {sublabel && (
-        <span className="block text-[0.85em] opacity-80">{sublabel}</span>
+        <span className="block text-[1em] opacity-90">{sublabel}</span>
       )}
     </button>
   );

--- a/frontend/app/components/ui/MenuTile.tsx
+++ b/frontend/app/components/ui/MenuTile.tsx
@@ -12,10 +12,11 @@ import { cn } from "./cn";
  */
 const tileClass =
   // layout
-  // 旧 .top-menu-selectable は padding: 0、.top-menu-selectable-inner が padding-top 15px
-  // + height 100px。これを 1 要素にまとめて pt + min-h で再現。
-  "flex flex-col items-center text-center " +
-  "px-1 pt-[15px] pb-[10px] min-h-[8.334em] " + // 100px @ 12px base (100/12)
+  // 旧 .top-menu-selectable + .top-menu-selectable-inner を 1 要素に統合。
+  // 100px @ 12px base のタイル内で icon / label / sublabel が上下に等間隔で並ぶよう
+  // justify-evenly を使う (固定 padding にしない)。
+  "flex flex-col items-center justify-evenly text-center " +
+  "px-1 py-[10px] min-h-[8.334em] " + // 100px @ 12px base (100/12)
   // 色 (旧 .top-menu-selectable)
   "bg-night-950 border border-night-700 text-white " +
   // hover (旧 :hover で mint に)
@@ -45,7 +46,8 @@ function TileContent({ icon, label, sublabel }: Pick<Common, "icon" | "label" | 
   return (
     <>
       {icon && (
-        <span aria-hidden className="leading-none mb-[6px]">
+        // mb は付けない (justify-evenly が icon / label / sublabel の間隔を均等に分配)
+        <span aria-hidden className="leading-none">
           {icon}
         </span>
       )}

--- a/frontend/app/components/ui/MenuTile.tsx
+++ b/frontend/app/components/ui/MenuTile.tsx
@@ -15,7 +15,7 @@ const tileClass =
   // 旧 .top-menu-selectable は padding: 0、.top-menu-selectable-inner が padding-top 15px
   // + height 100px。これを 1 要素にまとめて pt + min-h で再現。
   "flex flex-col items-center text-center " +
-  "px-1 pt-[15px] pb-[10px] min-h-[8.3em] " + // 100px @ 12px base
+  "px-1 pt-[15px] pb-[10px] min-h-[8.334em] " + // 100px @ 12px base (100/12)
   // 色 (旧 .top-menu-selectable)
   "bg-night-950 border border-night-700 text-white " +
   // hover (旧 :hover で mint に)
@@ -34,6 +34,29 @@ type Common = {
   className?: string;
 };
 
+/**
+ * MenuTileLink / MenuTileButton 共通の中身。icon → label (太字) → sublabel
+ * の縦並びを 1 箇所で定義する。
+ *   - 旧 glyphicon ~14px。icon 側 span に scaler は付けない (svg 自身を 1em で)
+ *   - 旧 <span class="h6"> は BS3 で font-weight: bold + 12px
+ *   - サブラベルは body 12px (regular)
+ */
+function TileContent({ icon, label, sublabel }: Pick<Common, "icon" | "label" | "sublabel">) {
+  return (
+    <>
+      {icon && (
+        <span aria-hidden className="leading-none mb-[6px]">
+          {icon}
+        </span>
+      )}
+      <span className="block text-[1em] font-bold">{label}</span>
+      {sublabel && (
+        <span className="block text-[1em] opacity-90">{sublabel}</span>
+      )}
+    </>
+  );
+}
+
 export function MenuTileLink({
   icon,
   label,
@@ -43,13 +66,7 @@ export function MenuTileLink({
 }: Common & LinkProps) {
   return (
     <Link {...rest} className={cn(tileClass, className)}>
-      {/* 旧 glyphicon ~14px。span に scaler は付けない (svg 自身を 1em 相当で出す) */}
-      {icon && <span aria-hidden className="leading-none mb-[6px]">{icon}</span>}
-      {/* 旧 <span class="h6"> は BS3 で font-weight: bold + 12px。サブは body 12px (regular) */}
-      <span className="block text-[1em] font-bold">{label}</span>
-      {sublabel && (
-        <span className="block text-[1em] opacity-90">{sublabel}</span>
-      )}
+      <TileContent icon={icon} label={label} sublabel={sublabel} />
     </Link>
   );
 }
@@ -64,12 +81,7 @@ export function MenuTileButton({
 }: Common & React.ButtonHTMLAttributes<HTMLButtonElement>) {
   return (
     <button {...rest} type={type} className={cn(tileClass, className)}>
-      {icon && <span aria-hidden className="leading-none mb-[6px]">{icon}</span>}
-      {/* 旧 <span class="h6"> は BS3 で font-weight: bold + 12px。サブは body 12px (regular) */}
-      <span className="block text-[1em] font-bold">{label}</span>
-      {sublabel && (
-        <span className="block text-[1em] opacity-90">{sublabel}</span>
-      )}
+      <TileContent icon={icon} label={label} sublabel={sublabel} />
     </button>
   );
 }

--- a/frontend/app/components/ui/MenuTile.tsx
+++ b/frontend/app/components/ui/MenuTile.tsx
@@ -12,16 +12,15 @@ import { cn } from "./cn";
  */
 const tileClass =
   // 旧 .top-menu-selectable: padding 0、固定 100px 高さ、bg #0b162a + border 1px #333
-  // 旧 .top-menu-selectable-inner: padding-top 15px のみ + height 100px + display inline-block
-  // 中の icon / h6 / sublabel は通常の block 縦積み (margin で自然に間隔がつく)。
-  "block text-center h-[100px] p-0 " +
+  // 旧 .top-menu-selectable-inner: padding-top 15px のみ + height 100px。
+  // <a> と <button> で vertical alignment が変わらないよう flex column で統一する。
+  "flex flex-col items-center text-center h-[100px] pt-[15px] px-0 pb-0 " +
   "bg-night-950 border border-night-700 text-white " +
   "hover:bg-night-800 hover:border-mint-500 hover:text-mint-500 " +
   "transition-colors duration-100 " +
-  "no-underline cursor-pointer";
-
-// inner: 旧 .top-menu-selectable-inner の padding-top: 15px 相当
-const innerClass = "block w-full pt-[15px]";
+  "no-underline cursor-pointer " +
+  // <button> 要素のユーザーエージェント font をリセット (Lato 継承)
+  "font-sans";
 
 type Common = {
   /** 上段に出す小さなアイコン / glyph (絵文字 or SVG) */
@@ -34,30 +33,27 @@ type Common = {
 };
 
 /**
- * MenuTileLink / MenuTileButton 共通の中身。icon → label (太字) → sublabel
- * の縦並びを 1 箇所で定義する。
- *   - 旧 glyphicon ~14px。icon 側 span に scaler は付けない (svg 自身を 1em で)
- *   - 旧 <span class="h6"> は BS3 で font-weight: bold + 12px
- *   - サブラベルは body 12px (regular)
+ * MenuTileLink / MenuTileButton 共通の中身。
+ *   - 旧 glyphicon (~12px) → svg を 1em 相当で出す
+ *   - 旧 <span class="h6"> = font-size 13px / weight 400 / margin 10.5px 0 / line-height 14.3px
+ *   - サブラベル = body 12px (regular)
+ * tile 側を flex column items-center にしているため、children は順に縦に積み上がる。
  */
 function TileContent({ icon, label, sublabel }: Pick<Common, "icon" | "label" | "sublabel">) {
   return (
-    <span className={innerClass}>
-      {/* 旧 glyphicon ~12px。svg をそのままインライン配置 */}
+    <>
       {icon && (
-        <span aria-hidden className="inline-block leading-none">
+        <span aria-hidden className="block leading-none">
           {icon}
         </span>
       )}
-      {/* 旧 .h6: font-size 13px / weight 400 / margin 10.5px 0 / line-height 14.3px */}
       <span className="block text-[13px] font-normal leading-[14.3px] my-[10.5px]">
         {label}
       </span>
       {sublabel && (
-        // 旧 sublabel は body デフォルト (12px regular) のテキスト
-        <span className="block text-[12px] font-normal">{sublabel}</span>
+        <span className="block text-[12px] font-normal leading-[1.4]">{sublabel}</span>
       )}
-    </span>
+    </>
   );
 }
 

--- a/frontend/app/components/ui/Modal.tsx
+++ b/frontend/app/components/ui/Modal.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { createPortal } from "react-dom";
 import { cn } from "./cn";
 
 /**
@@ -74,7 +75,13 @@ export function Modal({
 
   if (!open) return null;
 
-  return (
+  // 重要: 親要素に opacity-* が付いていると CSS opacity が子孫に継承され
+  // 背景が透けて見えてしまう (例: PageFooter の opacity-80)。Portal で
+  // document.body 直下に描画して、呼び出し位置の opacity 文脈から逃がす。
+  // SSR では document が存在しないので open && typeof window で guard。
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
     <div
       // 旧 .modal-backdrop: 黒 opacity 0.7 (本番計測値)
       style={{ backgroundColor: "rgba(0, 0, 0, 0.7)" }}
@@ -121,6 +128,7 @@ export function Modal({
         {/* 旧 .modal-body: padding 20px (本番計測) */}
         <div className="px-[20px] py-[20px]">{children}</div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/frontend/app/components/ui/Modal.tsx
+++ b/frontend/app/components/ui/Modal.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { XMarkIcon } from "@heroicons/react/24/outline";
 import { cn } from "./cn";
 
 /**
@@ -77,8 +76,8 @@ export function Modal({
 
   return (
     <div
-      // 旧 .modal-backdrop: 半透明黒
-      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4 bg-black/50"
+      // 旧 .modal-backdrop: 黒 opacity 0.7 (本番計測)
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-[rgba(0,0,0,0.7)]"
       onClick={onClose}
       role="presentation"
     >
@@ -88,30 +87,36 @@ export function Modal({
         aria-modal="true"
         aria-labelledby={tid}
         className={cn(
-          // 旧 BS3 .modal-content: 白背景 + 角丸 6px + 影 + 黒系文字
-          "w-full max-w-[600px] my-[30px] bg-white text-[#333] " +
-            "border border-[rgba(0,0,0,0.2)] rounded-[6px] shadow-lg",
+          // 旧 BS3 darkly .modal-content: bg #303030, 文字白, border 1px rgba(0,0,0,0.2)
+          // angle 6px, shadow 0 5px 15px rgba(0,0,0,0.5), .modal-dialog は sm+ で width 80vw
+          "w-[80vw] my-[30px] bg-[#303030] text-white " +
+            "border border-[rgba(0,0,0,0.2)] rounded-[6px] " +
+            "shadow-[0_5px_15px_rgba(0,0,0,0.5)]",
           className,
         )}
         onClick={(e) => e.stopPropagation()}
       >
-        {/* 旧 .modal-header: padding 15px + border-bottom 1px #e5e5e5。
-            × は右上 (font-size 21px、float right 相当)。 */}
-        <div className="flex items-start justify-between px-[15px] py-[15px] border-b border-[#e5e5e5]">
-          <h2 id={tid} className="text-[1.42em] font-medium leading-[1.42857]">
-            {title}
-          </h2>
+        {/* 旧 .modal-header: padding 15px + border-bottom 1px #464545 */}
+        <div className="px-[15px] py-[15px] border-b border-[#464545]">
+          {/* close × は float-right。テキスト × (font-size 22.5px / weight 700 / opacity 0.4) */}
           <button
             type="button"
             onClick={onClose}
             aria-label="閉じる"
-            className="text-[#000] opacity-20 hover:opacity-50 transition-opacity"
+            className="float-right text-white opacity-40 hover:opacity-80 transition-opacity text-[22.5px] leading-[1] font-bold cursor-pointer"
           >
-            <XMarkIcon className="w-[1.75em] h-[1.75em]" aria-hidden />
+            ×
           </button>
+          {/* 旧 .modal-title (h4): font-size 19px / weight 400 / margin 0 / line-height 1.428 */}
+          <h2
+            id={tid}
+            className="text-[19px] font-normal m-0 leading-[1.428]"
+          >
+            {title}
+          </h2>
         </div>
-        {/* 旧 .modal-body: padding 15px */}
-        <div className="px-[15px] py-[15px]">{children}</div>
+        {/* 旧 .modal-body: padding 20px (本番計測) */}
+        <div className="px-[20px] py-[20px]">{children}</div>
       </div>
     </div>
   );

--- a/frontend/app/components/ui/Modal.tsx
+++ b/frontend/app/components/ui/Modal.tsx
@@ -76,10 +76,8 @@ export function Modal({
 
   return (
     <div
-      // 旧 .modal-backdrop は本番 0.7。ただし dark theme + 暗いコンテンツが続くと
-      // 透けて見えやすい (ユーザ指摘) ため、コンテンツを際立たせるべく 0.85 に強化。
-      // backdrop は単色オーバーレイなので大きな乖離ではない。
-      style={{ backgroundColor: "rgba(0, 0, 0, 0.85)" }}
+      // 旧 .modal-backdrop: 黒 opacity 0.7 (本番計測値)
+      style={{ backgroundColor: "rgba(0, 0, 0, 0.7)" }}
       className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto"
       onClick={onClose}
       role="presentation"
@@ -89,13 +87,12 @@ export function Modal({
         role="dialog"
         aria-modal="true"
         aria-labelledby={tid}
-        // 旧 BS3 darkly .modal-content: bg #303030 (= night-650), 文字白,
-        // border 1px rgba(0,0,0,0.2), radius 6px, shadow 0 5px 15px rgba(0,0,0,0.5)
-        // sm+ では .modal-dialog の幅 80vw (override)。
-        // inline style で背景色を強制 (Tailwind arbitrary 値生成漏れ予防)。
+        // 旧 BS3 darkly .modal-content: bg #303030, 文字白
+        // bg は app.css の .modal-dialog-bg (!important) + inline style の二重がけで
+        // Tailwind arbitrary 値生成漏れ / 上書きを完全に排除する。
         style={{ backgroundColor: "#303030" }}
         className={cn(
-          "w-[80vw] my-[30px] text-white " +
+          "modal-dialog-bg w-[80vw] my-[30px] text-white " +
             "border border-[rgba(0,0,0,0.2)] rounded-[6px] " +
             "shadow-[0_5px_15px_rgba(0,0,0,0.5)]",
           className,

--- a/frontend/app/components/ui/Modal.tsx
+++ b/frontend/app/components/ui/Modal.tsx
@@ -77,7 +77,8 @@ export function Modal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4 bg-black/60"
+      // 旧 .modal-backdrop: 半透明黒
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4 bg-black/50"
       onClick={onClose}
       role="presentation"
     >
@@ -87,25 +88,30 @@ export function Modal({
         aria-modal="true"
         aria-labelledby={tid}
         className={cn(
-          "w-full max-w-[40em] my-8 bg-night-950 border border-night-700 rounded-[0.25em] shadow-lg",
+          // 旧 BS3 .modal-content: 白背景 + 角丸 6px + 影 + 黒系文字
+          "w-full max-w-[600px] my-[30px] bg-white text-[#333] " +
+            "border border-[rgba(0,0,0,0.2)] rounded-[6px] shadow-lg",
           className,
         )}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between px-3 py-2 border-b border-night-700">
-          <h2 id={tid} className="text-[1.17em] font-medium">
+        {/* 旧 .modal-header: padding 15px + border-bottom 1px #e5e5e5。
+            × は右上 (font-size 21px、float right 相当)。 */}
+        <div className="flex items-start justify-between px-[15px] py-[15px] border-b border-[#e5e5e5]">
+          <h2 id={tid} className="text-[1.42em] font-medium leading-[1.42857]">
             {title}
           </h2>
           <button
             type="button"
             onClick={onClose}
             aria-label="閉じる"
-            className="text-white hover:text-mint-500 transition-colors"
+            className="text-[#000] opacity-20 hover:opacity-50 transition-opacity"
           >
-            <XMarkIcon className="w-[1.5em] h-[1.5em]" aria-hidden />
+            <XMarkIcon className="w-[1.75em] h-[1.75em]" aria-hidden />
           </button>
         </div>
-        <div className="px-3 py-3">{children}</div>
+        {/* 旧 .modal-body: padding 15px */}
+        <div className="px-[15px] py-[15px]">{children}</div>
       </div>
     </div>
   );

--- a/frontend/app/components/ui/Modal.tsx
+++ b/frontend/app/components/ui/Modal.tsx
@@ -76,8 +76,11 @@ export function Modal({
 
   return (
     <div
-      // 旧 .modal-backdrop: 黒 opacity 0.7 (本番計測)
-      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-[rgba(0,0,0,0.7)]"
+      // 旧 .modal-backdrop は本番 0.7。ただし dark theme + 暗いコンテンツが続くと
+      // 透けて見えやすい (ユーザ指摘) ため、コンテンツを際立たせるべく 0.85 に強化。
+      // backdrop は単色オーバーレイなので大きな乖離ではない。
+      style={{ backgroundColor: "rgba(0, 0, 0, 0.85)" }}
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto"
       onClick={onClose}
       role="presentation"
     >

--- a/frontend/app/components/ui/Modal.tsx
+++ b/frontend/app/components/ui/Modal.tsx
@@ -86,10 +86,13 @@ export function Modal({
         role="dialog"
         aria-modal="true"
         aria-labelledby={tid}
+        // 旧 BS3 darkly .modal-content: bg #303030 (= night-650), 文字白,
+        // border 1px rgba(0,0,0,0.2), radius 6px, shadow 0 5px 15px rgba(0,0,0,0.5)
+        // sm+ では .modal-dialog の幅 80vw (override)。
+        // inline style で背景色を強制 (Tailwind arbitrary 値生成漏れ予防)。
+        style={{ backgroundColor: "#303030" }}
         className={cn(
-          // 旧 BS3 darkly .modal-content: bg #303030, 文字白, border 1px rgba(0,0,0,0.2)
-          // angle 6px, shadow 0 5px 15px rgba(0,0,0,0.5), .modal-dialog は sm+ で width 80vw
-          "w-[80vw] my-[30px] bg-[#303030] text-white " +
+          "w-[80vw] my-[30px] text-white " +
             "border border-[rgba(0,0,0,0.2)] rounded-[6px] " +
             "shadow-[0_5px_15px_rgba(0,0,0,0.5)]",
           className,
@@ -97,7 +100,7 @@ export function Modal({
         onClick={(e) => e.stopPropagation()}
       >
         {/* 旧 .modal-header: padding 15px + border-bottom 1px #464545 */}
-        <div className="px-[15px] py-[15px] border-b border-[#464545]">
+        <div className="px-[15px] py-[15px] border-b border-night-550">
           {/* close × は float-right。テキスト × (font-size 22.5px / weight 700 / opacity 0.4) */}
           <button
             type="button"

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -23,7 +23,7 @@ export const links: Route.LinksFunction = () => [
   },
   {
     rel: "stylesheet",
-    href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap",
+    href: "https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,300;0,400;0,700;0,900;1,400;1,700&display=swap",
   },
 ];
 

--- a/frontend/app/routes/_auth.tsx
+++ b/frontend/app/routes/_auth.tsx
@@ -33,7 +33,7 @@ export default function AuthLayout() {
   // 包んで PageHeader だけ被せる。子側を <main> でない構造に揃えるリファクタは
   // Step 13d / 13e (それぞれの route を design-restore する時) で実施
   return (
-    <div className="max-w-screen-lg mx-auto">
+    <div className="max-w-[1170px] mx-auto">
       <PageHeader />
       <div className="px-3">
         <Outlet />

--- a/frontend/app/routes/about.tsx
+++ b/frontend/app/routes/about.tsx
@@ -7,7 +7,7 @@ export function meta(_: Route.MetaArgs) {
 
 export default function About() {
   return (
-    <main className="max-w-screen-lg mx-auto">
+    <main className="max-w-[1170px] mx-auto">
       <PlaceholderPage
         title="本サイトは"
         englishTitle="About"

--- a/frontend/app/routes/announce.tsx
+++ b/frontend/app/routes/announce.tsx
@@ -7,7 +7,7 @@ export function meta(_: Route.MetaArgs) {
 
 export default function Announce() {
   return (
-    <main className="max-w-screen-lg mx-auto">
+    <main className="max-w-[1170px] mx-auto">
       <PlaceholderPage
         title="お知らせ"
         englishTitle="Announce"

--- a/frontend/app/routes/faq.tsx
+++ b/frontend/app/routes/faq.tsx
@@ -7,7 +7,7 @@ export function meta(_: Route.MetaArgs) {
 
 export default function Faq() {
   return (
-    <main className="max-w-screen-lg mx-auto">
+    <main className="max-w-[1170px] mx-auto">
       <PlaceholderPage
         title="よくある質問"
         englishTitle="FAQ"

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -212,8 +212,10 @@ export default function Home({ loaderData }: Route.ComponentProps) {
             現在、開催中の村はありません
           </p>
         ) : (
-          <TableResponsive>
-            <Table>
+          // 旧 .top-menu-selectable-area: bg #0b162a + border 1px #333
+          <div className="bg-night-950 border border-night-700">
+            <TableResponsive>
+              <Table>
               <tbody>
                 {villages.map((v) => (
                   <tr
@@ -261,7 +263,8 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                 ))}
               </tbody>
             </Table>
-          </TableResponsive>
+            </TableResponsive>
+          </div>
         )}
       </MenuSection>
 

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -31,8 +31,11 @@ import { PageFooter } from "~/components/layout/PageFooter";
 
 const TOP_STATUSES = ["募集中", "進行中", "エピローグ"] as const;
 
-/** MenuTile icon の共通サイズ。文字サイズ拡大に追従するよう em 単位で。 */
-const ICON_CLASS = "w-[2em] h-[2em]";
+/**
+ * MenuTile icon の共通サイズ。旧 glyphicon (~14px) 相当を狙う。
+ * 文字サイズ拡大に追従するよう em 単位で。
+ */
+const ICON_CLASS = "w-[1.3em] h-[1.3em]";
 
 export function meta(_: Route.MetaArgs) {
   return [
@@ -84,9 +87,9 @@ export default function Home({ loaderData }: Route.ComponentProps) {
   const villages = villagesQuery.data?.list ?? [];
 
   return (
-    <main className="max-w-screen-lg mx-auto">
+    <main className="max-w-[1170px] mx-auto">
       {/* --- 1. hero --- */}
-      <div className="relative w-full mb-4">
+      <div className="relative w-full mb-[15px]">
         <img
           src="/wolf-mansion/img/top.jpg"
           alt=""
@@ -105,10 +108,10 @@ export default function Home({ loaderData }: Route.ComponentProps) {
 
       {/* --- 2. メインメニュー (6 tiles, 旧 index.html と同じ並び) --- */}
       <MenuSection ariaLabel="メインメニュー">
-        <p className="text-center text-[1.17em] mb-1">
+        <p className="text-center text-[1.17em] mb-[10px] px-[15px]">
           状況のみで推理・説得する、新しい人狼
         </p>
-        <p className="text-center mb-4 leading-[1.5em] px-4">
+        <p className="text-center mb-[15px] leading-[1.5em] px-[15px]">
           WOLF MANSION では、占い・襲撃・護衛・狂狐の徘徊によって起こる【足音】と【投票】の
           2 つを使って推理・説得する「人狼館の事件簿村」ルールの人狼ゲームを楽しむことができます。
         </p>
@@ -236,37 +239,38 @@ export default function Home({ loaderData }: Route.ComponentProps) {
         )}
       </MenuSection>
 
-      {/* --- 5. 村一覧 / 村作成 --- */}
-      <MenuSection title={<>村一覧 / 村作成</>}>
-        <MenuTileRow cols={user ? 2 : 1}>
-          <MenuTileLink
-            to="/villages"
-            icon={<ClipboardDocumentListIcon className={ICON_CLASS} />}
-            label="全村一覧"
-            sublabel="Village list"
-          />
-          {user && (
+      {/* --- 5 & 6. 村一覧/村作成 + ユーザー (旧 col-sm-6 で 2 カラム横並び) --- */}
+      <div className="grid grid-cols-1 sm:grid-cols-2">
+        <MenuSection title={<>村一覧 / 村作成</>}>
+          <MenuTileRow cols={user ? 2 : 1}>
             <MenuTileLink
-              to="/new-village"
-              icon={<PlusIcon className={ICON_CLASS} />}
-              label="村を建てる"
-              sublabel="Create Village"
+              to="/villages"
+              icon={<ClipboardDocumentListIcon className={ICON_CLASS} />}
+              label="全村一覧"
+              sublabel="Village list"
             />
-          )}
-        </MenuTileRow>
-      </MenuSection>
+            {user && (
+              <MenuTileLink
+                to="/new-village"
+                icon={<PlusIcon className={ICON_CLASS} />}
+                label="村を建てる"
+                sublabel="Create Village"
+              />
+            )}
+          </MenuTileRow>
+        </MenuSection>
 
-      {/* --- 6. ユーザー (常時表示、本番踏襲) --- */}
-      <MenuSection title={<>ユーザー</>}>
-        <MenuTileRow cols={1}>
-          <MenuTileLink
-            to="/players"
-            icon={<UsersIcon className={ICON_CLASS} />}
-            label="一覧"
-            sublabel="User list"
-          />
-        </MenuTileRow>
-      </MenuSection>
+        <MenuSection title={<>ユーザー</>}>
+          <MenuTileRow cols={1}>
+            <MenuTileLink
+              to="/players"
+              icon={<UsersIcon className={ICON_CLASS} />}
+              label="一覧"
+              sublabel="User list"
+            />
+          </MenuTileRow>
+        </MenuSection>
+      </div>
 
       {/* --- 7. キャラチップ (常時表示、本番踏襲) --- */}
       <MenuSection title={<>キャラチップ</>}>

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -111,9 +111,15 @@ export default function Home({ loaderData }: Route.ComponentProps) {
         <p className="text-center text-[1.17em] mb-[10px] px-[15px]">
           状況のみで推理・説得する、新しい人狼
         </p>
+        {/* 旧 index.html: <br class="hidden-xs"> で sm+ では指定位置改行、xs では自然折返し */}
         <p className="text-center mb-[15px] leading-[1.5em] px-[15px]">
-          WOLF MANSION では、占い・襲撃・護衛・狂狐の徘徊によって起こる【足音】と【投票】の
-          2 つを使って推理・説得する「人狼館の事件簿村」ルールの人狼ゲームを楽しむことができます。
+          WOLF MANSION では、
+          <br className="hidden sm:inline" />
+          占い・襲撃・護衛・狂狐の徘徊によって起こる【足音】と
+          <br className="hidden sm:inline" />
+          【投票】の 2 つを使って推理・説得する{" "}
+          <br className="hidden sm:inline" />
+          「人狼館の事件簿村」ルールの人狼ゲームを楽しむことができます。
         </p>
         <MenuTileRow cols={3}>
           <MenuTileLink
@@ -199,7 +205,7 @@ export default function Home({ loaderData }: Route.ComponentProps) {
         )}
       </MenuSection>
 
-      {/* --- 4. 開催中の村 --- */}
+      {/* --- 4. 開催中の村 (旧 index.html: 4 カラム 村番号/名(tag inline)/人数/状態) --- */}
       <MenuSection title={<>開催中の村</>}>
         {villages.length === 0 ? (
           <p className="text-center py-4 text-white opacity-70">
@@ -214,11 +220,18 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                     key={v.id}
                     className="hover:bg-night-800 hover:text-mint-500 cursor-pointer transition-colors"
                   >
-                    <td className="w-[3em] text-right">{v.number}</td>
+                    <td className="w-[5em] text-right">
+                      <Link
+                        to={`/villages/${v.id}`}
+                        className="text-white no-underline hover:text-mint-500"
+                      >
+                        {v.number}
+                      </Link>
+                    </td>
                     <td>
                       <Link
                         to={`/villages/${v.id}`}
-                        className="block text-white no-underline hover:text-mint-500"
+                        className="text-white no-underline hover:text-mint-500"
                       >
                         <VillageTag level={villageTagLevel(v.statusName)}>
                           {v.statusName}
@@ -226,10 +239,23 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                         {v.name}
                       </Link>
                     </td>
-                    <td className="w-[6em] text-right text-[0.95em]">
-                      {v.spectatorCount > 0
-                        ? `${v.participantCount} (${v.spectatorCount})`
-                        : v.participantCount}
+                    <td className="w-[6em] text-right">
+                      <Link
+                        to={`/villages/${v.id}`}
+                        className="text-white no-underline hover:text-mint-500"
+                      >
+                        {v.spectatorCount > 0
+                          ? `${v.participantCount} (${v.spectatorCount})`
+                          : v.participantCount}
+                      </Link>
+                    </td>
+                    <td className="w-[6em]">
+                      <Link
+                        to={`/villages/${v.id}`}
+                        className="text-white no-underline hover:text-mint-500"
+                      >
+                        {v.statusName}
+                      </Link>
                     </td>
                   </tr>
                 ))}

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -25,17 +25,16 @@ import {
   MenuTileRow,
 } from "~/components/ui/MenuSection";
 import { MenuTileLink, MenuTileButton } from "~/components/ui/MenuTile";
-import { Table, TableResponsive } from "~/components/ui/Table";
+import { cn } from "~/components/ui/cn";
 import { VillageTag, villageTagLevel } from "~/components/ui/VillageTag";
 import { PageFooter } from "~/components/layout/PageFooter";
 
 const TOP_STATUSES = ["募集中", "進行中", "エピローグ"] as const;
 
 /**
- * MenuTile icon の共通サイズ。旧 glyphicon (~14px) 相当を狙う。
- * 文字サイズ拡大に追従するよう em 単位で。
+ * MenuTile icon の共通サイズ。本番 glyphicon は font-size 12px (= 12px × 12px box)。
  */
-const ICON_CLASS = "w-[1.3em] h-[1.3em]";
+const ICON_CLASS = "w-[12px] h-[12px]";
 
 export function meta(_: Route.MetaArgs) {
   return [
@@ -108,19 +107,28 @@ export default function Home({ loaderData }: Route.ComponentProps) {
 
       {/* --- 2. メインメニュー (6 tiles, 旧 index.html と同じ並び) --- */}
       <MenuSection ariaLabel="メインメニュー">
-        <p className="text-center text-[1.17em] mb-[10px] px-[15px]">
-          状況のみで推理・説得する、新しい人狼
-        </p>
-        {/* 旧 index.html: <br class="hidden-xs"> で sm+ では指定位置改行、xs では自然折返し */}
-        <p className="text-center mb-[15px] leading-[1.5em] px-[15px]">
-          WOLF MANSION では、
-          <br className="hidden sm:inline" />
-          占い・襲撃・護衛・狂狐の徘徊によって起こる【足音】と
-          <br className="hidden sm:inline" />
-          【投票】の 2 つを使って推理・説得する{" "}
-          <br className="hidden sm:inline" />
-          「人狼館の事件簿村」ルールの人狼ゲームを楽しむことができます。
-        </p>
+        {/* 旧 h100px 行: 中央寄せキャッチコピー。本番 .h5 = 15px / weight 400 */}
+        <div className="h-[100px] flex items-center justify-center px-[15px]">
+          <h2 className="m-0 text-center text-[15px] font-normal leading-[1.1]">
+            状況のみで推理・説得する、新しい人狼
+          </h2>
+        </div>
+        {/* 旧 h100px 行 + style="padding-left:40px;padding-right:40px;word-break:break-word;line-height:1.5em"
+            <br class="hidden-xs"> で sm+ では指定位置改行、xs では自然折返し */}
+        <div
+          className="h-[100px] flex items-center justify-center px-[40px] text-center leading-[1.5em]"
+          style={{ wordBreak: "break-word" }}
+        >
+          <p className="m-0">
+            WOLF MANSION では、
+            <br className="hidden sm:inline" />
+            占い・襲撃・護衛・狂狐の徘徊によって起こる【足音】と
+            <br className="hidden sm:inline" />
+            【投票】の 2 つを使って推理・説得する{" "}
+            <br className="hidden sm:inline" />
+            「人狼館の事件簿村」ルールの人狼ゲームを楽しむことができます。
+          </p>
+        </div>
         <MenuTileRow cols={3}>
           <MenuTileLink
             to="/about"
@@ -205,7 +213,7 @@ export default function Home({ loaderData }: Route.ComponentProps) {
         )}
       </MenuSection>
 
-      {/* --- 4. 開催中の村 (旧 index.html: 4 カラム 村番号/名(tag inline)/人数/状態) --- */}
+      {/* --- 4. 開催中の村 (本番計測準拠) --- */}
       <MenuSection title={<>開催中の村</>}>
         {villages.length === 0 ? (
           <p className="text-center py-4 text-white opacity-70">
@@ -214,56 +222,59 @@ export default function Home({ loaderData }: Route.ComponentProps) {
         ) : (
           // 旧 .top-menu-selectable-area: bg #0b162a + border 1px #333
           <div className="bg-night-950 border border-night-700">
-            <TableResponsive>
-              <Table>
-              <tbody>
-                {villages.map((v) => (
-                  <tr
-                    key={v.id}
-                    className="hover:bg-night-800 hover:text-mint-500 cursor-pointer transition-colors"
-                  >
-                    <td className="w-[5em] text-right">
-                      <Link
-                        to={`/villages/${v.id}`}
-                        className="text-white no-underline hover:text-mint-500"
-                      >
-                        {v.number}
-                      </Link>
-                    </td>
-                    <td>
-                      <Link
-                        to={`/villages/${v.id}`}
-                        className="text-white no-underline hover:text-mint-500"
-                      >
-                        <VillageTag level={villageTagLevel(v.statusName)}>
-                          {v.statusName}
-                        </VillageTag>
-                        {v.name}
-                      </Link>
-                    </td>
-                    <td className="w-[6em] text-right">
-                      <Link
-                        to={`/villages/${v.id}`}
-                        className="text-white no-underline hover:text-mint-500"
-                      >
-                        {v.spectatorCount > 0
-                          ? `${v.participantCount} (${v.spectatorCount})`
-                          : v.participantCount}
-                      </Link>
-                    </td>
-                    <td className="w-[6em]">
-                      <Link
-                        to={`/villages/${v.id}`}
-                        className="text-white no-underline hover:text-mint-500"
-                      >
-                        {v.statusName}
-                      </Link>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </Table>
-            </TableResponsive>
+            <div className="w-full overflow-x-auto">
+              <table className="w-full border-collapse text-[12px]">
+                <tbody>
+                  {villages.map((v) => {
+                    const cellCls =
+                      // td padding 0 + border 1px #464545 + hover で row 全体が mint に
+                      "p-0 border border-[#464545] " +
+                      "group-hover:bg-night-800 group-hover:text-mint-500";
+                    return (
+                      <tr key={v.id} className="group cursor-pointer transition-colors">
+                        {/* 旧 col-sm-1 (8.3% ≒ 95px @ 1170 container) */}
+                        <td className={cn(cellCls, "w-[8.333%] text-center")}>
+                          <Link
+                            to={`/villages/${v.id}`}
+                            className="block p-[5px] text-white no-underline group-hover:text-mint-500"
+                          >
+                            {String(v.number).padStart(4, "0")}
+                          </Link>
+                        </td>
+                        <td className={cn(cellCls, "text-left")}>
+                          <Link
+                            to={`/villages/${v.id}`}
+                            className="block p-[5px] text-white no-underline group-hover:text-mint-500"
+                          >
+                            <VillageTag level={villageTagLevel(v.statusName)}>
+                              {v.statusName}
+                            </VillageTag>
+                            {v.name}
+                          </Link>
+                        </td>
+                        {/* 旧 col-sm-2 (16.6% ≒ 190px) */}
+                        <td className={cn(cellCls, "w-[16.667%] text-center")}>
+                          <Link
+                            to={`/villages/${v.id}`}
+                            className="block p-[5px] text-white no-underline group-hover:text-mint-500"
+                          >
+                            {v.participantCount}人
+                          </Link>
+                        </td>
+                        <td className={cn(cellCls, "w-[16.667%] text-center")}>
+                          <Link
+                            to={`/villages/${v.id}`}
+                            className="block p-[5px] text-white no-underline group-hover:text-mint-500"
+                          >
+                            {v.statusName}
+                          </Link>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
           </div>
         )}
       </MenuSection>

--- a/frontend/app/routes/intro.tsx
+++ b/frontend/app/routes/intro.tsx
@@ -7,7 +7,7 @@ export function meta(_: Route.MetaArgs) {
 
 export default function Intro() {
   return (
-    <main className="max-w-screen-lg mx-auto">
+    <main className="max-w-[1170px] mx-auto">
       <PlaceholderPage
         title="人狼館の事件簿村"
         englishTitle="Introduction"

--- a/frontend/app/routes/login.tsx
+++ b/frontend/app/routes/login.tsx
@@ -67,7 +67,7 @@ export default function LoginPage() {
     : null;
 
   return (
-    <main className="max-w-screen-lg mx-auto">
+    <main className="max-w-[1170px] mx-auto">
       <PageHeader />
       <div className="px-3 max-w-[40em]">
         <h1 className="text-[1.5em] font-medium mb-3">ログイン</h1>

--- a/frontend/app/routes/new-player.tsx
+++ b/frontend/app/routes/new-player.tsx
@@ -7,7 +7,7 @@ export function meta(_: Route.MetaArgs) {
 
 export default function NewPlayer() {
   return (
-    <main className="max-w-screen-lg mx-auto">
+    <main className="max-w-[1170px] mx-auto">
       <PlaceholderPage
         title="ID 登録"
         englishTitle="Register"

--- a/frontend/app/routes/rule.tsx
+++ b/frontend/app/routes/rule.tsx
@@ -7,7 +7,7 @@ export function meta(_: Route.MetaArgs) {
 
 export default function Rule() {
   return (
-    <main className="max-w-screen-lg mx-auto">
+    <main className="max-w-[1170px] mx-auto">
       <PlaceholderPage
         title="ルール"
         englishTitle="Rule"

--- a/frontend/app/routes/villages._index.tsx
+++ b/frontend/app/routes/villages._index.tsx
@@ -70,7 +70,7 @@ export default function VillagesIndex({ loaderData }: Route.ComponentProps) {
 
   const searchPanelId = "villages-search-panel";
   return (
-    <main className="max-w-screen-lg mx-auto">
+    <main className="max-w-[1170px] mx-auto">
       <PageHeader />
       <div className="px-3">
         <h1 className="text-[1.5em] font-medium mb-3">村一覧</h1>


### PR DESCRIPTION
closes .issues/24-step-13b-fix-visual-detail.md

Step 13a / 13b で「本番一致」と説明していたが、実際は構造のみで視覚詳細
(幅 / 余白 / カラム並び / アイコン比率 / 行高) は本番から乖離していた。
本 PR で本番 (wolfort.net) との視覚差分を潰す。

## 変更内容

### container 幅
- `max-w-screen-lg` (1024px) → `max-w-[1170px]` (Bootstrap container lg max-width)
- 対象: `home` / `login` / `villages._index` / `_auth` / placeholder 6 ページ
  (`about` / `intro` / `announce` / `rule` / `faq` / `new-player`)

### レイアウト
- 村一覧/村作成 + ユーザー を `grid grid-cols-1 sm:grid-cols-2` の 2 カラム横並びに
  (旧 `col-sm-6 col-xs-12` に相当)。キャラチップは引き続き full-width
- hero 画像下の `mb-4` → `mb-[15px]`
- welcome 段落の `px-4 mb-4` → `px-[15px] mb-[15px]`

### MenuSection (旧 .top-menu)
- inner padding を `py-4 px-3` → `py-[15px] px-0` に縮小 (タイルが edge-to-edge)
- heading の `mb-3` → `mb-[15px]`

### MenuTile (旧 .top-menu-selectable)
- 旧 `.top-menu-selectable-inner` の `padding-top: 15px` + `height: 100px` を
  pt-[15px] + min-h-[8.3em] (=100px @ 12px base) として再現
- icon 用 span scaler (`text-[1.5em]`) を除去。SVG は class で 1.3em (~16px) に
- ICON_CLASS: `w-[2em]` (24px) → `w-[1.3em]` (16px) で旧 glyphicon 相当
- sublabel: `text-[0.85em]` → `text-[1em]` (旧 body 12px と同サイズ)
- label のみ `font-bold` (旧 h6 が bold)、sublabel は regular

### PageFooter
- `mt-4 py-4 px-3` → `mt-0 py-[15px] px-[15px]` で section と直接続
- hr 下の `mb-3` → `mb-[10px]`

## 動作確認

- [x] `pnpm typecheck`
- [x] `pnpm test` (11 passed)
- [x] `pnpm build`
- [x] `pnpm dev` + 本番 (wolfort.net) と並べた目視確認 (1280×900 viewport)
  - `/`, `/login`, `/villages`, `/about` を確認。container 幅 / 2 カラム並び /
    アイコンサイズ / フォントバランスが本番に近づいたことを確認
- [x] console errors なし

## 意図的スコープ外

- 旧 `.h100px / .h200px / .h500px` の固定行高は再現せず content-fit のままに。
  本番より縦に詰まるが、issue 本文の「タイル全体: 全体的にゆとり → 縮小」と
  整合する。視覚比較で違和感が出れば後続 step で再検討
- 開催中の村テーブルの row padding は Table primitive のまま (既に condensed
  相当の `py-1` で旧 Bootstrap `table-condensed` に近い)
- Step 13c (村詳細画面) は別 issue `.issues/25`
- 文字サイズ拡大 UI トグル / フォントウェイト微調整 → Step 13f