### PR TITLE
Step 13c: 村詳細画面の旧 Thymeleaf デザイン復元 (#25)

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/response/village/VillageSettingsView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/village/VillageSettingsView.kt
@@ -1,5 +1,7 @@
 package com.ort.app.api.response.village
 
+import com.ort.app.domain.model.chara.Charachips
+import com.ort.app.domain.model.skill.Skills
 import com.ort.app.domain.model.village.Village
 import com.ort.dbflute.allcommon.CDef
 import io.swagger.v3.oas.annotations.media.Schema
@@ -59,8 +61,18 @@ data class VillageSettingsView(
     val organization: String,
     @field:Schema(description = "ダミーキャラ ID")
     val dummyCharaId: Int,
+    @field:Schema(description = "ダミーキャラ名 (= 1日目発言主)")
+    val dummyCharaName: String,
+    @field:Schema(description = "村のキャラチップ一覧 (`isOriginalCharachip=false` のときのみ外部リンク用に id を使う)")
+    val charachips: List<CharachipSummaryView>,
+    @field:Schema(description = "通常発言の役職別制限 (制限がかかっている役職のみ。空ならすべて無制限)")
+    val sayRestrictList: List<SkillSayRestrictView>,
+    @field:Schema(description = "役職発言 (人狼の囁き/共鳴/恋人/念話) の発言種別別制限 (制限がかかっているもののみ)")
+    val skillSayRestrictList: List<MessageTypeSayRestrictView>,
+    @field:Schema(description = "RP 発言 (アクション) の発言種別別制限")
+    val rpSayRestrictList: List<MessageTypeSayRestrictView>,
 ) {
-    constructor(village: Village) : this(
+    constructor(village: Village, charachips: Charachips) : this(
         personMin = village.setting.personMin,
         personMax = village.setting.personMax,
         startDatetime = village.setting.startDatetime,
@@ -91,5 +103,75 @@ data class VillageSettingsView(
         isRandomOrganization = village.setting.rule.isRandomOrganization,
         organization = village.setting.organize.fixedOrganization,
         dummyCharaId = village.setting.chara.dummyCharaId,
+        dummyCharaName = charachips.charas().list.firstOrNull { it.id == village.setting.chara.dummyCharaId }?.name
+            ?: "?",
+        charachips = charachips.list.map { CharachipSummaryView(it.id, it.name) },
+        sayRestrictList = mapSayRestrictList(village),
+        skillSayRestrictList = mapSkillRestrictList(
+            village,
+            listOf(
+                CDef.MessageType.人狼の囁き,
+                CDef.MessageType.共鳴発言,
+                CDef.MessageType.恋人発言,
+                CDef.MessageType.念話,
+            ),
+        ),
+        rpSayRestrictList = mapSkillRestrictList(
+            village,
+            listOf(CDef.MessageType.アクション),
+        ),
     )
+
+    @Schema(description = "キャラチップの id + 表示名 (`isOriginalCharachip=false` のときのみクライアントは外部リンクを作る)")
+    data class CharachipSummaryView(val id: Int, val name: String)
+
+    @Schema(description = "通常発言の役職別制限。制限がかかっている役職のみリストに含む")
+    data class SkillSayRestrictView(
+        val skillCode: String,
+        val skillName: String,
+        val count: Int,
+        val length: Int,
+    )
+
+    @Schema(description = "発言種別別の発言制限。制限がかかっている発言種別のみリストに含む")
+    data class MessageTypeSayRestrictView(
+        val messageTypeCode: String,
+        val messageTypeName: String,
+        val count: Int,
+        val length: Int,
+    )
+
+    companion object {
+        private fun mapSayRestrictList(village: Village): List<SkillSayRestrictView> {
+            // 旧 modal-village-info.html は「制限がかかっている役職のみ表示」だったため
+            // ここでも `normalSayRestriction` に登録されているものだけを返す。
+            return village.setting.sayRestriction.normalSayRestriction.mapNotNull { restrict ->
+                val skill = Skills.all().filterNotSomeone().list.find { it.code == restrict.skill.code }
+                    ?: return@mapNotNull null
+                SkillSayRestrictView(
+                    skillCode = skill.code,
+                    skillName = skill.name,
+                    count = restrict.count,
+                    length = restrict.length,
+                )
+            }
+        }
+
+        private fun mapSkillRestrictList(
+            village: Village,
+            types: List<CDef.MessageType>,
+        ): List<MessageTypeSayRestrictView> {
+            return types.mapNotNull { mt ->
+                val restrict = village.setting.sayRestriction.skillSayRestriction
+                    .find { it.messageType.code == mt.code() }
+                    ?: return@mapNotNull null
+                MessageTypeSayRestrictView(
+                    messageTypeCode = mt.code(),
+                    messageTypeName = mt.alias(),
+                    count = restrict.count,
+                    length = restrict.length,
+                )
+            }
+        }
+    }
 }

--- a/backend/src/main/kotlin/com/ort/app/api/response/village/VillageView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/response/village/VillageView.kt
@@ -1,6 +1,7 @@
 package com.ort.app.api.response.village
 
 import com.ort.app.api.response.skill.SkillView
+import com.ort.app.domain.model.chara.Charachips
 import com.ort.app.domain.model.village.Village
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
@@ -52,6 +53,7 @@ data class VillageView(
         participants: VillageParticipantsView,
         isCreator: Boolean,
         isParticipating: Boolean,
+        charachips: Charachips,
     ) : this(
         id = village.id,
         number = village.id.toString().padStart(4, '0'),
@@ -64,7 +66,7 @@ data class VillageView(
         epilogueDay = village.epilogueDay,
         winCampName = village.winCamp?.name,
         roomWidth = village.roomSize?.width,
-        settings = VillageSettingsView(village),
+        settings = VillageSettingsView(village, charachips),
         days = VillageDaysView(village.days),
         participants = participants,
         isCreator = isCreator,

--- a/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/v1/villages/VillageDetailRestController.kt
@@ -78,6 +78,7 @@ class VillageDetailRestController(
             participants = participants,
             isCreator = isCreator,
             isParticipating = ctx.myself != null,
+            charachips = ctx.charachips,
         )
     }
 

--- a/backend/src/main/kotlin/com/ort/app/domain/model/village/participant/dead/Dead.kt
+++ b/backend/src/main/kotlin/com/ort/app/domain/model/village/participant/dead/Dead.kt
@@ -8,12 +8,12 @@ data class Dead(
     val reason: DeadReason?,
     val histories: DeadHistories
 ) {
-    fun isMiserableDead(): Boolean = isDead && reason?.isMiserable() ?: false
-    fun isExecuted(): Boolean = isDead && reason?.isExecuted() ?: false
-    fun isAttacked(): Boolean = isDead && reason?.isAttacked() ?: false
-    fun isSuicideDead(): Boolean = isDead && reason?.isSuicide() ?: false
-    fun isSuddenlyDead(): Boolean = isDead && reason?.isSuddenly() ?: false
-    fun isPsychicable(): Boolean = isDead && reason?.isPsychicable() ?: false
+    fun isMiserableDead(): Boolean = isDead && (reason?.isMiserable() ?: false)
+    fun isExecuted(): Boolean = isDead && (reason?.isExecuted() ?: false)
+    fun isAttacked(): Boolean = isDead && (reason?.isAttacked() ?: false)
+    fun isSuicideDead(): Boolean = isDead && (reason?.isSuicide() ?: false)
+    fun isSuddenlyDead(): Boolean = isDead && (reason?.isSuddenly() ?: false)
+    fun isPsychicable(): Boolean = isDead && (reason?.isPsychicable() ?: false)
 
     fun isDeadWhen(day: Int): Boolean {
         // 最後に死んだ日

--- a/frontend/app/app.css
+++ b/frontend/app/app.css
@@ -161,3 +161,11 @@ body {
   cursor: pointer;
   opacity: 0;
 }
+
+/* 旧 .message a (本文中のアンカー / リンク): 赤系 #f00000
+ * .message-public-system a は mint だが、PUBLIC_SYSTEM は本文中に >>N を含まないので
+ * 共通の赤指定でよい */
+.message-link {
+  color: var(--color-blood-600);
+  cursor: pointer;
+}

--- a/frontend/app/features/village/detail/ActionPanel.tsx
+++ b/frontend/app/features/village/detail/ActionPanel.tsx
@@ -39,7 +39,7 @@ export function ActionPanel({
   if (myself.isSpectator) return null;
 
   return (
-    <Panel>
+    <Panel data-action-panel>
       <PanelHeading>
         <h2 className="text-sm m-0">行動</h2>
       </PanelHeading>

--- a/frontend/app/features/village/detail/ActionPanel.tsx
+++ b/frontend/app/features/village/detail/ActionPanel.tsx
@@ -14,6 +14,7 @@ import {
   useFootstepCandidatesQuery,
   useVoteMutation,
 } from "./hooks";
+import { Panel, PanelBody, PanelHeading } from "~/components/ui/Panel";
 
 /**
  * 進行中の村で「能力 / 投票 / コミット」をまとめて行う操作パネル。
@@ -38,21 +39,27 @@ export function ActionPanel({
   if (myself.isSpectator) return null;
 
   return (
-    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4 space-y-4">
-      <h2 className="text-sm text-slate-400">行動</h2>
-      <AbilitySection
-        village={village}
-        myself={myself}
-        ability={myself.ability}
-        isDead={myself.isDead}
-      />
-      <VoteSection
-        village={village}
-        myselfCharaId={myself.charaId}
-        vote={myself.vote}
-      />
-      <CommitSection villageId={village.id} commit={myself.commit} />
-    </section>
+    <Panel>
+      <PanelHeading>
+        <h2 className="text-sm m-0">行動</h2>
+      </PanelHeading>
+      <PanelBody>
+        <div className="space-y-4">
+          <AbilitySection
+            village={village}
+            myself={myself}
+            ability={myself.ability}
+            isDead={myself.isDead}
+          />
+          <VoteSection
+            village={village}
+            myselfCharaId={myself.charaId}
+            vote={myself.vote}
+          />
+          <CommitSection villageId={village.id} commit={myself.commit} />
+        </div>
+      </PanelBody>
+    </Panel>
   );
 }
 
@@ -90,8 +97,8 @@ function AbilitySection({
   const showForm = ability.canUseAbility && !isDead;
 
   return (
-    <div className="space-y-3 border-t border-slate-700/60 pt-3 first:border-t-0 first:pt-0">
-      <div className="text-xs text-slate-400">
+    <div className="space-y-3 border-t border-night-700 pt-3 first:border-t-0 first:pt-0">
+      <div className="text-xs opacity-80">
         能力 {ability.typeName ? `(${ability.typeName})` : ""}
       </div>
 
@@ -99,7 +106,7 @@ function AbilitySection({
 
       {ability.skillHistoryList.length > 0 && (
         <div className="space-y-1">
-          <p className="text-xs text-slate-400">能力セット履歴</p>
+          <p className="text-xs opacity-80">能力セット履歴</p>
           <ul className="text-xs text-slate-300 space-y-0.5">
             {ability.skillHistoryList.map((h, i) => (
               <li key={`${i}-${h}`}>{h}</li>
@@ -361,7 +368,7 @@ function AbilityForm({
           </button>
         )}
         {mutation.isError && (
-          <span className="text-xs text-rose-300">{mutation.error.message}</span>
+          <span className="text-xs text-blood-500">{mutation.error.message}</span>
         )}
       </div>
     </form>
@@ -381,8 +388,8 @@ function VoteSection({
 }) {
   if (!vote.canVote) return null;
   return (
-    <div className="space-y-2 border-t border-slate-700/60 pt-3">
-      <div className="text-xs text-slate-400">投票</div>
+    <div className="space-y-2 border-t border-night-700 pt-3">
+      <div className="text-xs opacity-80">投票</div>
       <VoteForm
         villageId={village.id}
         participants={village.participants.list}
@@ -449,7 +456,7 @@ function VoteForm({
           {mutation.isPending ? "送信中..." : vote.targetCharaId != null ? "投票変更" : "投票"}
         </button>
         {mutation.isError && (
-          <span className="text-xs text-rose-300">{mutation.error.message}</span>
+          <span className="text-xs text-blood-500">{mutation.error.message}</span>
         )}
       </div>
     </form>
@@ -473,14 +480,14 @@ function CommitSection({
   }
 
   return (
-    <div className="space-y-2 border-t border-slate-700/60 pt-3">
-      <div className="text-xs text-slate-400">コミット (行動確定)</div>
+    <div className="space-y-2 border-t border-night-700 pt-3">
+      <div className="text-xs opacity-80">コミット (行動確定)</div>
       <div className="flex items-center gap-3">
         <span className="text-sm">
           {commit.isCommitting ? (
-            <span className="text-emerald-300">確定済み</span>
+            <span className="text-mint-500">確定済み</span>
           ) : (
-            <span className="text-slate-300">未確定</span>
+            <span className="opacity-80">未確定</span>
           )}
         </span>
         <button
@@ -496,7 +503,7 @@ function CommitSection({
               : "コミットする"}
         </button>
         {mutation.isError && (
-          <span className="text-xs text-rose-300">{mutation.error.message}</span>
+          <span className="text-xs text-blood-500">{mutation.error.message}</span>
         )}
       </div>
     </div>
@@ -507,8 +514,7 @@ function CommitSection({
 
 /**
  * 子要素を `<label>` で包んでフォームコントロールと関連付ける。
- * 単一の input/select を渡す前提なので、`<label>` の中に置けば htmlFor は不要
- * (スクリーンリーダーは内包要素を自動で関連付ける)。
+ * 旧 BS3 .form-horizontal 風に label を左 (sm:w-[8em]) + control を右に並べる。
  */
 function Row({
   label,
@@ -520,10 +526,12 @@ function Row({
   children: React.ReactNode;
 }) {
   return (
-    <label className="block space-y-1">
-      <span className="text-xs text-slate-400">{label}</span>
-      {children}
-      {suffix && <span className="block text-xs text-slate-500">{suffix}</span>}
+    <label className="block sm:flex sm:items-start sm:gap-2">
+      <span className="block sm:w-[8em] shrink-0 text-[0.95em] opacity-80 py-1">{label}</span>
+      <span className="block flex-1 space-y-1">
+        {children}
+        {suffix && <span className="block text-[0.85em] opacity-60">{suffix}</span>}
+      </span>
     </label>
   );
 }
@@ -537,10 +545,10 @@ function buildCharaNameMap(participants: VillageParticipantView[]): Record<numbe
 }
 
 const inputClass =
-  "w-full bg-slate-900 border border-slate-700 rounded px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:outline-none focus:border-indigo-500 disabled:opacity-50";
+  "w-full bg-night-900 border border-night-700 rounded-[3px] px-2 py-1 text-[1em] focus:outline-none focus:border-mint-500 disabled:opacity-50";
 
 const primaryButtonClass =
-  "rounded bg-indigo-500 hover:bg-indigo-400 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium";
+  "px-[9px] py-[6px] rounded-[3px] border-2 border-bs-success-600 bg-bs-success-500 text-white text-[13px] hover:bg-bs-success-700 hover:border-bs-success-700 disabled:opacity-50 disabled:cursor-not-allowed";
 
 const secondaryButtonClass =
-  "rounded bg-slate-700 hover:bg-slate-600 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium";
+  "px-[9px] py-[6px] rounded-[3px] border-2 border-night-700 bg-night-800 text-white text-[13px] hover:bg-night-700 disabled:opacity-50 disabled:cursor-not-allowed";

--- a/frontend/app/features/village/detail/FooterMenuDock.tsx
+++ b/frontend/app/features/village/detail/FooterMenuDock.tsx
@@ -1,0 +1,116 @@
+import {
+  ArrowDownIcon,
+  ArrowPathIcon,
+  ArrowUpIcon,
+  FunnelIcon,
+  InformationCircleIcon,
+} from "@heroicons/react/24/outline";
+
+/**
+ * 旧 .old-thymeleaf/templates/village/footer-menu.html (`#footer-menu.footer-menu-bottom`)
+ * 相当の bottom-fixed dock。Step 13c で復元。
+ *
+ * 旧画面と同じく ["最上部へ", "最下部へ", "更新", "抽出", "情報"] を並べ、
+ * `data-floating-group` 相当 (display: flex; padding: 3px) で横並び。
+ * `投票欄へ` (未投票時のみ) は本実装でも `showVoteShortcut` で出し分ける。
+ *
+ * 旧画面の「設定」(modal-dsetting) は本 PR ではスコープ外。
+ *
+ * 絵文字使用禁止 (13a 方針) のため、glyphicon は heroicons の SVG に置換。
+ */
+export function FooterMenuDock({
+  onOpenInfo,
+  onOpenFilter,
+  isFiltered,
+  showVoteShortcut,
+  onGoToVote,
+  onRefresh,
+}: {
+  onOpenInfo: () => void;
+  onOpenFilter: () => void;
+  isFiltered: boolean;
+  showVoteShortcut: boolean;
+  onGoToVote?: () => void;
+  onRefresh?: () => void;
+}) {
+  return (
+    <div
+      id="footer-menu"
+      className="fixed bottom-0 left-0 right-0 z-20 w-screen"
+    >
+      {showVoteShortcut && onGoToVote && (
+        <div
+          className="flex w-full px-[3px] py-[3px]"
+          style={{ backgroundColor: "var(--color-night-500)" }}
+        >
+          <DockButton variant="vote" onClick={onGoToVote}>
+            投票欄へ (未セットのままだと突然死します)
+          </DockButton>
+        </div>
+      )}
+      <div
+        className="flex w-full px-[3px] py-[3px]"
+        style={{ backgroundColor: "var(--color-night-500)" }}
+      >
+        <DockButton onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}>
+          <ArrowUpIcon className="w-4 h-4 inline-block" aria-hidden="true" />
+          <span className="hidden sm:inline ml-1">最上部へ</span>
+        </DockButton>
+        <DockButton
+          onClick={() =>
+            window.scrollTo({ top: document.body.scrollHeight, behavior: "smooth" })
+          }
+        >
+          <ArrowDownIcon className="w-4 h-4 inline-block" aria-hidden="true" />
+          <span className="hidden sm:inline ml-1">最下部へ</span>
+        </DockButton>
+        {onRefresh && (
+          <DockButton onClick={onRefresh}>
+            <ArrowPathIcon className="w-4 h-4 inline-block" aria-hidden="true" />
+            <span className="hidden sm:inline ml-1">更新</span>
+          </DockButton>
+        )}
+        <DockButton onClick={onOpenFilter} active={isFiltered}>
+          <FunnelIcon className="w-4 h-4 inline-block" aria-hidden="true" />
+          <span className="hidden sm:inline ml-1">{isFiltered ? "抽出中" : "抽出"}</span>
+        </DockButton>
+        <DockButton onClick={onOpenInfo}>
+          <InformationCircleIcon className="w-4 h-4 inline-block" aria-hidden="true" />
+          <span className="hidden sm:inline ml-1">情報</span>
+        </DockButton>
+      </div>
+    </div>
+  );
+}
+
+function DockButton({
+  children,
+  onClick,
+  active,
+  variant,
+}: {
+  children: React.ReactNode;
+  onClick?: () => void;
+  active?: boolean;
+  variant?: "vote";
+}) {
+  // 旧 #footer-menu .btn-footermenu: bg #222222 / mint border + mint text
+  // hover / active: mint bg + white
+  // .footermenu-vote: red border + red text、hover で赤 bg + white
+  const isVote = variant === "vote";
+  const base =
+    "flex-1 px-[6px] py-[5px] mx-[1px] border text-[0.95em] cursor-pointer text-center leading-tight rounded-[3px] transition-colors duration-100";
+  let cls: string;
+  if (isVote) {
+    cls = `${base} border-blood-500 text-blood-500 bg-night-500 hover:bg-blood-500 hover:text-white`;
+  } else if (active) {
+    cls = `${base} border-mint-600 bg-mint-600 text-white`;
+  } else {
+    cls = `${base} border-mint-600 text-mint-600 bg-night-500 hover:bg-mint-600 hover:text-white`;
+  }
+  return (
+    <button type="button" className={cls} onClick={onClick}>
+      {children}
+    </button>
+  );
+}

--- a/frontend/app/features/village/detail/FooterMenuDock.tsx
+++ b/frontend/app/features/village/detail/FooterMenuDock.tsx
@@ -47,10 +47,7 @@ export function FooterMenuDock({
           </DockButton>
         </div>
       )}
-      <div
-        className="flex w-full px-[3px] py-[3px]"
-        style={{ backgroundColor: "var(--color-night-500)" }}
-      >
+      <div className="flex w-full px-[3px] py-[3px] bg-night-500">
         <DockButton onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}>
           <ArrowUpIcon className="w-4 h-4 inline-block" aria-hidden="true" />
           <span className="hidden sm:inline ml-1">最上部へ</span>

--- a/frontend/app/features/village/detail/FooterMenuDock.tsx
+++ b/frontend/app/features/village/detail/FooterMenuDock.tsx
@@ -40,8 +40,7 @@ export function FooterMenuDock({
     >
       {showVoteShortcut && onGoToVote && (
         <div
-          className="flex w-full px-[3px] py-[3px]"
-          style={{ backgroundColor: "var(--color-night-500)" }}
+          className="flex w-full px-[3px] py-[3px] bg-night-500"
         >
           <DockButton variant="vote" onClick={onGoToVote}>
             投票欄へ (未セットのままだと突然死します)

--- a/frontend/app/features/village/detail/MessageCard.tsx
+++ b/frontend/app/features/village/detail/MessageCard.tsx
@@ -232,13 +232,19 @@ function parseLine(line: string, isConvertDisable: boolean, keyBase: string): Re
   const out: React.ReactNode[] = [];
   let remaining = line;
   let idx = 0;
+  // text 断片にも key を付ける (React の key 警告予防 + reconciler の最適化が
+  // 効くようにするため)。Fragment でラップして key を載せる。
   while (remaining.length > 0) {
     const best = findEarliestMatch(remaining, isConvertDisable);
     if (!best) {
-      out.push(remaining);
+      out.push(<React.Fragment key={`${keyBase}-t${idx}`}>{remaining}</React.Fragment>);
       break;
     }
-    if (best.index > 0) out.push(remaining.slice(0, best.index));
+    if (best.index > 0) {
+      const textChunk = remaining.slice(0, best.index);
+      out.push(<React.Fragment key={`${keyBase}-t${idx}`}>{textChunk}</React.Fragment>);
+      idx++;
+    }
     out.push(best.render(`${keyBase}-${idx}`, isConvertDisable));
     idx++;
     remaining = remaining.slice(best.index + best.length);
@@ -268,10 +274,21 @@ function findEarliestMatch(s: string, isConvertDisable: boolean): Match | null {
     /(>>s\d{1,5})/,
     /(>>\d{1,5})/,
   ];
+  // 同じ index に複数パターンがマッチした場合は **マッチ長が長い方** を優先する
+  // (例: `>>*12` を `>>\d{1,5}` ではなく `>>\*\d{1,5}` で拾う)。現状の入力では
+  // 各プレフィックス文字が digit でないため同一 index で競合しないが、防御的に
+  // この不変条件を明示する。
   let earliestAnchor: { idx: number; text: string } | null = null;
   for (const re of anchorRegexes) {
     const m = re.exec(s);
-    if (m && (earliestAnchor == null || m.index < earliestAnchor.idx)) {
+    if (!m) continue;
+    if (earliestAnchor == null) {
+      earliestAnchor = { idx: m.index, text: m[1] };
+      continue;
+    }
+    if (m.index < earliestAnchor.idx) {
+      earliestAnchor = { idx: m.index, text: m[1] };
+    } else if (m.index === earliestAnchor.idx && m[1].length > earliestAnchor.text.length) {
       earliestAnchor = { idx: m.index, text: m[1] };
     }
   }

--- a/frontend/app/features/village/detail/MessageCard.tsx
+++ b/frontend/app/features/village/detail/MessageCard.tsx
@@ -1,18 +1,20 @@
+import * as React from "react";
 import type { MessageView, VillageParticipantView } from "./api";
 import { useSayFormRequester } from "./SayFormContext";
 
 /**
- * 1 発言ぶんのカード。`MessageView.typeCode` に応じて色 / 番号プレフィックスを出し分け、
- * 発言者キャラ画像とプレイヤー名 (エピローグ以降のみ backend が返す) を表示する。
+ * 1 発言ぶんのカード。`MessageView.typeCode` に応じて色 / アンカー記号 / 構造を
+ * 旧 Thymeleaf `.message-*` variant に揃えて描画する。
  *
- * 旧 Thymeleaf 版 `.old-thymeleaf/templates/village-template/message-partial.html` の
- * 表示種別 (NORMAL_SAY / WEREWOLF_SAY / MASON_SAY / LOVERS_SAY / MONOLOGUE_SAY /
- * SECRET_SAY / GRAVE_SAY / SPECTATE_SAY / CREATOR_SAY / TELEPATHY / ACTION / 各種
- * PRIVATE_* / PUBLIC_SYSTEM / PARTICIPANTS) を一通りカバーする。
+ * Step 13c で旧 .old-thymeleaf/templates/village-template/message-partial.html
+ * と bootstrap-override.css の色値を 1:1 で持ち込んだ。
  *
- * Step 12d 以降:
- * - アンカー (`>>N` のラベル部分) をクリックすると SayForm の textarea に `>>N` を挿入
- * - 各カードに [返信] を出し、SECRET_SAY なら宛先 auto-set 込みで反映
+ * - 通常発言系 (kind=say): header (anchor + name + time) + face image + bubble + footer (返信/秘話)
+ * - システム系 (kind=system): bubble だけのシンプル枠
+ *
+ * 装飾タグ (`[[b]]` / `[[s]]` / `[[large]]` 等) は本文 text を簡易パースして
+ * React 要素を組み立てる (XSS 安全)。`loud` / `rainbow` / `extra-small` の自動
+ * 付与は backend 側にフラグが必要なため当面非対応。
  */
 export function MessageCard({
   message,
@@ -27,15 +29,25 @@ export function MessageCard({
     : undefined;
   const requestSay = useSayFormRequester();
 
-  // PUBLIC_SYSTEM / PRIVATE_* / PARTICIPANTS 等は番号も発言者も持たない単純な
-  // システム枠で出す (旧画面 message-public-system / message-private-* に対応)。
+  const content = renderMessageContent(message.text, message.isConvertDisable);
+
   if (style.kind === "system") {
     return (
-      <article
-        className={`rounded border px-3 py-2 text-sm whitespace-pre-wrap ${style.body}`}
-        data-message-type={message.typeCode}
-      >
-        {message.text}
+      <article className="mb-[1em]" data-message-type={message.typeCode}>
+        <div
+          className="message-bubble"
+          style={{
+            backgroundColor: style.bg,
+            color: style.color,
+            border: `1px solid ${style.border}`,
+            padding: "0.75em",
+            borderRadius: "0.42em",
+            fontSize: "1em",
+            wordBreak: "break-word",
+          }}
+        >
+          {content}
+        </div>
       </article>
     );
   }
@@ -58,216 +70,129 @@ export function MessageCard({
       anchorPrefix: style.anchorPrefix,
       messageNumber: message.number,
       isSecret,
-      // 秘話への返信: 元発言者のキャラ ID を宛先に
       secretTargetCharaId: isSecret ? fromParticipant?.chara.id : undefined,
     });
   }
 
   return (
-    <article
-      className={`rounded border ${style.frame}`}
-      data-message-type={message.typeCode}
-    >
-      <header className="px-3 pt-2 text-xs text-slate-400 flex flex-wrap items-center gap-x-2 gap-y-0.5">
+    <article className="mb-[1em]" data-message-type={message.typeCode}>
+      <div className="text-[0.85em] mb-[2px] flex flex-wrap items-baseline gap-x-2">
         {anchor && (
           <button
             type="button"
             onClick={handleAnchorClick}
-            className="font-mono text-slate-400 hover:text-indigo-300"
+            className="font-mono message-link hover:underline"
             title="アンカーを発言フォームに挿入"
           >
             {anchor}
           </button>
         )}
-        <span className="text-slate-200">{message.fromCharaName ?? style.fallbackFrom}</span>
-        {message.toCharaName && (
-          <span className="text-slate-400">→ {message.toCharaName}</span>
-        )}
+        <span>{message.fromCharaName ?? style.fallbackFrom}</span>
+        {message.toCharaName && <span>→ {message.toCharaName}</span>}
         {fromParticipant?.playerName && (
-          <span className="text-slate-500">[{fromParticipant.playerName}]</span>
+          <span className="opacity-80">[{fromParticipant.playerName}]</span>
         )}
-        <span className="text-slate-500 ml-auto">{formatTime(message.datetime)}</span>
-        {message.number != null && (
+        <span className="ml-auto opacity-80">{formatTime(message.datetime)}</span>
+      </div>
+      <div className="flex items-start gap-[5px]">
+        {fromParticipant && (
+          <div className="shrink-0">
+            <img
+              src={fromParticipant.chara.defaultImageUrl}
+              width={fromParticipant.chara.imageWidth}
+              height={fromParticipant.chara.imageHeight}
+              alt=""
+              loading="lazy"
+              style={{
+                maxWidth: 60,
+                maxHeight: 60,
+                width: "auto",
+                height: "auto",
+              }}
+            />
+          </div>
+        )}
+        <div
+          className="message-bubble flex-1"
+          style={{
+            backgroundColor: style.bg,
+            color: style.color,
+            border: `1px solid ${style.border}`,
+            padding: "0.75em",
+            borderRadius: "0.42em",
+            fontSize: "1em",
+            wordBreak: "break-word",
+            fontFamily: "sans-serif",
+          }}
+        >
+          {content}
+        </div>
+      </div>
+      {message.number != null && (
+        <div className="text-[0.85em] mt-1 flex justify-end gap-3">
           <button
             type="button"
             onClick={handleReplyClick}
-            className="text-xs px-1.5 py-0.5 rounded border border-slate-600 text-slate-300 hover:border-slate-400"
-            title={isSecret ? "秘話で返信 (宛先 auto-set)" : "返信"}
+            className="message-link hover:underline"
+            title={isSecret ? "秘話で返信" : "返信"}
           >
-            返信
+            &gt;&gt;{isSecret ? "秘話" : "返信"}
           </button>
-        )}
-      </header>
-      <div className="px-3 pb-2 pt-1 flex gap-2">
-        {fromParticipant && (
-          <img
-            src={fromParticipant.chara.defaultImageUrl}
-            width={fromParticipant.chara.imageWidth}
-            height={fromParticipant.chara.imageHeight}
-            alt=""
-            loading="lazy"
-            className="shrink-0 rounded border border-slate-700"
-            style={{
-              maxWidth: 60,
-              maxHeight: 60,
-              width: "auto",
-              height: "auto",
-            }}
-          />
-        )}
-        {/* React JSX は子要素の文字列を textContent としてレンダリングするため、
-            `message.text` を直接埋め込んでも XSS にはならない。旧 Thymeleaf の
-            `{{{messageContent}}}` (HTML 非エスケープ) に相当する HTML 装飾
-            (大声 / 虹色 / アンカー link) は Step 12d で安全に再実装する。 */}
-        <p className={`flex-1 text-sm whitespace-pre-wrap ${style.text}`}>{message.text}</p>
-      </div>
+        </div>
+      )}
     </article>
   );
 }
-
-// ---------- styles ----------
 
 type MessageKind = "say" | "system";
 
 type MessageStyle = {
   kind: MessageKind;
-  /** カード枠 (kind=say のときに使用) */
-  frame: string;
-  /** 本文文字色 (kind=say のときに使用) */
-  text: string;
-  /** システム枠の background+border (kind=system のときに使用) */
-  body: string;
-  /** >>N のような番号プレフィックス記号 (旧画面のアンカー記法に揃える) */
+  bg: string;
+  color: string;
+  border: string;
   anchorPrefix: string;
-  /** fromCharaName が null のときに表示するフォールバック (主に creator) */
   fallbackFrom: string;
 };
 
 const DEFAULT_STYLE: MessageStyle = {
   kind: "say",
-  frame: "bg-slate-800/40 border-slate-700",
-  text: "text-slate-100",
-  body: "",
+  bg: "#ffffff",
+  color: "#555555",
+  border: "#e3e3e3",
   anchorPrefix: ">>",
   fallbackFrom: "?",
 };
 
-// 旧 .old-thymeleaf/templates/village-template/message-partial.html の anchor 記法と
-// 配色を Tailwind に移植したもの。背景は slate ベースに寄せて統一感を出す。
 const MESSAGE_STYLES: Record<string, MessageStyle> = {
-  NORMAL_SAY: {
-    kind: "say",
-    frame: "bg-slate-800/50 border-slate-600",
-    text: "text-slate-100",
-    body: "",
-    anchorPrefix: ">>",
-    fallbackFrom: "?",
-  },
-  WEREWOLF_SAY: {
-    kind: "say",
-    frame: "bg-rose-950/40 border-rose-700",
-    text: "text-rose-100",
-    body: "",
-    anchorPrefix: ">>*",
-    fallbackFrom: "?",
-  },
-  MASON_SAY: {
-    kind: "say",
-    frame: "bg-violet-950/40 border-violet-700",
-    text: "text-violet-100",
-    body: "",
-    anchorPrefix: ">>=",
-    fallbackFrom: "?",
-  },
-  LOVERS_SAY: {
-    kind: "say",
-    frame: "bg-pink-950/40 border-pink-700",
-    text: "text-pink-100",
-    body: "",
-    anchorPrefix: ">>?",
-    fallbackFrom: "?",
-  },
-  MONOLOGUE_SAY: {
-    kind: "say",
-    frame: "bg-slate-900/60 border-slate-700",
-    text: "text-slate-300 italic",
-    body: "",
-    anchorPrefix: ">>-",
-    fallbackFrom: "?",
-  },
-  SECRET_SAY: {
-    kind: "say",
-    frame: "bg-amber-950/40 border-amber-700",
-    text: "text-amber-100",
-    body: "",
-    anchorPrefix: ">>s",
-    fallbackFrom: "?",
-  },
-  GRAVE_SAY: {
-    kind: "say",
-    frame: "bg-zinc-900/70 border-zinc-700",
-    text: "text-zinc-300",
-    body: "",
-    anchorPrefix: ">>+",
-    fallbackFrom: "?",
-  },
-  SPECTATE_SAY: {
-    kind: "say",
-    frame: "bg-sky-950/40 border-sky-700",
-    text: "text-sky-100",
-    body: "",
-    anchorPrefix: ">>@",
-    fallbackFrom: "?",
-  },
-  CREATOR_SAY: {
-    kind: "say",
-    frame: "bg-yellow-950/40 border-yellow-700",
-    text: "text-yellow-100",
-    body: "",
-    anchorPrefix: ">>#",
-    fallbackFrom: "天からのお告げ",
-  },
-  TELEPATHY: {
-    kind: "say",
-    frame: "bg-indigo-950/40 border-indigo-700",
-    text: "text-indigo-100",
-    body: "",
-    anchorPrefix: ">>_",
-    fallbackFrom: "?",
-  },
-  ACTION: {
-    kind: "say",
-    frame: "bg-slate-800/30 border-slate-700",
-    text: "text-slate-300 italic",
-    body: "",
-    anchorPrefix: ">>a",
-    fallbackFrom: "",
-  },
-  // システム / 個別役職向け private 系: 番号もキャラ画像も持たない一行枠
-  PUBLIC_SYSTEM: makeSystem("bg-slate-700/30 border-slate-600 text-slate-100"),
-  PRIVATE_SYSTEM: makeSystem("bg-slate-800/50 border-slate-600 text-slate-200"),
-  PRIVATE_SEER: makeSystem("bg-emerald-950/40 border-emerald-700 text-emerald-100"),
-  PRIVATE_WISE: makeSystem("bg-emerald-950/40 border-emerald-700 text-emerald-100"),
-  PRIVATE_PSYCHIC: makeSystem("bg-teal-950/40 border-teal-700 text-teal-100"),
-  PRIVATE_GURU: makeSystem("bg-teal-950/40 border-teal-700 text-teal-100"),
-  PRIVATE_CORONER: makeSystem("bg-teal-950/40 border-teal-700 text-teal-100"),
-  PRIVATE_INVESTIGATE: makeSystem("bg-cyan-950/40 border-cyan-700 text-cyan-100"),
-  PRIVATE_WEREWOLF: makeSystem("bg-rose-950/40 border-rose-700 text-rose-100"),
-  PRIVATE_LOVER: makeSystem("bg-pink-950/40 border-pink-700 text-pink-100"),
-  PRIVATE_FOX: makeSystem("bg-orange-950/40 border-orange-700 text-orange-100"),
-  PRIVATE_ABILITY: makeSystem("bg-slate-800/60 border-slate-600 text-slate-200"),
-  PARTICIPANTS: makeSystem("bg-slate-700/30 border-slate-600 text-slate-100"),
+  NORMAL_SAY: { kind: "say", bg: "#ffffff", color: "#555555", border: "#e3e3e3", anchorPrefix: ">>", fallbackFrom: "?" },
+  WEREWOLF_SAY: { kind: "say", bg: "#f2aeae", color: "#333333", border: "#f2aeae", anchorPrefix: ">>*", fallbackFrom: "?" },
+  MASON_SAY: { kind: "say", bg: "#aef2ae", color: "#333333", border: "#aef2ae", anchorPrefix: ">>=", fallbackFrom: "?" },
+  LOVERS_SAY: { kind: "say", bg: "#f2cece", color: "#cc2222", border: "#f2cece", anchorPrefix: ">>?", fallbackFrom: "?" },
+  TELEPATHY: { kind: "say", bg: "#f2f2ae", color: "#cc2200", border: "#f2f2ae", anchorPrefix: ">>_", fallbackFrom: "?" },
+  MONOLOGUE_SAY: { kind: "say", bg: "#aaaaaa", color: "#333333", border: "#b5b5b5", anchorPrefix: ">>-", fallbackFrom: "?" },
+  SECRET_SAY: { kind: "say", bg: "#aa99aa", color: "#333333", border: "#b5b5b5", anchorPrefix: ">>s", fallbackFrom: "?" },
+  GRAVE_SAY: { kind: "say", bg: "#a9edf7", color: "#333333", border: "#a9edf7", anchorPrefix: ">>+", fallbackFrom: "?" },
+  SPECTATE_SAY: { kind: "say", bg: "#ffdea9", color: "#333333", border: "#ffdea9", anchorPrefix: ">>@", fallbackFrom: "?" },
+  CREATOR_SAY: { kind: "say", bg: "transparent", color: "#00bc8c", border: "#00bc8c", anchorPrefix: ">>#", fallbackFrom: "天からのお告げ" },
+  ACTION: { kind: "say", bg: "#232355", color: "#ffffff", border: "#232355", anchorPrefix: ">>a", fallbackFrom: "" },
+  PUBLIC_SYSTEM: makeSystem("transparent", "#ffffff", "transparent"),
+  PRIVATE_SYSTEM: makeSystem("#333333", "#eeeeee", "#cccccc"),
+  PRIVATE_SEER: makeSystem("#334033", "#eeeeee", "#34a865"),
+  PRIVATE_WISE: makeSystem("#334033", "#eeeeee", "#34a865"),
+  PRIVATE_PSYCHIC: makeSystem("#333340", "#eeeeee", "#3465a8"),
+  PRIVATE_GURU: makeSystem("#333340", "#eeeeee", "#3465a8"),
+  PRIVATE_CORONER: makeSystem("#333340", "#eeeeee", "#3465a8"),
+  PRIVATE_INVESTIGATE: makeSystem("#403333", "#eeeeee", "#a86534"),
+  PRIVATE_WEREWOLF: makeSystem("#403333", "#eeeeee", "#a83434"),
+  PRIVATE_LOVER: makeSystem("#403333", "#eeeeee", "#f9318f"),
+  PRIVATE_FOX: makeSystem("#403333", "#eeeeee", "#c9c934"),
+  PRIVATE_ABILITY: makeSystem("#333333", "#eeeeee", "#cccccc"),
+  PARTICIPANTS: makeSystem("transparent", "#ffffff", "transparent"),
 };
 
-function makeSystem(body: string): MessageStyle {
-  return {
-    kind: "system",
-    frame: "",
-    text: "",
-    body,
-    anchorPrefix: "",
-    fallbackFrom: "",
-  };
+function makeSystem(bg: string, color: string, border: string): MessageStyle {
+  return { kind: "system", bg, color, border, anchorPrefix: "", fallbackFrom: "" };
 }
 
 function renderAnchor(prefix: string, num: number | null | undefined): string {
@@ -281,4 +206,130 @@ function formatTime(iso: string): string {
   const hh = String(d.getHours()).padStart(2, "0");
   const mi = String(d.getMinutes()).padStart(2, "0");
   return `${hh}:${mi}`;
+}
+
+/**
+ * 本文 text を React 要素ツリーに変換する。改行 → <br>, アンカー (`>>N` 系) →
+ * .message-link span, 装飾タグ (`[[b]]` `[[s]]` `[[large]]` `[[small]]` `[[#hex]]`
+ * `[[netabare]]` `[[cw]]` `[[tp]]` `[[ruby]]`) → 対応要素。
+ *
+ * 装飾タグの入れ子は旧 JS が逐次 regex 置換していたため非対応 (= 最外側 1 段階のみ)。
+ * `isConvertDisable=true` なら装飾タグ変換をスキップし改行 + アンカーのみ適用する。
+ */
+function renderMessageContent(text: string, isConvertDisable: boolean): React.ReactNode {
+  const lines = text.split(/\r\n|\r|\n/);
+  const out: React.ReactNode[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    out.push(
+      <React.Fragment key={`l-${i}`}>{parseLine(lines[i], isConvertDisable, `l-${i}`)}</React.Fragment>,
+    );
+    if (i < lines.length - 1) out.push(<br key={`br-${i}`} />);
+  }
+  return <>{out}</>;
+}
+
+function parseLine(line: string, isConvertDisable: boolean, keyBase: string): React.ReactNode[] {
+  const out: React.ReactNode[] = [];
+  let remaining = line;
+  let idx = 0;
+  while (remaining.length > 0) {
+    const best = findEarliestMatch(remaining, isConvertDisable);
+    if (!best) {
+      out.push(remaining);
+      break;
+    }
+    if (best.index > 0) out.push(remaining.slice(0, best.index));
+    out.push(best.render(`${keyBase}-${idx}`, isConvertDisable));
+    idx++;
+    remaining = remaining.slice(best.index + best.length);
+  }
+  return out;
+}
+
+type Match = {
+  index: number;
+  length: number;
+  render: (key: string, isConvertDisable: boolean) => React.ReactNode;
+};
+
+function findEarliestMatch(s: string, isConvertDisable: boolean): Match | null {
+  const candidates: Match[] = [];
+
+  const anchorRegexes = [
+    /(>>\*\d{1,5})/,
+    /(>>=\d{1,5})/,
+    /(>>\?\d{1,5})/,
+    /(>>_\d{1,5})/,
+    /(>>@\d{1,5})/,
+    /(>>-\d{1,5})/,
+    /(>>\+\d{1,5})/,
+    /(>>#\d{1,5})/,
+    /(>>a\d{1,5})/,
+    /(>>s\d{1,5})/,
+    /(>>\d{1,5})/,
+  ];
+  let earliestAnchor: { idx: number; text: string } | null = null;
+  for (const re of anchorRegexes) {
+    const m = re.exec(s);
+    if (m && (earliestAnchor == null || m.index < earliestAnchor.idx)) {
+      earliestAnchor = { idx: m.index, text: m[1] };
+    }
+  }
+  if (earliestAnchor) {
+    const { idx, text } = earliestAnchor;
+    candidates.push({
+      index: idx,
+      length: text.length,
+      render: (k) => <span key={k} className="message-link">{text}</span>,
+    });
+  }
+
+  if (!isConvertDisable) {
+    pushTag(/\[\[(#[0-9a-fA-F]{6})\]\]([\s\S]*?)\[\[\/#\]\]/, s, candidates, (m, k, cd) => (
+      <span key={k} style={{ color: m[1] }}>{parseLine(m[2], cd, `${k}-i`)}</span>
+    ));
+    pushTag(/\[\[b\]\]([\s\S]*?)\[\[\/b\]\]/, s, candidates, (m, k, cd) => (
+      <strong key={k}>{parseLine(m[1], cd, `${k}-i`)}</strong>
+    ));
+    pushTag(/\[\[s\]\]([\s\S]*?)\[\[\/s\]\]/, s, candidates, (m, k, cd) => (
+      <span key={k} style={{ textDecoration: "line-through" }}>{parseLine(m[1], cd, `${k}-i`)}</span>
+    ));
+    pushTag(/\[\[large\]\]([\s\S]*?)\[\[\/large\]\]/, s, candidates, (m, k, cd) => (
+      <span key={k} style={{ fontSize: "150%" }}>{parseLine(m[1], cd, `${k}-i`)}</span>
+    ));
+    pushTag(/\[\[small\]\]([\s\S]*?)\[\[\/small\]\]/, s, candidates, (m, k, cd) => (
+      <span key={k} style={{ fontSize: "80%" }}>{parseLine(m[1], cd, `${k}-i`)}</span>
+    ));
+    pushTag(/\[\[ruby\]\]([\s\S]*?)\[\[rt\]\]([\s\S]*?)\[\[\/rt\]\]\[\[\/ruby\]\]/, s, candidates, (m, k) => (
+      <ruby key={k}>{m[1]}<rt>{m[2]}</rt></ruby>
+    ));
+    pushTag(/\[\[netabare\]\]([\s\S]*?)\[\[\/netabare\]\]/, s, candidates, (m, k, cd) => (
+      <span key={k} className="netabare">{parseLine(m[1], cd, `${k}-i`)}</span>
+    ));
+    pushTag(/\[\[cw\]\]([\s\S]*?)\[\[\/cw\]\]/, s, candidates, (m, k, cd) => (
+      <span key={k} className="netabare">{parseLine(m[1], cd, `${k}-i`)}</span>
+    ));
+    pushTag(/\[\[tp\]\]([\s\S]*?)\[\[\/tp\]\]/, s, candidates, (m, k, cd) => (
+      <span key={k} className="transparency">{parseLine(m[1], cd, `${k}-i`)}</span>
+    ));
+  }
+
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => a.index - b.index);
+  return candidates[0];
+}
+
+function pushTag(
+  re: RegExp,
+  s: string,
+  candidates: Match[],
+  render: (m: RegExpExecArray, key: string, isConvertDisable: boolean) => React.ReactNode,
+) {
+  const m = re.exec(s);
+  if (!m) return;
+  candidates.push({
+    index: m.index,
+    length: m[0].length,
+    render: (k, cd) => render(m, k, cd),
+  });
 }

--- a/frontend/app/features/village/detail/MessageFilter.tsx
+++ b/frontend/app/features/village/detail/MessageFilter.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 import type { VillageParticipantView } from "./api";
+import { Modal } from "~/components/ui/Modal";
+import { Button } from "~/components/ui/Button";
 
 /**
  * UI 上で「1 つの絞り込み単位」として扱う発言種別。backend 側の
@@ -53,6 +55,14 @@ export function isEmptyFilter(v: MessageFilterValue): boolean {
   );
 }
 
+/**
+ * 発言フィルタ Modal。Step 13c で Modal primitive に揃え、checkbox UI を
+ * 旧 BS3 .form-horizontal 風の見た目に近づけた。
+ *
+ * 旧画面の `aria-controls` 先要素は collapse 時に DOM から消える設計だったが、
+ * 本実装は Modal の open/close で全体を出し入れする形なので、JAWS 等で問題に
+ * なる aria-controls 先要素の常駐化問題は構造上発生しない (13a 残 nit 解消)。
+ */
 export function MessageFilterModal({
   open,
   value,
@@ -67,12 +77,9 @@ export function MessageFilterModal({
   onClose: () => void;
 }) {
   const [draft, setDraft] = useState<MessageFilterValue>(value);
-  // モーダルを開くたびに親の最新値で初期化する。閉じている間は不要な再 render を避ける。
   useEffect(() => {
     if (open) setDraft(value);
   }, [open, value]);
-
-  if (!open) return null;
 
   const toggleType = (code: string) => {
     setDraft((d) => ({
@@ -103,66 +110,26 @@ export function MessageFilterModal({
   const selectable = participants.filter((p) => !p.isGone);
 
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-label="発言フィルタ"
-      className="fixed inset-0 z-40 flex items-center justify-center bg-black/60 p-4"
-      onClick={onClose}
-    >
-      <div
-        className="w-full max-w-3xl max-h-[90vh] overflow-y-auto rounded-xl bg-slate-900 border border-slate-700 p-5 space-y-4"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <h3 className="text-base font-semibold">発言抽出</h3>
-
-        <section>
-          <div className="flex items-center justify-between">
-            <h4 className="text-sm text-slate-300">発言種別</h4>
-            <div className="text-xs space-x-2">
-              <button
-                type="button"
-                className="text-slate-300 hover:text-slate-100"
-                onClick={() => setDraft((d) => ({ ...d, messageType: [] }))}
-              >
-                クリア
-              </button>
-              <button
-                type="button"
-                className="text-slate-300 hover:text-slate-100"
-                onClick={() =>
-                  setDraft((d) => ({ ...d, messageType: MESSAGE_FILTER_TYPES.map((t) => t.code) }))
-                }
-              >
-                全選択
-              </button>
-            </div>
+    <Modal open={open} onClose={onClose} title="発言抽出">
+      <div className="space-y-4">
+        <FilterSection
+          title="発言種別"
+          onClear={() => setDraft((d) => ({ ...d, messageType: [] }))}
+          onSelectAll={() =>
+            setDraft((d) => ({ ...d, messageType: MESSAGE_FILTER_TYPES.map((t) => t.code) }))
+          }
+        >
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-1">
+            {MESSAGE_FILTER_TYPES.map((t) => (
+              <CheckboxItem
+                key={t.code}
+                checked={draft.messageType.includes(t.code)}
+                onToggle={() => toggleType(t.code)}
+                label={t.label}
+              />
+            ))}
           </div>
-          <div className="mt-2 grid grid-cols-2 sm:grid-cols-4 gap-1">
-            {MESSAGE_FILTER_TYPES.map((t) => {
-              const active = draft.messageType.includes(t.code);
-              return (
-                <label
-                  key={t.code}
-                  className={
-                    "flex items-center gap-2 text-xs cursor-pointer rounded px-2 py-1 border " +
-                    (active
-                      ? "bg-indigo-600/30 border-indigo-400 text-indigo-50"
-                      : "bg-slate-800/40 border-slate-700 text-slate-300 hover:bg-slate-700/40")
-                  }
-                >
-                  <input
-                    type="checkbox"
-                    checked={active}
-                    onChange={() => toggleType(t.code)}
-                    className="accent-indigo-500"
-                  />
-                  {t.label}
-                </label>
-              );
-            })}
-          </div>
-        </section>
+        </FilterSection>
 
         <ParticipantSelector
           title="発言者"
@@ -181,44 +148,91 @@ export function MessageFilterModal({
         />
 
         <section>
-          <h4 className="text-sm text-slate-300">キーワード</h4>
+          <h4 className="text-[0.95em] mb-1">キーワード</h4>
           <input
             type="text"
             value={draft.keyword}
             onChange={(e) => setDraft((d) => ({ ...d, keyword: e.target.value }))}
             placeholder="スペース区切りで OR"
-            className="mt-2 w-full rounded bg-slate-800 border border-slate-700 px-3 py-1.5 text-sm"
+            className="w-full bg-night-900 border border-night-700 rounded-[3px] px-2 py-1 text-[1em]"
           />
         </section>
 
-        <div className="flex justify-end gap-2 pt-2 border-t border-slate-700">
-          <button
-            type="button"
-            className="rounded border border-slate-600 px-3 py-1.5 text-sm text-slate-200 hover:bg-slate-800"
-            onClick={() => setDraft(EMPTY_FILTER)}
-          >
-            リセット
-          </button>
-          <button
-            type="button"
-            className="rounded border border-slate-600 px-3 py-1.5 text-sm text-slate-200 hover:bg-slate-800"
-            onClick={onClose}
-          >
-            閉じる
-          </button>
-          <button
-            type="button"
-            className="rounded bg-indigo-500 hover:bg-indigo-400 px-3 py-1.5 text-sm text-white"
+        <div className="flex justify-end gap-2 pt-2 border-t border-night-550">
+          <Button variant="default" onClick={() => setDraft(EMPTY_FILTER)}>リセット</Button>
+          <Button variant="default" onClick={onClose}>閉じる</Button>
+          <Button
+            variant="success"
             onClick={() => {
               onApply(draft);
               onClose();
             }}
           >
             抽出
-          </button>
+          </Button>
         </div>
       </div>
-    </div>
+    </Modal>
+  );
+}
+
+function FilterSection({
+  title,
+  onClear,
+  onSelectAll,
+  children,
+}: {
+  title: string;
+  onClear: () => void;
+  onSelectAll?: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      <div className="flex items-center justify-between mb-1">
+        <h4 className="text-[0.95em] m-0">{title}</h4>
+        <div className="text-[0.85em] flex gap-2">
+          <button type="button" className="message-link hover:underline" onClick={onClear}>
+            クリア
+          </button>
+          {onSelectAll && (
+            <button type="button" className="message-link hover:underline" onClick={onSelectAll}>
+              全選択
+            </button>
+          )}
+        </div>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function CheckboxItem({
+  checked,
+  onToggle,
+  label,
+}: {
+  checked: boolean;
+  onToggle: () => void;
+  label: string;
+}) {
+  return (
+    <label
+      className={
+        "flex items-center gap-2 text-[0.95em] cursor-pointer rounded-[3px] px-2 py-1 border " +
+        (checked
+          ? "bg-mint-600 border-mint-600 text-white"
+          : "bg-night-900 border-night-700 hover:border-mint-600")
+      }
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={onToggle}
+        className="accent-mint-600"
+      />
+      <span className="truncate">{label}</span>
+    </label>
   );
 }
 
@@ -236,41 +250,17 @@ function ParticipantSelector({
   onClear: () => void;
 }) {
   return (
-    <section>
-      <div className="flex items-center justify-between">
-        <h4 className="text-sm text-slate-300">{title}</h4>
-        <button
-          type="button"
-          className="text-xs text-slate-300 hover:text-slate-100"
-          onClick={onClear}
-        >
-          クリア
-        </button>
+    <FilterSection title={title} onClear={onClear}>
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-1">
+        {selectable.map((p) => (
+          <CheckboxItem
+            key={p.id}
+            checked={selected.includes(p.id)}
+            onToggle={() => onToggle(p.id)}
+            label={p.name}
+          />
+        ))}
       </div>
-      <div className="mt-2 grid grid-cols-2 sm:grid-cols-3 gap-1">
-        {selectable.map((p) => {
-          const active = selected.includes(p.id);
-          return (
-            <label
-              key={p.id}
-              className={
-                "flex items-center gap-2 text-xs cursor-pointer rounded px-2 py-1 border " +
-                (active
-                  ? "bg-indigo-600/30 border-indigo-400 text-indigo-50"
-                  : "bg-slate-800/40 border-slate-700 text-slate-300 hover:bg-slate-700/40")
-              }
-            >
-              <input
-                type="checkbox"
-                checked={active}
-                onChange={() => onToggle(p.id)}
-                className="accent-indigo-500"
-              />
-              <span className="truncate">{p.name}</span>
-            </label>
-          );
-        })}
-      </div>
-    </section>
+    </FilterSection>
   );
 }

--- a/frontend/app/features/village/detail/ParticipateActions.tsx
+++ b/frontend/app/features/village/detail/ParticipateActions.tsx
@@ -11,6 +11,7 @@ import type {
   MyselfView,
   VillageView,
 } from "./api";
+import { Panel as UIPanel, PanelBody, PanelHeading } from "~/components/ui/Panel";
 
 /**
  * プロローグ中の参加系操作 UI。
@@ -117,9 +118,9 @@ function ParticipateForm({ village }: { village: VillageView }) {
         {!isOriginal && (
           <Field label="キャラ">
             {isLoadingCharas ? (
-              <p className="text-slate-400 text-sm">読み込み中...</p>
+              <p className="opacity-80 text-sm">読み込み中...</p>
             ) : charas.length === 0 ? (
-              <p className="text-slate-400 text-sm">選択可能なキャラがいません</p>
+              <p className="opacity-80 text-sm">選択可能なキャラがいません</p>
             ) : (
               <CharaGrid charas={charas} selectedId={charaId} onSelect={onSelectChara} />
             )}
@@ -136,7 +137,7 @@ function ParticipateForm({ village }: { village: VillageView }) {
               disabled={mutation.isPending}
             />
             {charaImage && (
-              <p className="text-xs text-slate-400 mt-1">
+              <p className="text-xs opacity-80 mt-1">
                 {charaImage.name} ({Math.round(charaImage.size / 1024)} KB)
               </p>
             )}
@@ -198,7 +199,7 @@ function ParticipateForm({ village }: { village: VillageView }) {
               placeholder={`挨拶など (発言扱い、${MESSAGE_MAX_LENGTH} 文字以内)`}
               disabled={mutation.isPending}
             />
-            <p className="text-xs text-slate-500 text-right">
+            <p className="text-xs opacity-60 text-right">
               {joinMessage.length} / {MESSAGE_MAX_LENGTH}
             </p>
           </div>
@@ -238,7 +239,7 @@ function ParticipateForm({ village }: { village: VillageView }) {
             {mutation.isPending ? "送信中..." : spectator ? "見学する" : "入村する"}
           </button>
           {mutation.isError && (
-            <span className="text-xs text-rose-300">{mutation.error.message}</span>
+            <span className="text-xs text-blood-500">{mutation.error.message}</span>
           )}
         </div>
       </form>
@@ -264,14 +265,14 @@ function CharaGrid({
             <button
               type="button"
               onClick={() => onSelect(c.id)}
-              className={`w-full text-left p-2 rounded border text-sm transition ${
+              className={`w-full text-left p-2 rounded-[3px] border text-[0.95em] transition ${
                 isSelected
-                  ? "border-indigo-400 bg-indigo-500/20"
-                  : "border-slate-700 hover:border-slate-500 bg-slate-900/40"
+                  ? "border-mint-500 bg-mint-600/20"
+                  : "border-night-700 hover:border-mint-500 bg-night-900"
               }`}
             >
               <span className="font-medium">{c.name}</span>
-              <span className="ml-2 text-xs text-slate-400">[{c.shortName}]</span>
+              <span className="ml-2 text-xs opacity-80">[{c.shortName}]</span>
             </button>
           </li>
         );
@@ -302,7 +303,7 @@ function ParticipatingActions({
         )}
         {!village.isCreator && <LeaveButton villageId={village.id} />}
         {village.isCreator && (
-          <p className="text-xs text-slate-500">
+          <p className="text-xs opacity-60">
             村建ては退村できません (廃村は別途 admin 画面で操作)。
           </p>
         )}
@@ -330,7 +331,7 @@ function SwitchParticipateButton({
         {isSpectator ? "参加者になる" : "見学者になる"}
       </button>
       {mutation.isError && (
-        <span className="text-xs text-rose-300">{mutation.error.message}</span>
+        <span className="text-xs text-blood-500">{mutation.error.message}</span>
       )}
     </div>
   );
@@ -363,8 +364,8 @@ function ChangeRequestSkillForm({
   const submittable = !mutation.isPending;
 
   return (
-    <form onSubmit={submit} className="space-y-2 border-t border-slate-700/60 pt-3">
-      <p className="text-xs text-slate-400">希望役職変更</p>
+    <form onSubmit={submit} className="space-y-2 border-t border-night-700 pt-3">
+      <p className="text-xs opacity-80">希望役職変更</p>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
         <SkillSelect
           value={requestedSkill}
@@ -388,7 +389,7 @@ function ChangeRequestSkillForm({
           {mutation.isPending ? "送信中..." : "希望を反映"}
         </button>
         {mutation.isError && (
-          <span className="text-xs text-rose-300">{mutation.error.message}</span>
+          <span className="text-xs text-blood-500">{mutation.error.message}</span>
         )}
       </div>
     </form>
@@ -402,17 +403,17 @@ function LeaveButton({ villageId }: { villageId: number }) {
     mutation.mutate();
   }
   return (
-    <div className="flex items-center gap-3 border-t border-slate-700/60 pt-3">
+    <div className="flex items-center gap-3 border-t border-night-700 pt-3">
       <button
         type="button"
         onClick={onClick}
         disabled={mutation.isPending}
-        className="rounded bg-rose-600 hover:bg-rose-500 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium"
+        className="px-[9px] py-[6px] rounded-[3px] border-2 border-blood-500 bg-blood-500 text-white text-[13px] hover:bg-blood-600 hover:border-blood-600 disabled:opacity-50 disabled:cursor-not-allowed"
       >
         {mutation.isPending ? "送信中..." : "退村する"}
       </button>
       {mutation.isError && (
-        <span className="text-xs text-rose-300">{mutation.error.message}</span>
+        <span className="text-xs text-blood-500">{mutation.error.message}</span>
       )}
     </div>
   );
@@ -422,18 +423,21 @@ function LeaveButton({ villageId }: { villageId: number }) {
 
 function Panel({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
-      <h2 className="text-sm text-slate-400 mb-3">{title}</h2>
-      {children}
-    </section>
+    <UIPanel>
+      <PanelHeading>
+        <h2 className="text-sm m-0">{title}</h2>
+      </PanelHeading>
+      <PanelBody>{children}</PanelBody>
+    </UIPanel>
   );
 }
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  // 旧 .form-horizontal 風: sm 以上で label を左 8em、コントロールを右に並べる
   return (
-    <div className="space-y-1">
-      <label className="text-xs text-slate-400">{label}</label>
-      {children}
+    <div className="sm:flex sm:items-start sm:gap-2">
+      <label className="block sm:w-[8em] shrink-0 text-[0.95em] opacity-80 py-1">{label}</label>
+      <div className="flex-1 space-y-1">{children}</div>
     </div>
   );
 }
@@ -479,10 +483,10 @@ const MESSAGE_MAX_LENGTH = 400;
 const OMAKASE_CODE = "LEFTOVER";
 
 const inputClass =
-  "w-full bg-slate-900 border border-slate-700 rounded px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:outline-none focus:border-indigo-500 disabled:opacity-50";
+  "w-full bg-night-900 border border-night-700 rounded-[3px] px-2 py-1 text-[1em] focus:outline-none focus:border-mint-500 disabled:opacity-50";
 
 const primaryButtonClass =
-  "rounded bg-indigo-500 hover:bg-indigo-400 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium";
+  "px-[9px] py-[6px] rounded-[3px] border-2 border-bs-success-600 bg-bs-success-500 text-white text-[13px] hover:bg-bs-success-700 hover:border-bs-success-700 disabled:opacity-50 disabled:cursor-not-allowed";
 
 const secondaryButtonClass =
-  "rounded bg-slate-700 hover:bg-slate-600 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium";
+  "px-[9px] py-[6px] rounded-[3px] border-2 border-night-700 bg-night-800 text-white text-[13px] hover:bg-night-700 disabled:opacity-50 disabled:cursor-not-allowed";

--- a/frontend/app/features/village/detail/RoomGridPanel.tsx
+++ b/frontend/app/features/village/detail/RoomGridPanel.tsx
@@ -1,16 +1,20 @@
+import { HeartIcon } from "@heroicons/react/24/solid";
 import type { VillageParticipantView, VillageView } from "./api";
+import { Panel, PanelBody, PanelHeading } from "~/components/ui/Panel";
 
 /**
  * 部屋割りグリッド (旧 .old-thymeleaf/templates/village/situation.html の room
- * 部分を React に移植したもの)。
+ * 部分を React に移植したもの)。Step 13c で旧 BS3 .panel.panel-default + room
+ * セルの見た目 (border / selected-room の mint border) に揃えた。
  *
  * 表示条件: 村の `roomWidth` が確定済 (= プロローグ終了後) かつ `day > 0`。
  * `village.participants.list` のうち `roomNumber` が割り当てられたものを対象に、
  * `roomWidth` 列のグリッドへ並べる。見学者と退村済は除外。
  *
  * 死亡者は半透明 + `<dead.day>d <記号>` を重ねる (記号: 襲撃系=▲ / 処刑=▼ /
- * 突然=凸 / 後追=❤ / MISERABLE=▲)。進行中の無惨死は backend が code/name を
- * `MISERABLE` / `無惨` に統一して返すので、フロントは MISERABLE → ▲ で扱う。
+ * 突然=凸 / 後追=ハート icon / MISERABLE=▲)。
+ * 進行中の無惨死は backend が code/name を `MISERABLE` / `無惨` に統一して返すので、
+ * フロントは MISERABLE → ▲ で扱う。
  *
  * 死亡判定は backend が現状 (最新日基準) で返す `dead` (= DeadView | null) を
  * 使う (任意の日の生死再現は範囲外、12c 以降)。
@@ -32,19 +36,23 @@ export function RoomGridPanel({
   if (roomed.length === 0) return null;
 
   return (
-    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
-      <h2 className="text-sm text-slate-400 mb-3">部屋割り</h2>
-      <div
-        className="grid gap-2"
-        style={{
-          gridTemplateColumns: `repeat(${village.roomWidth}, minmax(0, 1fr))`,
-        }}
-      >
-        {roomed.map((p) => (
-          <RoomCell key={p.id} participant={p} />
-        ))}
-      </div>
-    </section>
+    <Panel>
+      <PanelHeading>
+        <h2 className="text-sm m-0">部屋割り</h2>
+      </PanelHeading>
+      <PanelBody>
+        <div
+          className="grid gap-[2px]"
+          style={{
+            gridTemplateColumns: `repeat(${village.roomWidth}, minmax(0, 1fr))`,
+          }}
+        >
+          {roomed.map((p) => (
+            <RoomCell key={p.id} participant={p} />
+          ))}
+        </div>
+      </PanelBody>
+    </Panel>
   );
 }
 
@@ -55,11 +63,9 @@ function RoomCell({ participant }: { participant: VillageParticipantView }) {
     : "--";
   return (
     <div
-      className={
-        "relative flex flex-col items-center justify-end rounded border border-slate-700 bg-slate-900/40 p-1 " +
-        (dead ? "opacity-40" : "")
-      }
+      className="relative flex flex-col items-center justify-end border border-night-700 bg-night-900 p-1"
       title={participant.name}
+      style={dead ? { opacity: 0.5 } : undefined}
     >
       <img
         src={participant.chara.defaultImageUrl}
@@ -70,11 +76,12 @@ function RoomCell({ participant }: { participant: VillageParticipantView }) {
         className="shrink-0"
         style={{ maxWidth: 60, maxHeight: 60, width: "auto", height: "auto" }}
       />
-      <div className="text-[10px] font-mono text-center leading-tight text-slate-200 mt-0.5">
+      <div className="text-[0.85em] font-mono text-center leading-tight mt-0.5">
         <span>{room} {participant.chara.shortName}</span>
         {dead && (
-          <span className="block text-rose-300">
-            {dead.day}d {deadMarkOf(dead.code)}
+          <span className="flex items-center justify-center gap-0.5 mt-0.5">
+            <span>{dead.day}d</span>
+            <DeadMark code={dead.code} />
           </span>
         )}
       </div>
@@ -85,19 +92,21 @@ function RoomCell({ participant }: { participant: VillageParticipantView }) {
 /**
  * `CDef.DeadReason` の code (または backend の合成コード MISERABLE) から旧画面
  * 表記の記号を返す。
- * 旧 situation.html (line 80) の三項演算子は `EXECUTE → ▼`, `SUDDON → 凸`,
- * `SUICIDE → ❤︎`, それ以外 (襲撃系) → `▲`。襲撃系 (`ATTACK / DIVINED /
- * TRAPPED / BOMBED / ZAKO`) と `MISERABLE` (進行中マスク) を明示列挙して同じ ▲ にする。
- * 不明 code も安全側に倒して `▲` (= 何らかの無惨な死) として扱う。
+ * 旧 situation.html (line 80) の三項演算子: `EXECUTE → ▼`, `SUDDON → 凸`,
+ * `SUICIDE → ❤︎` (heart-icon に置換), それ以外 (襲撃系) → `▲`。
+ *
+ * 旧画面では `❤︎` は絵文字だったが、13a で「絵文字使用禁止」が方針として決まっている
+ * ため heroicons の HeartIcon に置換する。
  */
-function deadMarkOf(code: string): string {
+function DeadMark({ code }: { code: string }) {
   switch (code) {
     case "EXECUTE":
-      return "▼";
-    case "SUDDON": // backend の DeadReason 突然 の code は「SUDDON」(spelling は backend 既存)
-      return "凸";
+      return <span>▼</span>;
+    case "SUDDON":
+      // backend の DeadReason 突然 の code は「SUDDON」(spelling は backend 既存)
+      return <span>凸</span>;
     case "SUICIDE":
-      return "❤";
+      return <HeartIcon className="inline-block w-[1em] h-[1em] text-blood-500" aria-label="後追" />;
     // 旧画面で同色 (#ff0000) 扱いだった襲撃系。記号は ATTACK 含め全て ▲ に揃える。
     // MISERABLE は進行中マスクの合成コード (backend が無惨死を統一して返す)。
     case "ATTACK":
@@ -106,8 +115,8 @@ function deadMarkOf(code: string): string {
     case "BOMBED":
     case "ZAKO":
     case "MISERABLE":
-      return "▲";
+      return <span>▲</span>;
     default:
-      return "▲";
+      return <span>▲</span>;
   }
 }

--- a/frontend/app/features/village/detail/RpActions.tsx
+++ b/frontend/app/features/village/detail/RpActions.tsx
@@ -7,6 +7,7 @@ import {
   useFaceTypesQuery,
   useMemoMutation,
 } from "./hooks";
+import { Panel, PanelBody, PanelHeading } from "~/components/ui/Panel";
 
 /**
  * RP 系 (キャラ名 / 簡易メモ / 表情差分) の編集パネル。
@@ -36,12 +37,18 @@ export function RpActions({
   if (!showChangeName && !showMemo && !showFaceType) return null;
 
   return (
-    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4 space-y-4">
-      <h2 className="text-sm text-slate-400">RP</h2>
-      {showChangeName && <ChangeNameForm villageId={village.id} myself={myself} />}
-      {showMemo && <MemoForm villageId={village.id} myself={myself} />}
-      {showFaceType && <FaceTypesForm villageId={village.id} />}
-    </section>
+    <Panel>
+      <PanelHeading>
+        <h2 className="text-sm m-0">RP</h2>
+      </PanelHeading>
+      <PanelBody>
+        <div className="space-y-4">
+          {showChangeName && <ChangeNameForm villageId={village.id} myself={myself} />}
+          {showMemo && <MemoForm villageId={village.id} myself={myself} />}
+          {showFaceType && <FaceTypesForm villageId={village.id} />}
+        </div>
+      </PanelBody>
+    </Panel>
   );
 }
 
@@ -74,8 +81,8 @@ function ChangeNameForm({ villageId, myself }: { villageId: number; myself: Myse
   const dirty = name !== myself.charaName || shortName !== myself.charaShortName;
 
   return (
-    <form onSubmit={submit} className="space-y-2 first:border-t-0 first:pt-0 border-t border-slate-700/60 pt-3">
-      <p className="text-xs text-slate-400">キャラ名変更</p>
+    <form onSubmit={submit} className="space-y-2 first:border-t-0 first:pt-0 border-t border-night-700 pt-3">
+      <p className="text-xs opacity-80">キャラ名変更</p>
       <div className="grid grid-cols-[1fr_5rem] gap-2 items-end">
         <Field label="表示名 (40 文字以内)">
           <input
@@ -107,7 +114,7 @@ function ChangeNameForm({ villageId, myself }: { villageId: number; myself: Myse
           {mutation.isPending ? "送信中..." : "名前を変更"}
         </button>
         {mutation.isError && (
-          <span className="text-xs text-rose-300">{mutation.error.message}</span>
+          <span className="text-xs text-blood-500">{mutation.error.message}</span>
         )}
       </div>
     </form>
@@ -136,8 +143,8 @@ function MemoForm({ villageId, myself }: { villageId: number; myself: MyselfView
   const dirty = memo !== (myself.memo ?? "");
 
   return (
-    <form onSubmit={submit} className="space-y-2 border-t border-slate-700/60 pt-3">
-      <p className="text-xs text-slate-400">簡易メモ ({MEMO_MAX_LENGTH} 文字以内、自分しか見えない)</p>
+    <form onSubmit={submit} className="space-y-2 border-t border-night-700 pt-3">
+      <p className="text-xs opacity-80">簡易メモ ({MEMO_MAX_LENGTH} 文字以内、自分しか見えない)</p>
       <input
         type="text"
         value={memo}
@@ -155,11 +162,11 @@ function MemoForm({ villageId, myself }: { villageId: number; myself: MyselfView
         >
           {mutation.isPending ? "送信中..." : "メモを保存"}
         </button>
-        <span className="text-xs text-slate-500">
+        <span className="text-xs opacity-60">
           {memo.length} / {MEMO_MAX_LENGTH}
         </span>
         {mutation.isError && (
-          <span className="text-xs text-rose-300">{mutation.error.message}</span>
+          <span className="text-xs text-blood-500">{mutation.error.message}</span>
         )}
       </div>
     </form>
@@ -207,22 +214,22 @@ function FaceTypesForm({ villageId }: { villageId: number }) {
     items.every((it) => it.name.trim().length >= 1 && it.name.trim().length <= 5);
 
   return (
-    <div className="space-y-4 border-t border-slate-700/60 pt-3">
+    <div className="space-y-4 border-t border-night-700 pt-3">
       <form onSubmit={submit} className="space-y-3">
-        <p className="text-xs text-slate-400">表情差分編集</p>
-        {query.isLoading && <p className="text-slate-400 text-sm">読み込み中...</p>}
+        <p className="text-xs opacity-80">表情差分編集</p>
+        {query.isLoading && <p className="opacity-80 text-sm">読み込み中...</p>}
         {query.isError && (
-          <p className="text-rose-300 text-sm">表情差分の取得に失敗しました</p>
+          <p className="text-blood-500 text-sm">表情差分の取得に失敗しました</p>
         )}
         {query.data && items.length === 0 && (
-          <p className="text-slate-400 text-sm">編集可能な表情差分がありません</p>
+          <p className="opacity-80 text-sm">編集可能な表情差分がありません</p>
         )}
         {items.length > 0 && (
           <ul className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             {items.map((it, idx) => (
               <li
                 key={it.code}
-                className="flex gap-3 items-start rounded border border-slate-700 p-2 bg-slate-900/40"
+                className="flex gap-3 items-start rounded-[3px] border border-night-700 p-2 bg-night-900"
               >
                 <img
                   src={it.url}
@@ -241,7 +248,7 @@ function FaceTypesForm({ villageId }: { villageId: number }) {
                     placeholder="表情名 (1-5 文字)"
                     disabled={mutation.isPending}
                   />
-                  <label className="flex items-center gap-1 text-xs text-slate-300">
+                  <label className="flex items-center gap-1 text-xs opacity-90">
                     <input
                       type="checkbox"
                       checked={it.isDisplay}
@@ -264,7 +271,7 @@ function FaceTypesForm({ villageId }: { villageId: number }) {
             {mutation.isPending ? "送信中..." : "表情差分を更新"}
           </button>
           {mutation.isError && (
-            <span className="text-xs text-rose-300">{mutation.error.message}</span>
+            <span className="text-xs text-blood-500">{mutation.error.message}</span>
           )}
         </div>
       </form>
@@ -320,9 +327,9 @@ function AddFaceTypeForm({ villageId }: { villageId: number }) {
   }
 
   return (
-    <form onSubmit={submit} className="space-y-2 border-t border-slate-700/40 pt-3">
-      <p className="text-xs text-slate-400">表情差分追加</p>
-      <ul className="text-xs text-slate-500 list-disc pl-4 space-y-0.5">
+    <form onSubmit={submit} className="space-y-2 border-t border-night-700 pt-3">
+      <p className="text-xs opacity-80">表情差分追加</p>
+      <ul className="text-xs opacity-60 list-disc pl-4 space-y-0.5">
         <li>表情差分名は 1〜5 文字。</li>
         <li>画像は 60x60px で表示されるため 60 の倍数解像度推奨。</li>
         <li>100KB を超える画像はアップロードできません。</li>
@@ -347,12 +354,12 @@ function AddFaceTypeForm({ villageId }: { villageId: number }) {
             accept={FACE_TYPE_IMAGE_ACCEPT}
             onChange={onFileChange}
             disabled={mutation.isPending}
-            className="text-xs text-slate-200 file:mr-2 file:rounded file:border-0 file:bg-slate-700 file:px-2 file:py-1 file:text-slate-100 hover:file:bg-slate-600 disabled:opacity-50"
+            className="text-xs file:mr-2 file:rounded-[3px] file:border-0 file:bg-night-700 file:px-2 file:py-1 file:text-white hover:file:bg-night-600 disabled:opacity-50"
           />
         </Field>
       </div>
       {image != null && !imageValid && (
-        <p className="text-xs text-rose-300">
+        <p className="text-xs text-blood-500">
           {!imageExtValid
             ? "対応形式は png / jpg / jpeg / gif / webp のみです"
             : image.size === 0
@@ -369,7 +376,7 @@ function AddFaceTypeForm({ villageId }: { villageId: number }) {
           {mutation.isPending ? "送信中..." : "表情差分を追加"}
         </button>
         {mutation.isError && (
-          <span className="text-xs text-rose-300">{mutation.error.message}</span>
+          <span className="text-xs text-blood-500">{mutation.error.message}</span>
         )}
       </div>
     </form>
@@ -379,16 +386,18 @@ function AddFaceTypeForm({ villageId }: { villageId: number }) {
 // ---------- 部品 ----------
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  // ChangeName / FaceTypes フォーム内で grid-cols-[1fr_5rem] / grid-cols-[1fr_auto] と
+  // 組み合わせて使うため、ここでは form-horizontal にせず縦積みのまま (ラベル + コントロール)。
   return (
     <div className="space-y-1">
-      <label className="text-xs text-slate-400">{label}</label>
+      <label className="text-[0.95em] opacity-80">{label}</label>
       {children}
     </div>
   );
 }
 
 const inputClass =
-  "w-full bg-slate-900 border border-slate-700 rounded px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:outline-none focus:border-indigo-500 disabled:opacity-50";
+  "w-full bg-night-900 border border-night-700 rounded-[3px] px-2 py-1 text-[1em] focus:outline-none focus:border-mint-500 disabled:opacity-50";
 
 const primaryButtonClass =
-  "rounded bg-indigo-500 hover:bg-indigo-400 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium";
+  "px-[9px] py-[6px] rounded-[3px] border-2 border-bs-success-600 bg-bs-success-500 text-white text-[13px] hover:bg-bs-success-700 hover:border-bs-success-700 disabled:opacity-50 disabled:cursor-not-allowed";

--- a/frontend/app/features/village/detail/SayForm.tsx
+++ b/frontend/app/features/village/detail/SayForm.tsx
@@ -2,23 +2,22 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { MyselfSayMessageTypeView, MyselfView } from "./api";
 import { useSayMutation } from "./hooks";
 import { useSayAnchorSubscription } from "./SayFormContext";
+import { Panel, PanelBody, PanelHeading } from "~/components/ui/Panel";
 
 const SECRET_SAY_CODE = "SECRET_SAY";
 
 /**
- * 発言フォーム (Step 12d で旧 Thymeleaf `say-form.html` 相当を React に復元)。
+ * 発言フォーム (Step 12d で旧 Thymeleaf `say-form.html` 相当を React に復元 →
+ * Step 13c で旧 BS3 .btn-saytypes / .btn-dark-success のスタイルに揃えた)。
  *
- * - 発言種別タブ (myself.say.availableMessageTypes)
+ * - 発言種別タブ (myself.say.availableMessageTypes) → 旧 .btn-saytypes
  * - 表情差分セレクタ (myself.say.selectableFaceTypes、選択中の画像をプレビュー)
- * - 装飾タグボタン (二重タグ / 色タグ / 単発タグ)
+ * - 装飾タグボタン (太字 / 取消 / 大 / 小 / ルビ / 隠 / 透 / 色 7 種 / 単発 [[]])
  * - アンカー自動入力 (MessageCard クリック → SayFormContext 経由で `>>N\n` 挿入)
  * - 返信ボタン (秘話なら messageType=SECRET_SAY + 宛先 auto-set)
  * - 秘話宛先セレクタ
  * - 変換無効チェック
- * - 残り回数 / 文字数表示 + submit ガード
- *
- * 表示判定 (= 親側で SayForm 自体を出すか) は `myself.say.isAvailableSay && availableMessageTypes 非空`
- * を呼び出し側でチェックしてもらう前提。
+ * - 残り回数 / 文字数 / 行数表示 + submit ガード
  */
 export function SayForm({
   villageId,
@@ -43,10 +42,6 @@ export function SayForm({
   );
   const [convertDisable, setConvertDisable] = useState(false);
   const [secretTargetCharaId, setSecretTargetCharaId] = useState<number | "">("");
-  // テキスト挿入後にカーソル位置を確実に DOM へ反映するため、React の commit 後に
-  // 動く `useLayoutEffect` で setSelectionRange する。`requestAnimationFrame` だと
-  // concurrent mode 下で稀に setText の commit より前に走り、カーソル位置が
-  // ずれることがあるため避ける。
   const [pendingCursor, setPendingCursor] = useState<number | null>(null);
   useLayoutEffect(() => {
     if (pendingCursor == null) return;
@@ -57,24 +52,18 @@ export function SayForm({
     setPendingCursor(null);
   }, [pendingCursor, text]);
 
-  // myself が更新されて (= 役職判明 / 死亡 等) 現在の messageTypeCode が消えたら
-  // デフォルトに切り替える。発言種別を変えた選択は維持したいので、まだ available
-  // ならそのまま残す。
   useEffect(() => {
     if (availableTypes.find((t) => t.code === messageTypeCode)) return;
     setMessageTypeCode(defaultType?.code ?? "NORMAL_SAY");
   }, [availableTypes, defaultType, messageTypeCode]);
 
-  // 表情差分も同様: 現選択が消えたら先頭に戻す
   useEffect(() => {
     if (myself.say.selectableFaceTypes.find((f) => f.code === faceTypeCode)) return;
     setFaceTypeCode(myself.say.selectableFaceTypes[0]?.code ?? "");
   }, [myself.say.selectableFaceTypes, faceTypeCode]);
 
-  // アンカー / 返信を受け取って textarea 末尾に挿入
   useSayAnchorSubscription((req) => {
     if (req.isSecret) {
-      // 秘話への返信: messageType を SECRET_SAY に切替、宛先も auto-set
       if (availableTypes.find((t) => t.code === SECRET_SAY_CODE)) {
         setMessageTypeCode(SECRET_SAY_CODE);
         if (req.secretTargetCharaId != null) {
@@ -93,7 +82,6 @@ export function SayForm({
   const isSecret = messageTypeCode === SECRET_SAY_CODE;
   const secretSayTargets = myself.say.secretSayTargets;
 
-  // 残り回数: 制限ありで remainingCount == 0 のときは disable
   const remainingCount = currentTypeInfo?.remainingCount ?? null;
   const maxCount = currentTypeInfo?.maxCount ?? null;
   const maxLength = currentTypeInfo?.maxLength ?? 400;
@@ -123,15 +111,12 @@ export function SayForm({
     let nextCursor: number;
     if (kind === "double") {
       inserted = `[[${tag}]]${selected}[[/${tag}]]`;
-      // 選択あり → 挿入後の選択範囲末尾、無し → 開きタグ直後
       nextCursor = selected.length > 0 ? start + inserted.length : start + `[[${tag}]]`.length;
     } else {
-      // 単発タグ ([[...]] を 1 つだけ挿入。`tag` が空なら `[[]]` を挿入する旧画面踏襲)
       inserted = `[[${tag}]]`;
       nextCursor = start + inserted.length;
     }
     setText(before + inserted + after);
-    // commit 後に確実に setSelectionRange するため useLayoutEffect 経由で位置反映
     setPendingCursor(nextCursor);
   }
 
@@ -150,130 +135,132 @@ export function SayForm({
       {
         onSuccess: () => {
           setText("");
-          // 秘話宛先は連続で同じ相手に送ることが多いので維持する (旧画面踏襲)
         },
       },
     );
   }
 
   return (
-    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
-      <h2 className="text-sm text-slate-400 mb-2">発言</h2>
-
-      {/* 発言種別タブ */}
-      <div role="radiogroup" aria-label="発言種別" className="flex flex-wrap gap-1 mb-2">
-        {availableTypes.map((t) => (
-          <MessageTypeButton
-            key={t.code}
-            type={t}
-            active={t.code === messageTypeCode}
-            onSelect={() => setMessageTypeCode(t.code)}
-          />
-        ))}
-      </div>
-
-      {/* 秘話宛先 (秘話選択時のみ) */}
-      {isSecret && (
-        <div className="mb-2">
-          <label className="block text-xs text-slate-400 mb-1">秘話相手</label>
-          <select
-            value={secretTargetCharaId}
-            onChange={(e) =>
-              setSecretTargetCharaId(e.target.value === "" ? "" : Number(e.target.value))
-            }
-            className="w-full bg-slate-900 border border-slate-700 rounded px-2 py-1 text-sm text-slate-100"
-          >
-            <option value="">秘話相手を選択してください</option>
-            {secretSayTargets.map((t) => (
-              <option key={t.charaId} value={t.charaId}>
-                {t.name}
-              </option>
-            ))}
-          </select>
-        </div>
-      )}
-
-      {/* 装飾タグ */}
-      <DecorationTagBar onInsert={insertTag} />
-
-      <form onSubmit={submit} className="space-y-2">
-        <div className="flex gap-2">
-          {/* キャラ画像プレビュー + 表情差分セレクタ */}
-          {myself.say.selectableFaceTypes.length > 0 && (
-            <div className="flex flex-col items-stretch shrink-0 w-32">
-              <img
-                src={
-                  myself.say.selectableFaceTypes.find((f) => f.code === faceTypeCode)?.url ??
-                  myself.say.selectableFaceTypes[0]?.url
-                }
-                alt={faceTypeCode}
-                loading="lazy"
-                className="rounded border border-slate-700 max-w-full"
-                style={{ maxHeight: 120, width: "auto", height: "auto" }}
-              />
-              <select
-                value={faceTypeCode}
-                onChange={(e) => setFaceTypeCode(e.target.value)}
-                className="mt-1 bg-slate-900 border border-slate-700 rounded px-1 py-0.5 text-xs text-slate-100"
-              >
-                {myself.say.selectableFaceTypes.map((f) => (
-                  <option key={f.code} value={f.code}>
-                    {f.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
-
-          <textarea
-            ref={textareaRef}
-            value={text}
-            onChange={(e) => setText(e.target.value)}
-            rows={6}
-            placeholder={`発言を入力 (${maxLength} 文字以内)`}
-            className="flex-1 bg-slate-900 border border-slate-700 rounded px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:outline-none focus:border-indigo-500"
-            disabled={sayMutation.isPending}
-          />
-        </div>
-
-        {/* 文字数 / 行数 / 残り回数 */}
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-400">
-          <span className={isOverLength ? "text-rose-300" : ""}>
-            文字数 {text.length} / {maxLength}
-          </span>
-          <span className={isOverLine ? "text-rose-300" : ""}>
-            行数 {lineCount} / {maxLine}
-          </span>
-          {remainingCount != null && maxCount != null && (
-            <span className={remainingCount === 0 ? "text-rose-300" : ""}>
-              残り {remainingCount} / {maxCount} 回
-            </span>
-          )}
-          <label className="ml-auto flex items-center gap-1 text-slate-300 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={convertDisable}
-              onChange={(e) => setConvertDisable(e.target.checked)}
-              className="accent-indigo-500"
+    <Panel>
+      <PanelHeading>
+        <h2 className="text-sm m-0">発言</h2>
+      </PanelHeading>
+      <PanelBody>
+        {/* 発言種別タブ (旧 .btn-saytypes 相当) */}
+        <div role="radiogroup" aria-label="発言種別" className="flex flex-wrap gap-[2px] mb-1">
+          {availableTypes.map((t) => (
+            <MessageTypeButton
+              key={t.code}
+              type={t}
+              active={t.code === messageTypeCode}
+              onSelect={() => setMessageTypeCode(t.code)}
             />
-            装飾・変換無効
-          </label>
+          ))}
         </div>
 
-        <div className="flex items-center gap-3">
-          <button
-            type="submit"
-            disabled={!canSubmit}
-            className="rounded bg-indigo-500 hover:bg-indigo-400 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium"
-          >
-            {sayMutation.isPending ? "送信中..." : submitLabel(messageTypeCode)}
-          </button>
-          {sayMutation.isError && (
-            <span className="text-xs text-rose-300">{sayMutation.error.message}</span>
-          )}
-        </div>
-      </form>
-    </section>
+        {/* 秘話宛先 (秘話選択時のみ) */}
+        {isSecret && (
+          <div className="mb-2">
+            <label className="block text-[0.95em] mb-1">秘話相手</label>
+            <select
+              value={secretTargetCharaId}
+              onChange={(e) =>
+                setSecretTargetCharaId(e.target.value === "" ? "" : Number(e.target.value))
+              }
+              className="w-full bg-night-900 border border-night-700 rounded-[3px] px-2 py-1 text-[1em]"
+            >
+              <option value="">秘話相手を選択してください</option>
+              {secretSayTargets.map((t) => (
+                <option key={t.charaId} value={t.charaId}>
+                  {t.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {/* 装飾タグ */}
+        <DecorationTagBar onInsert={insertTag} />
+
+        <form onSubmit={submit} className="space-y-2">
+          <div className="flex gap-2">
+            {/* キャラ画像プレビュー + 表情差分セレクタ */}
+            {myself.say.selectableFaceTypes.length > 0 && (
+              <div className="flex flex-col items-stretch shrink-0 w-[8em]">
+                <img
+                  src={
+                    myself.say.selectableFaceTypes.find((f) => f.code === faceTypeCode)?.url ??
+                    myself.say.selectableFaceTypes[0]?.url
+                  }
+                  alt={faceTypeCode}
+                  loading="lazy"
+                  className="border border-night-700 max-w-full"
+                  style={{ maxHeight: 120, width: "auto", height: "auto" }}
+                />
+                <select
+                  value={faceTypeCode}
+                  onChange={(e) => setFaceTypeCode(e.target.value)}
+                  className="mt-1 bg-night-900 border border-night-700 rounded-[3px] px-1 py-0.5 text-[0.95em]"
+                >
+                  {myself.say.selectableFaceTypes.map((f) => (
+                    <option key={f.code} value={f.code}>
+                      {f.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            <textarea
+              ref={textareaRef}
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              rows={6}
+              placeholder={`発言を入力 (${maxLength} 文字以内)`}
+              className="flex-1 bg-night-900 border border-night-700 rounded-[3px] px-2 py-1.5 text-[1em] focus:outline-none focus:border-mint-500"
+              disabled={sayMutation.isPending}
+            />
+          </div>
+
+          {/* 文字数 / 行数 / 残り回数 (旧画面では右下に並んでいた) */}
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[0.95em]">
+            <span className={isOverLength ? "text-blood-500" : ""}>
+              文字数 {text.length} / {maxLength}
+            </span>
+            <span className={isOverLine ? "text-blood-500" : ""}>
+              行数 {lineCount} / {maxLine}
+            </span>
+            {remainingCount != null && maxCount != null && (
+              <span className={remainingCount === 0 ? "text-blood-500" : ""}>
+                残り {remainingCount} / {maxCount} 回
+              </span>
+            )}
+            <label className="ml-auto flex items-center gap-1 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={convertDisable}
+                onChange={(e) => setConvertDisable(e.target.checked)}
+                className="accent-mint-600"
+              />
+              装飾・変換無効
+            </label>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className="px-[9px] py-[6px] rounded-[3px] border-2 border-bs-success-600 bg-bs-success-500 text-white text-[13px] hover:bg-bs-success-700 hover:border-bs-success-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {sayMutation.isPending ? "送信中..." : submitLabel(messageTypeCode)}
+            </button>
+            {sayMutation.isError && (
+              <span className="text-[0.95em] text-blood-500">{sayMutation.error.message}</span>
+            )}
+          </div>
+        </form>
+      </PanelBody>
+    </Panel>
   );
 }
 
@@ -286,27 +273,24 @@ function MessageTypeButton({
   active: boolean;
   onSelect: () => void;
 }) {
+  // 旧 .btn-saytypes .btn-success: dark bg #222222 + mint border + mint text
+  // active: mint bg + white text
+  const base =
+    "px-[9px] py-[5px] rounded-[3px] border border-mint-600 text-[0.95em] cursor-pointer transition-colors duration-100";
+  const cls = active
+    ? `${base} bg-mint-600 text-white`
+    : `${base} bg-night-500 text-mint-600 hover:bg-mint-600 hover:text-white`;
   return (
-    <button
-      type="button"
-      role="radio"
-      aria-checked={active}
-      onClick={onSelect}
-      className={`px-2 py-1 rounded border text-xs ${
-        active
-          ? "bg-indigo-500 border-indigo-400 text-white"
-          : "bg-slate-900 border-slate-700 text-slate-300 hover:border-slate-500"
-      }`}
-    >
+    <button type="button" role="radio" aria-checked={active} onClick={onSelect} className={cls}>
       {type.name}
     </button>
   );
 }
 
 /**
- * 旧 say-form.html の `data-tag-type=double / single` ボタン群を Tailwind に移植。
+ * 旧 say-form.html `data-tag-type=double / single` ボタン群。
  * クリックで textarea の選択範囲を `[[<tag>]]...[[/<tag>]]` でラップ (色タグは tag に
- * `#ff0000` 等が入る)。`single` は `[[]]` を 1 つ挿入するだけ。
+ * `#ff0000` 等が入る)。`single` は `[[]]` を 1 つだけ挿入する。
  */
 function DecorationTagBar({
   onInsert,
@@ -325,12 +309,10 @@ function DecorationTagBar({
       {["#ff0000", "#ff8800", "#dddd00", "#00dd00", "#00dddd", "#0000ff", "#ee00ee"].map((c) => (
         <ColorTagBtn key={c} color={c} onInsert={onInsert} />
       ))}
-      {/* 単発 [[]] (旧画面の data-tag-type=single, data-tag-name=""): カーソル位置に
-          [[]] を挿入。ランダムタグ等を後から書く起点として使う */}
       <button
         type="button"
         onClick={() => onInsert("", "single")}
-        className="px-2 py-0.5 rounded border bg-slate-900 border-slate-700 text-slate-300 hover:border-slate-500 text-xs"
+        className="px-2 py-0.5 rounded-[3px] border border-night-700 bg-night-900 text-[0.95em] hover:border-mint-500"
         title="[[]] を挿入"
       >
         [[]]
@@ -358,7 +340,7 @@ function TagBtn({
     <button
       type="button"
       onClick={() => onInsert(tag, kind)}
-      className={`px-2 py-0.5 rounded border bg-slate-900 border-slate-700 text-slate-300 hover:border-slate-500 text-xs ${
+      className={`px-2 py-0.5 rounded-[3px] border border-night-700 bg-night-900 text-[0.95em] hover:border-mint-500 ${
         bold ? "font-bold" : ""
       } ${strike ? "line-through" : ""}`}
       title={`[[${tag}]]...[[/${tag}]]`}
@@ -379,7 +361,7 @@ function ColorTagBtn({
     <button
       type="button"
       onClick={() => onInsert(color, "double")}
-      className="w-6 h-6 rounded border border-slate-700 hover:border-slate-400"
+      className="w-6 h-6 rounded-[3px] border border-night-700 hover:border-night-300"
       style={{ backgroundColor: color }}
       title={`[[${color}]]...[[/${color}]]`}
       aria-label={`色タグ ${color}`}
@@ -406,11 +388,8 @@ function submitLabel(typeCode: string): string {
     case "SPECTATE_SAY":
       return "見学発言";
     case "ACTION":
-      // アクション発言は専用 UI (旧 ActionPanel 相当) が未実装で、本 SayForm の
-      // 種別タブには通常出ない想定。万一 backend が含めて返した場合は汎用ラベルで動く
       return "アクション";
     default:
       return "発言する";
   }
 }
-

--- a/frontend/app/features/village/detail/SituationPanel.tsx
+++ b/frontend/app/features/village/detail/SituationPanel.tsx
@@ -5,10 +5,13 @@ import type {
   VillageSituationView,
   VillageSituationVoteMemberView,
 } from "./api";
+import { Panel, PanelBody, PanelHeading } from "~/components/ui/Panel";
+import { Table, TableResponsive } from "~/components/ui/Table";
 
 /**
  * 旧 .old-thymeleaf/templates/village/situation.html の "状況 / 投票 / 足音 (日別)"
- * タブ相当を React に復元。
+ * タブ相当を React に復元。Step 13c で Panel + Table primitive に揃え、旧 BS3
+ * .panel.panel-default + .table-bordered.table-condensed.small の見た目に寄せた。
  *
  * 表示順: 状況テーブル → 投票テーブル → 日別足音 (旧画面と同じ順)。
  *
@@ -23,8 +26,6 @@ export function SituationPanel({
   situation: VillageSituationView | null;
   selectedDay: number;
 }) {
-  // React hooks の順序固定のため、useMemo は早期 return より前で呼ぶ。
-  // situation == null のときも空配列扱いで evaluate して問題ない (重い処理ではない)。
   const visibleWhole = useMemo(
     () => (situation ? situation.whole.filter((d) => d.day <= selectedDay) : []),
     [situation, selectedDay],
@@ -35,31 +36,32 @@ export function SituationPanel({
   );
 
   if (!situation) return null;
-  // 旧画面と同じく、`day = 0` (プロローグ) では何も意味ある情報がない (= テーブル全部空) ので
-  // パネルごと非表示にする。
   if (selectedDay <= 0) return null;
 
   const hasWhole = visibleWhole.length > 0;
   // 投票は前日に行われ翌日処刑なので、`selectedDay >= 3` ではじめて表示可能な投票が
-  // 1 つでも存在する (= 2d 投票結果が公開できる)。`VoteTable` の内部判定と
-  // 整合させ、`selectedDay <= 2` のときは「状況」セクションに投票表が無いだけで
-  // whole / dayFootsteps があれば表示する。
+  // 1 つでも存在する (= 2d 投票結果が公開できる)。
   const hasVote =
     situation.vote.list.length > 0 &&
     situation.vote.maxVoteCount > 0 &&
     selectedDay >= 3;
   const hasDayFootsteps = visibleDayFootsteps.some((d) => d.footstep.trim().length > 0);
 
-  // 3 サブブロックいずれも内容なしならパネル自体出さない。
   if (!hasWhole && !hasVote && !hasDayFootsteps) return null;
 
   return (
-    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4 space-y-5">
-      <h2 className="text-sm text-slate-400">状況</h2>
-      {hasWhole && <WholeTable rows={visibleWhole} />}
-      {hasVote && <VoteTable vote={situation.vote} selectedDay={selectedDay} />}
-      {hasDayFootsteps && <DayFootstepsTable rows={visibleDayFootsteps} />}
-    </section>
+    <Panel>
+      <PanelHeading>
+        <h2 className="text-sm m-0">状況</h2>
+      </PanelHeading>
+      <PanelBody>
+        <div className="space-y-3">
+          {hasWhole && <WholeTable rows={visibleWhole} />}
+          {hasVote && <VoteTable vote={situation.vote} selectedDay={selectedDay} />}
+          {hasDayFootsteps && <DayFootstepsTable rows={visibleDayFootsteps} />}
+        </div>
+      </PanelBody>
+    </Panel>
   );
 }
 
@@ -69,46 +71,40 @@ function WholeTable({ rows }: { rows: VillageSituationDayView[] }) {
   // で判定する (= dispSpoilerContent 相当)。
   const hasAbility = rows.some((r) => r.ability.length > 0);
   return (
-    <div className="overflow-x-auto">
-      <h3 className="text-xs text-slate-400 mb-1">日次状況</h3>
-      <table className="min-w-full text-xs border-collapse">
-        <thead>
-          <tr className="text-slate-400">
-            <th className="border border-slate-700 px-2 py-1 text-center w-12">日付</th>
-            <th className="border border-slate-700 px-2 py-1 text-left">突然死</th>
-            <th className="border border-slate-700 px-2 py-1 text-left">処刑</th>
-            <th className="border border-slate-700 px-2 py-1 text-left">無惨</th>
-            <th className="border border-slate-700 px-2 py-1 text-left">復活</th>
-            <th className="border border-slate-700 px-2 py-1 text-left">後追</th>
-            {hasAbility && (
-              <th className="border border-slate-700 px-2 py-1 text-left">能力</th>
-            )}
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((r) => (
-            <tr key={r.day}>
-              <td className="border border-slate-700 px-2 py-1 text-center text-slate-300">
-                {r.day}d
-              </td>
-              <td className="border border-slate-700 px-2 py-1">{formatList(r.suddenlyDeath)}</td>
-              <td className="border border-slate-700 px-2 py-1">{formatList(r.executed)}</td>
-              <td className="border border-slate-700 px-2 py-1">{formatList(r.miserable)}</td>
-              <td className="border border-slate-700 px-2 py-1">{formatList(r.revival)}</td>
-              <td className="border border-slate-700 px-2 py-1">{formatList(r.suicide)}</td>
-              {hasAbility && (
-                // 能力履歴は backend (`AbilityDomainService.mapAbilitySituation`) が
-                // `[type]from → to` の整形済み文字列を 1 件 1 行で List に詰めて返す。
-                // 他の列 (突然死 / 処刑等) は単純な name list なので `formatList` で
-                // 「、」区切りにするが、ability は 1 件ずつが長い文字列のため改行で並べる。
-                <td className="border border-slate-700 px-2 py-1 whitespace-pre-line">
-                  {r.ability.join("\n")}
-                </td>
-              )}
+    <div>
+      <h3 className="text-[0.95em] mb-1">日次状況</h3>
+      <TableResponsive>
+        <Table>
+          <thead>
+            <tr>
+              <th className="text-center w-12">日付</th>
+              <th>突然死</th>
+              <th>処刑</th>
+              <th>無惨</th>
+              <th>復活</th>
+              <th>後追</th>
+              {hasAbility && <th>能力</th>}
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.day}>
+                <td className="text-center">{r.day}d</td>
+                <td>{formatList(r.suddenlyDeath)}</td>
+                <td>{formatList(r.executed)}</td>
+                <td>{formatList(r.miserable)}</td>
+                <td>{formatList(r.revival)}</td>
+                <td>{formatList(r.suicide)}</td>
+                {hasAbility && (
+                  // 能力履歴は backend (`AbilityDomainService.mapAbilitySituation`) が
+                  // `[type]from → to` の整形済み文字列を 1 件 1 行で List に詰めて返す。
+                  <td className="whitespace-pre-line">{r.ability.join("\n")}</td>
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      </TableResponsive>
     </div>
   );
 }
@@ -125,39 +121,35 @@ function VoteTable({
   vote: VillageSituationView["vote"];
   selectedDay: number;
 }) {
-  // 表示すべき日列を計算: 2d 〜 (selectedDay - 1) まで (= 投票は前日に行われ翌日処刑)
-  // ただし「実際に存在する vote の最大日」も超えないように cap する (旧 `maxVoteCount` 互換)。
   const maxDayInVotes = vote.list.reduce<number>((acc, m) => {
     const dmax = m.voteList.reduce<number>((a, v) => Math.max(a, v.day), 0);
     return Math.max(acc, dmax);
   }, 0);
-  // selectedDay - 1 まで (= 当日 selectedDay で開示できる投票は前日まで)
-  // 例: selectedDay=3 なら 2d 投票結果は確定済みで表示してよい。
   const upperDay = Math.min(maxDayInVotes, Math.max(0, selectedDay - 1));
   if (upperDay < 2) return null;
   const dayCols: number[] = [];
   for (let d = 2; d <= upperDay; d++) dayCols.push(d);
 
   return (
-    <div className="overflow-x-auto">
-      <h3 className="text-xs text-slate-400 mb-1">投票</h3>
-      <table className="min-w-full text-xs border-collapse">
-        <thead>
-          <tr className="text-slate-400">
-            <th className="border border-slate-700 px-2 py-1 text-left">投票者</th>
-            {dayCols.map((d) => (
-              <th key={d} className="border border-slate-700 px-2 py-1 text-center">
-                {d}d
-              </th>
+    <div>
+      <h3 className="text-[0.95em] mb-1">投票</h3>
+      <TableResponsive>
+        <Table>
+          <thead>
+            <tr>
+              <th>投票者</th>
+              {dayCols.map((d) => (
+                <th key={d} className="text-center">{d}d</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {vote.list.map((member) => (
+              <VoteRow key={member.participantId} member={member} dayCols={dayCols} />
             ))}
-          </tr>
-        </thead>
-        <tbody>
-          {vote.list.map((member) => (
-            <VoteRow key={member.participantId} member={member} dayCols={dayCols} />
-          ))}
-        </tbody>
-      </table>
+          </tbody>
+        </Table>
+      </TableResponsive>
     </div>
   );
 }
@@ -169,7 +161,6 @@ function VoteRow({
   member: VillageSituationVoteMemberView;
   dayCols: number[];
 }) {
-  // O(N×M) を避けるため day→target の Map を作る。投票は 1 日 1 回。
   const byDay = useMemo(() => {
     const m = new Map<number, string>();
     for (const cell of member.voteList) m.set(cell.day, cell.targetCharaShortName);
@@ -177,40 +168,32 @@ function VoteRow({
   }, [member.voteList]);
   return (
     <tr>
-      <td className="border border-slate-700 px-2 py-1 text-slate-300 whitespace-nowrap">
-        {member.charaShortName}
-      </td>
+      <td className="whitespace-nowrap">{member.charaShortName}</td>
       {dayCols.map((d) => (
-        <td key={d} className="border border-slate-700 px-2 py-1 text-center text-slate-200">
-          {byDay.get(d) ?? ""}
-        </td>
+        <td key={d} className="text-center">{byDay.get(d) ?? ""}</td>
       ))}
     </tr>
   );
 }
 
-function DayFootstepsTable({
-  rows,
-}: {
-  rows: VillageDayFootstepView[];
-}) {
+function DayFootstepsTable({ rows }: { rows: VillageDayFootstepView[] }) {
   return (
-    <div className="overflow-x-auto">
-      <h3 className="text-xs text-slate-400 mb-1">足音 (日別)</h3>
-      <table className="min-w-full text-xs border-collapse">
-        <tbody>
-          {rows.map((r) => (
-            <tr key={r.day}>
-              <td className="border border-slate-700 px-2 py-1 text-center text-slate-300 w-12">
-                {r.day}d
-              </td>
-              <td className="border border-slate-700 px-2 py-1 whitespace-pre-line">
-                {r.footstep.trim().length > 0 ? r.footstep : "なし"}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <div>
+      <h3 className="text-[0.95em] mb-1">足音 (日別)</h3>
+      <TableResponsive>
+        <Table>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.day}>
+                <td className="text-center w-12">{r.day}d</td>
+                <td className="whitespace-pre-line">
+                  {r.footstep.trim().length > 0 ? r.footstep : "なし"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      </TableResponsive>
     </div>
   );
 }

--- a/frontend/app/features/village/detail/VillageInfoModal.tsx
+++ b/frontend/app/features/village/detail/VillageInfoModal.tsx
@@ -1,10 +1,21 @@
+import * as React from "react";
+import { Link } from "react-router";
 import type { VillageView } from "./api";
+import { Modal } from "~/components/ui/Modal";
+import { Button, LinkButton } from "~/components/ui/Button";
+import { Table, TableResponsive } from "~/components/ui/Table";
 
 /**
  * 旧 .old-thymeleaf/templates/village/modal-village-info.html 相当の村情報モーダル。
  *
- * 設定変更ボタンは creator のみ表示。設定値の表示だけ行うので backend は
- * 既存の `VillageView.settings` (= VillageSettingsView) をそのまま使う。
+ * Step 13c で:
+ * - 旧 Bootstrap 3 .modal-* に揃えるため Modal primitive を使う (createPortal で
+ *   親 opacity の影響を回避済)
+ * - 旧画面と同じ「設定 / RP 設定」2 表 + 発言制限 (通常 / 役職 / RP) 表を復元
+ * - キャラセット (公式なら `/charachips/:id` への内部リンク) + ダミーキャラ名を追加
+ *   (`.issues/20` を同時解消)
+ *
+ * 設定変更ボタンは creator のみ表示する。
  */
 export function VillageInfoModal({
   open,
@@ -15,118 +26,205 @@ export function VillageInfoModal({
   village: VillageView;
   onClose: () => void;
 }) {
-  if (!open) return null;
   const s = village.settings;
   const intervalText = formatInterval(s.dayChangeIntervalSeconds);
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-label="村情報"
-      className="fixed inset-0 z-40 flex items-center justify-center bg-black/60 p-4"
-      onClick={onClose}
-    >
-      <div
-        className="w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-xl bg-slate-900 border border-slate-700 p-5 space-y-3"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between">
-          <h3 className="text-base font-semibold">村情報</h3>
-          <button
-            type="button"
-            className="text-slate-400 hover:text-slate-200 text-sm"
-            onClick={onClose}
-            aria-label="閉じる"
-          >
-            ×
-          </button>
-        </div>
-        <dl className="text-xs grid grid-cols-[10rem_1fr] gap-y-1 gap-x-3">
-          {s.welcomeRangeName && <Row label="募集範囲" value={s.welcomeRangeName} />}
-          <Row label="最少開始人数" value={s.personMin} />
-          <Row label="定員" value={s.personMax} />
-          <Row label="開始日時" value={formatDateTime(s.startDatetime)} />
-          <Row label="更新間隔" value={intervalText} />
-          <Row label="投票形式" value={s.voteTypeName} />
-          <Row
-            label="役職希望"
-            value={s.isSkillRequestAvailable ? "可能" : "不可"}
-          />
-          <Row
-            label="見学入村"
-            value={s.isSpectateAvailable ? "可能" : "不可"}
-          />
-          <Row
-            label="プロデューサー機能"
-            value={s.creatorIsProducer ? "あり" : "なし"}
-          />
-          <Row
-            label="同一人狼連続襲撃"
-            value={s.availableSameWolfAttack ? "可能" : "不可"}
-          />
-          <Row
-            label="狩人連続護衛"
-            value={s.availableGuardSameTarget ? "可能" : "不可"}
-          />
-          <Row
-            label="転生時役職候補"
-            value={s.reincarnationSkillAll ? "全役職" : "編成に含まれる役職のみ"}
-          />
-          <Row
-            label="墓下見学役職公開"
-            value={s.openSkillInGrave ? "公開" : "非公開"}
-          />
-          <Row
-            label="墓下/地上の会話"
-            value={s.visibleGraveSpectateMessage ? "可能" : "不可"}
-          />
-          <Row label="秘話" value={s.allowedSecretSayName} />
-          <Row label="突然死" value={s.availableSuddenlyDeath ? "あり" : "なし"} />
-          <Row label="コミット" value={s.availableCommit ? "あり" : "なし"} />
-          <Row label="アクション発言" value={s.availableAction ? "可能" : "不可"} />
-          {s.ageLimitName && <Row label="年齢制限" value={s.ageLimitName} />}
-          <Row label="入村パスワード" value={s.joinPasswordRequired ? "あり" : "なし"} />
-          <Row label="館を建てたプレイヤー" value={village.createPlayerName} />
-          {!s.isRandomOrganization && s.organization && (
-            <Row
-              label="役職構成"
-              value={
-                <pre className="whitespace-pre-wrap font-sans text-xs">{s.organization}</pre>
-              }
-            />
-          )}
-          {s.isRandomOrganization && (
-            <Row label="役職構成" value="ランダム編成 (闇鍋)" />
-          )}
-        </dl>
-        <div className="flex justify-end gap-2 pt-2 border-t border-slate-700">
+    <Modal open={open} onClose={onClose} title="村情報">
+      <div className="space-y-3">
+        <TableResponsive>
+          <Table>
+            <tbody>
+              {s.welcomeRangeName && <InfoRow label="募集範囲" value={s.welcomeRangeName} />}
+              <InfoRow label="最少開始人数" value={s.personMin} />
+              <InfoRow label="定員" value={s.personMax} />
+              <InfoRow label="開始日時" value={formatDateTime(s.startDatetime)} />
+              <InfoRow label="更新間隔" value={intervalText} />
+              <InfoRow label="投票形式" value={s.voteTypeName} />
+              <InfoRow label="役職希望" value={s.isSkillRequestAvailable ? "可能" : "不可"} />
+              <InfoRow
+                label="見学入村"
+                value={s.isSpectateAvailable ? "可能（[キャラチップ人数 - 定員]人まで）" : "不可"}
+              />
+              <InfoRow label="プロデューサー機能" value={s.creatorIsProducer ? "あり" : "なし"} />
+              <InfoRow
+                label="同一人狼による連続襲撃"
+                value={s.availableSameWolfAttack ? "可能" : "不可 (開始時点で狼2以下編成の場合は可能に変更されます)"}
+              />
+              <InfoRow
+                label="狩人による連続護衛"
+                value={s.availableGuardSameTarget ? "可能" : "不可"}
+              />
+              <InfoRow
+                label="転生時の役職候補"
+                value={s.reincarnationSkillAll ? "全役職" : "編成に含まれる役職のみ"}
+              />
+              <InfoRow label="墓下見学役職公開" value={s.openSkillInGrave ? "公開" : "非公開"} />
+              <InfoRow
+                label="墓下見学と地上との会話"
+                value={s.visibleGraveSpectateMessage ? "可能" : "不可"}
+              />
+              <InfoRow label="秘話" value={s.allowedSecretSayName} />
+              <InfoRow label="突然死" value={s.availableSuddenlyDeath ? "あり" : "なし"} />
+              <InfoRow label="コミット" value={s.availableCommit ? "あり" : "なし"} />
+              <InfoRow
+                label="キャラセット"
+                value={<CharachipList charachips={s.charachips} isOriginal={s.isOriginalCharachip} />}
+              />
+              <InfoRow label="ダミーキャラ" value={s.dummyCharaName} />
+              <InfoRow label="入村パスワード" value={s.joinPasswordRequired ? "あり" : "なし"} />
+              <InfoRow label="館を建てたプレイヤー" value={village.createPlayerName} />
+              {!s.isRandomOrganization && (
+                <InfoRow
+                  label="役職構成"
+                  value={
+                    s.organization ? (
+                      <pre className="whitespace-pre-wrap font-sans m-0">{s.organization}</pre>
+                    ) : (
+                      ""
+                    )
+                  }
+                />
+              )}
+              {s.isRandomOrganization && (
+                <InfoRow label="役職構成（闇鍋）" value="ランダム編成" />
+              )}
+              <InfoRow
+                label="発言制限（通常発言）"
+                value={<NormalSayRestrictTable list={s.sayRestrictList} />}
+              />
+              <InfoRow
+                label="発言制限（役職発言）"
+                value={<MessageTypeRestrictTable list={s.skillSayRestrictList} />}
+              />
+            </tbody>
+          </Table>
+        </TableResponsive>
+
+        <p className="text-[0.95em] mb-1">RP設定</p>
+        <TableResponsive>
+          <Table>
+            <tbody>
+              {s.ageLimitName && <InfoRow label="年齢制限" value={s.ageLimitName} />}
+              <InfoRow label="アクション" value={s.availableAction ? "可能" : "不可"} />
+              {s.availableAction && (
+                <InfoRow
+                  label="発言制限（RP発言）"
+                  value={<MessageTypeRestrictTable list={s.rpSayRestrictList} />}
+                />
+              )}
+            </tbody>
+          </Table>
+        </TableResponsive>
+
+        <p className="text-[0.95em] opacity-80">館を建てたプレイヤーのみ設定を変更できます。</p>
+        <div className="flex justify-end gap-2 pt-1">
           {village.isCreator && (
-            <a
-              href={`/wolf-mansion/villages/${village.id}/settings`}
-              className="rounded bg-emerald-600 hover:bg-emerald-500 px-3 py-1.5 text-sm text-white"
+            <LinkButton
+              to={`/villages/${village.id}/settings`}
+              variant="success"
+              onClick={onClose}
             >
               設定変更
-            </a>
+            </LinkButton>
           )}
-          <button
-            type="button"
-            className="rounded border border-slate-600 px-3 py-1.5 text-sm text-slate-200 hover:bg-slate-800"
-            onClick={onClose}
-          >
-            閉じる
-          </button>
+          <Button variant="default" onClick={onClose}>閉じる</Button>
         </div>
       </div>
+    </Modal>
+  );
+}
+
+function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <tr>
+      <th className="w-[12em] align-top">{label}</th>
+      <td>{value}</td>
+    </tr>
+  );
+}
+
+function CharachipList({
+  charachips,
+  isOriginal,
+}: {
+  charachips: { id: number; name: string }[];
+  isOriginal: boolean;
+}) {
+  if (charachips.length === 0) return <>—</>;
+  return (
+    <>
+      {charachips.map((c, i) => (
+        <React.Fragment key={c.id}>
+          {/* オリジナルキャラチップ村は外部リンクがないので名前だけ表示 (旧画面踏襲) */}
+          {isOriginal ? (
+            <span>{c.name}</span>
+          ) : (
+            <Link to={`/charachips/${c.id}`} className="message-link" target="_blank" rel="noopener noreferrer">
+              {c.name}
+            </Link>
+          )}
+          {i < charachips.length - 1 && <span>、</span>}
+        </React.Fragment>
+      ))}
+    </>
+  );
+}
+
+function NormalSayRestrictTable({
+  list,
+}: {
+  list: { skillCode: string; skillName: string; count: number; length: number }[];
+}) {
+  if (list.length === 0) return <>制限がかかっている役職はありません。</>;
+  return (
+    <div>
+      <p className="m-0 mb-1 text-[0.95em]">制限がかかっている役職のみ表示しています。</p>
+      <Table>
+        <thead>
+          <tr>
+            <th>役職</th>
+            <th>1回あたりの発言文字数 * 1日あたりの発言回数</th>
+          </tr>
+        </thead>
+        <tbody>
+          {list.map((r) => (
+            <tr key={r.skillCode}>
+              <td>{r.skillName}</td>
+              <td>{r.length} * {r.count}</td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
     </div>
   );
 }
 
-function Row({ label, value }: { label: string; value: React.ReactNode }) {
+function MessageTypeRestrictTable({
+  list,
+}: {
+  list: { messageTypeCode: string; messageTypeName: string; count: number; length: number }[];
+}) {
+  if (list.length === 0) return <>制限がかかっている発言種別はありません。</>;
   return (
-    <>
-      <dt className="text-slate-400">{label}</dt>
-      <dd className="text-slate-100 break-all">{value}</dd>
-    </>
+    <div>
+      <p className="m-0 mb-1 text-[0.95em]">制限がかかっている発言種別のみ表示しています。</p>
+      <Table>
+        <thead>
+          <tr>
+            <th>発言種別</th>
+            <th>1回あたりの発言文字数 * 1日あたりの発言回数</th>
+          </tr>
+        </thead>
+        <tbody>
+          {list.map((r) => (
+            <tr key={r.messageTypeCode}>
+              <td>{r.messageTypeName}</td>
+              <td>{r.length} * {r.count}</td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </div>
   );
 }
 

--- a/frontend/app/features/village/detail/VillageInfoModal.tsx
+++ b/frontend/app/features/village/detail/VillageInfoModal.tsx
@@ -72,7 +72,8 @@ export function VillageInfoModal({
               />
               <InfoRow label="ダミーキャラ" value={s.dummyCharaName} />
               <InfoRow label="入村パスワード" value={s.joinPasswordRequired ? "あり" : "なし"} />
-              <InfoRow label="館を建てたプレイヤー" value={village.createPlayerName} />
+              {/* 「館を建てたプレイヤー」は VillageView 直下のフィールドで「設定」では
+                  ないため、設定テーブルから分離して RP 設定テーブルの後に出す。 */}
               {!s.isRandomOrganization && (
                 <InfoRow
                   label="役職構成"
@@ -112,6 +113,14 @@ export function VillageInfoModal({
                   value={<MessageTypeRestrictTable list={s.rpSayRestrictList} />}
                 />
               )}
+            </tbody>
+          </Table>
+        </TableResponsive>
+
+        <TableResponsive>
+          <Table>
+            <tbody>
+              <InfoRow label="館を建てたプレイヤー" value={village.createPlayerName} />
             </tbody>
           </Table>
         </TableResponsive>
@@ -178,12 +187,14 @@ function NormalSayRestrictTable({
   if (list.length === 0) return <>制限がかかっている役職はありません。</>;
   return (
     <div>
-      <p className="m-0 mb-1 text-[0.95em]">制限がかかっている役職のみ表示しています。</p>
+      <p className="m-0 mb-1 text-[0.95em]">
+        制限がかかっている役職のみ表示しています。「文字数 * 回数」は 1 回あたりの発言文字数 × 1 日あたりの発言回数。
+      </p>
       <Table>
         <thead>
           <tr>
             <th>役職</th>
-            <th>1回あたりの発言文字数 * 1日あたりの発言回数</th>
+            <th>文字数 * 回数</th>
           </tr>
         </thead>
         <tbody>
@@ -207,12 +218,14 @@ function MessageTypeRestrictTable({
   if (list.length === 0) return <>制限がかかっている発言種別はありません。</>;
   return (
     <div>
-      <p className="m-0 mb-1 text-[0.95em]">制限がかかっている発言種別のみ表示しています。</p>
+      <p className="m-0 mb-1 text-[0.95em]">
+        制限がかかっている発言種別のみ表示しています。「文字数 * 回数」は 1 回あたりの発言文字数 × 1 日あたりの発言回数。
+      </p>
       <Table>
         <thead>
           <tr>
             <th>発言種別</th>
-            <th>1回あたりの発言文字数 * 1日あたりの発言回数</th>
+            <th>文字数 * 回数</th>
           </tr>
         </thead>
         <tbody>

--- a/frontend/app/features/village/detail/api.ts
+++ b/frontend/app/features/village/detail/api.ts
@@ -87,12 +87,10 @@ export type MessagesQuery = {
 
 export async function fetchVillageMessages(
   villageId: number,
-  query: number | MessagesQuery | undefined,
+  query: MessagesQuery | undefined,
   fetcher: ApiFetch = browserFetch,
 ): Promise<MessagesView> {
-  // 後方互換: 旧シグネチャ (day: number) も受け付ける。
-  const q: MessagesQuery =
-    typeof query === "number" ? { day: query } : (query ?? {});
+  const q: MessagesQuery = query ?? {};
   const params = new URLSearchParams();
   if (typeof q.day === "number") params.set("day", String(q.day));
   if (typeof q.pageSize === "number") params.set("pageSize", String(q.pageSize));

--- a/frontend/app/features/village/detail/hooks.ts
+++ b/frontend/app/features/village/detail/hooks.ts
@@ -85,16 +85,13 @@ export function useVillageQuery(
 /**
  * messages query を filter / paging 付きで取得する。queryKey に query 全体の
  * stable representation を含めるので、フィルタや page が変わると自動で refetch される。
- *
- * 後方互換: 第二引数に number (day) を渡したら `{ day }` と等価に扱う。
  */
 export function useVillageMessagesQuery(
   villageId: number,
-  query: number | MessagesQuery | undefined,
+  query: MessagesQuery | undefined,
   initialData?: MessagesView,
 ): UseQueryResult<MessagesView> {
-  const q: MessagesQuery =
-    typeof query === "number" ? { day: query } : (query ?? {});
+  const q: MessagesQuery = query ?? {};
   // 配列やオプショナルを stable な形に揃える (順序ずれで queryKey が変わるのを防ぐ)。
   const keyPart = {
     day: q.day ?? "latest",

--- a/frontend/app/routes/villages.$id.tsx
+++ b/frontend/app/routes/villages.$id.tsx
@@ -317,9 +317,9 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
     myself.say.availableMessageTypes.length > 0;
 
   const queryClient = useQueryClient();
-  function refreshAll() {
+  const refreshAll = useCallback(() => {
     queryClient.invalidateQueries({ queryKey: ["village", villageId] });
-  }
+  }, [queryClient, villageId]);
 
   return (
     <main className="text-white pb-[60px]">

--- a/frontend/app/routes/villages.$id.tsx
+++ b/frontend/app/routes/villages.$id.tsx
@@ -24,6 +24,7 @@ import {
 import { ActionPanel } from "~/features/village/detail/ActionPanel";
 import { AdminPanel } from "~/features/village/detail/AdminPanel";
 import { CreatorPanel } from "~/features/village/detail/CreatorPanel";
+import { FooterMenuDock } from "~/features/village/detail/FooterMenuDock";
 import { MessageCard } from "~/features/village/detail/MessageCard";
 import { ParticipateActions } from "~/features/village/detail/ParticipateActions";
 import { RoomGridPanel } from "~/features/village/detail/RoomGridPanel";
@@ -40,6 +41,10 @@ import {
 import { VillageInfoModal } from "~/features/village/detail/VillageInfoModal";
 import { useMeQuery } from "~/features/auth/hooks";
 import { ssrFetch } from "~/lib/api/client";
+import { Panel, PanelBody, PanelHeading } from "~/components/ui/Panel";
+import { Button, LinkButton } from "~/components/ui/Button";
+import { VillageTag, villageTagLevel } from "~/components/ui/VillageTag";
+import { useQueryClient } from "@tanstack/react-query";
 
 const PAGE_SIZE = 50;
 
@@ -311,9 +316,14 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
     myself.say.isAvailableSay &&
     myself.say.availableMessageTypes.length > 0;
 
+  const queryClient = useQueryClient();
+  function refreshAll() {
+    queryClient.invalidateQueries({ queryKey: ["village", villageId] });
+  }
+
   return (
-    <main className="min-h-screen bg-slate-900 text-slate-100">
-      <section className="max-w-4xl mx-auto px-6 py-10 space-y-6">
+    <main className="text-white pb-[60px]">
+      <section className="max-w-[1170px] mx-auto px-2 py-4 space-y-3">
         <SayFormProvider>
           <VillageHeader
             village={village}
@@ -376,6 +386,24 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
           onClose={() => setShowInfo(false)}
         />
       </section>
+      <FooterMenuDock
+        onOpenInfo={() => setShowInfo(true)}
+        onOpenFilter={() => setShowFilter(true)}
+        isFiltered={isFiltered}
+        showVoteShortcut={
+          !!myself &&
+          village.statusCode === "IN_PROGRESS" &&
+          myself.vote.canVote &&
+          myself.vote.targetCharaId == null
+        }
+        onGoToVote={() => {
+          // 行動パネル (id 未設定だが ActionPanel の <h2>行動</h2> 近辺) へ簡易スクロール。
+          // 厳密な id ターゲットは別 PR で。
+          const el = document.querySelector("[data-action-panel]");
+          el?.scrollIntoView({ behavior: "smooth", block: "start" });
+        }}
+        onRefresh={refreshAll}
+      />
     </main>
   );
 }
@@ -400,59 +428,49 @@ function VillageHeader({
   return (
     <header className="space-y-2">
       <div className="flex items-center justify-between">
-        <div className="flex items-baseline gap-3">
-          <span className="font-mono text-slate-400 text-sm">#{village.number}</span>
-          <h1 className="text-2xl font-bold">{village.name}</h1>
+        <div className="flex items-baseline gap-2">
+          <span className="font-mono opacity-60 text-[0.95em]">#{village.number}</span>
+          <h1 className="text-[1.5em] font-bold m-0">
+            <VillageTag level={villageTagLevel(village.statusName)}>{village.statusName}</VillageTag>
+            {village.name}
+          </h1>
         </div>
-        <Link to="/villages" className="text-sm text-slate-400 hover:text-slate-200">
+        <Link to="/villages" className="message-link hover:underline">
           ← 村一覧
         </Link>
       </div>
-      <div className="flex flex-wrap items-center gap-3 text-sm text-slate-300">
-        <StatusBadge name={village.statusName} />
+      <div className="flex flex-wrap items-center gap-3 text-[0.95em] opacity-90">
         <span>現在 {village.time.latestDay}日目</span>
         {village.time.nextDayChangeDatetime && (
-          <span className="text-slate-400">
+          <span className="opacity-80">
             次回更新: {formatDateTime(village.time.nextDayChangeDatetime)}
           </span>
         )}
         {village.winCampName && (
-          <span className="text-amber-300">勝利: {village.winCampName}</span>
+          <span className="text-mint-500">勝利: {village.winCampName}</span>
         )}
       </div>
-      <p className="text-xs text-slate-500">
+      <p className="text-[0.85em] opacity-60 m-0">
         村建て: {village.createPlayerName} / {village.participants.count}人
         {village.participants.spectatorCount > 0 ? ` (見学${village.participants.spectatorCount})` : ""}
       </p>
       <div className="flex flex-wrap gap-2 pt-1">
-        <button
-          type="button"
-          className="rounded border border-slate-600 px-2.5 py-1 text-xs text-slate-200 hover:bg-slate-800"
-          onClick={onOpenInfo}
-        >
-          村情報
-        </button>
-        <button
-          type="button"
-          className={
-            "rounded border px-2.5 py-1 text-xs " +
-            (isFiltered
-              ? "border-indigo-400 bg-indigo-600/30 text-indigo-50"
-              : "border-slate-600 text-slate-200 hover:bg-slate-800")
-          }
+        <Button variant="dark-success" onClick={onOpenInfo}>村情報</Button>
+        <Button
+          variant={isFiltered ? "success" : "dark-success"}
           onClick={onOpenFilter}
           aria-pressed={isFiltered}
         >
           発言抽出{isFiltered ? " (絞り込み中)" : ""}
-        </button>
-        <Link
+        </Button>
+        <LinkButton
+          variant="dark-success"
           to={`/villages/${villageId}/scrap?day=${selectedDay}`}
           target="_blank"
           rel="noopener noreferrer"
-          className="rounded border border-slate-600 px-2.5 py-1 text-xs text-slate-200 hover:bg-slate-800"
         >
-          切り抜き ↗
-        </Link>
+          切り抜き
+        </LinkButton>
       </div>
     </header>
   );
@@ -479,7 +497,7 @@ function DayTabs({
     <div
       role="tablist"
       aria-label="日付ナビゲーション"
-      className="flex flex-wrap gap-1 rounded-xl bg-slate-800/30 border border-slate-700 p-2"
+      className="flex flex-wrap gap-[2px] border border-night-700 bg-night-950 p-2 rounded-[3px]"
     >
       {days.map((day) => {
         const active = day === selectedDay;
@@ -491,10 +509,10 @@ function DayTabs({
             aria-selected={active}
             onClick={() => onSelect(day)}
             className={
-              "rounded px-2.5 py-1 text-xs font-mono transition " +
+              "px-[9px] py-[5px] rounded-[3px] border text-[0.95em] font-mono transition-colors duration-100 " +
               (active
-                ? "bg-indigo-500/40 text-indigo-50 border border-indigo-400"
-                : "border border-transparent text-slate-300 hover:bg-slate-700/40")
+                ? "bg-mint-600 text-white border-mint-600"
+                : "border-mint-600 text-mint-600 bg-night-500 hover:bg-mint-600 hover:text-white")
             }
           >
             {day === 0 ? "プロローグ" : `${day}日目`}
@@ -507,15 +525,19 @@ function DayTabs({
 
 function MyselfPanel({ myself }: { myself: MyselfView }) {
   return (
-    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
-      <h2 className="text-sm text-slate-400 mb-2">あなた</h2>
-      <p className="text-base">
-        {myself.name}
-        {myself.skill && <span className="ml-2 text-indigo-300">[{myself.skill.name}]</span>}
-        {myself.campCode && <span className="ml-2 text-amber-300">{myself.campCode}</span>}
-        {myself.isDead && <span className="ml-2 text-rose-300">死亡</span>}
-      </p>
-    </section>
+    <Panel>
+      <PanelHeading>
+        <h2 className="text-sm m-0">あなた</h2>
+      </PanelHeading>
+      <PanelBody>
+        <p className="m-0">
+          {myself.name}
+          {myself.skill && <span className="ml-2 text-mint-500">[{myself.skill.name}]</span>}
+          {myself.campCode && <span className="ml-2 text-warning-500">{myself.campCode}</span>}
+          {myself.isDead && <span className="ml-2 text-blood-500">死亡</span>}
+        </p>
+      </PanelBody>
+    </Panel>
   );
 }
 
@@ -526,10 +548,14 @@ function MyselfPanel({ myself }: { myself: MyselfView }) {
 function ParticipantsPanel({ participants }: { participants: VillageParticipantView[] }) {
   if (participants.length === 0) {
     return (
-      <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
-        <h2 className="text-sm text-slate-400">参加者</h2>
-        <p className="text-slate-400 text-sm py-2">まだ参加者がいません</p>
-      </section>
+      <Panel>
+        <PanelHeading>
+          <h2 className="text-sm m-0">参加者</h2>
+        </PanelHeading>
+        <PanelBody>
+          <p className="opacity-80 m-0">まだ参加者がいません</p>
+        </PanelBody>
+      </Panel>
     );
   }
   // 退村済み (isGone) は旧画面でも参加者一覧から外れていたので除外する。
@@ -544,17 +570,23 @@ function ParticipantsPanel({ participants }: { participants: VillageParticipantV
     else alive.push(p);
   }
   return (
-    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4 space-y-4">
-      <h2 className="text-sm text-slate-400">
-        参加者 (生存 {alive.length} / 死亡 {dead.length}
-        {spectators.length > 0 ? ` / 見学 ${spectators.length}` : ""})
-      </h2>
-      <ParticipantSubList title={`生存 (${alive.length})`} items={alive} kind="alive" />
-      <ParticipantSubList title={`死亡 (${dead.length})`} items={dead} kind="dead" />
-      {spectators.length > 0 && (
-        <ParticipantSubList title={`見学 (${spectators.length})`} items={spectators} kind="spectator" />
-      )}
-    </section>
+    <Panel>
+      <PanelHeading>
+        <h2 className="text-sm m-0">
+          参加者 (生存 {alive.length} / 死亡 {dead.length}
+          {spectators.length > 0 ? ` / 見学 ${spectators.length}` : ""})
+        </h2>
+      </PanelHeading>
+      <PanelBody>
+        <div className="space-y-4">
+          <ParticipantSubList title={`生存 (${alive.length})`} items={alive} kind="alive" />
+          <ParticipantSubList title={`死亡 (${dead.length})`} items={dead} kind="dead" />
+          {spectators.length > 0 && (
+            <ParticipantSubList title={`見学 (${spectators.length})`} items={spectators} kind="spectator" />
+          )}
+        </div>
+      </PanelBody>
+    </Panel>
   );
 }
 
@@ -572,8 +604,8 @@ function ParticipantSubList({
   if (items.length === 0) {
     return (
       <div>
-        <h3 className="text-xs text-slate-400 mb-1">{title}</h3>
-        <p className="text-xs text-slate-500 px-2">なし</p>
+        <h3 className="text-[0.95em] opacity-80 mb-1">{title}</h3>
+        <p className="text-[0.85em] opacity-60 px-2 m-0">なし</p>
       </div>
     );
   }
@@ -581,28 +613,27 @@ function ParticipantSubList({
   const isSpectator = kind === "spectator";
   return (
     <div>
-      <h3 className="text-xs text-slate-400 mb-1">{title}</h3>
-      <ul className="grid grid-cols-1 sm:grid-cols-2 gap-1.5">
+      <h3 className="text-[0.95em] opacity-80 mb-1">{title}</h3>
+      <ul className="grid grid-cols-1 sm:grid-cols-2 gap-1.5 list-none p-0 m-0">
         {items.map((p) => (
-          <li key={p.id} className="flex items-center gap-2 text-sm">
-            <span className="font-mono text-slate-500 w-10 shrink-0">
+          <li key={p.id} className="flex items-center gap-2 text-[0.95em]">
+            <span className="font-mono opacity-60 w-10 shrink-0">
               {p.roomNumber != null ? String(p.roomNumber).padStart(2, "0") : "--"}
             </span>
-            <span className={`flex-1 truncate ${isDead ? "text-slate-400" : ""}`}>
+            <span className={`flex-1 truncate ${isDead ? "opacity-80" : ""}`}>
               {p.name}
               {p.memo && (
-                <span className="ml-2 text-slate-500 text-xs">[{p.memo}]</span>
+                <span className="ml-2 opacity-60 text-[0.85em]">[{p.memo}]</span>
               )}
             </span>
             {p.skill && (
-              <span className="text-xs text-indigo-300 shrink-0">[{p.skill.shortName}]</span>
+              <span className="text-[0.85em] text-mint-500 shrink-0">[{p.skill.shortName}]</span>
             )}
             {isSpectator && (
-              <span className="text-xs text-slate-400 shrink-0">見学</span>
+              <span className="text-[0.85em] opacity-80 shrink-0">見学</span>
             )}
-            {/* p.dead は backend で進行中の無惨死を MISERABLE / 無惨 にマスク済 */}
             {isDead && p.dead && (
-              <span className="text-xs text-rose-300 shrink-0">
+              <span className="text-[0.85em] text-blood-500 shrink-0">
                 {p.dead.day}d {p.dead.name}
               </span>
             )}
@@ -639,38 +670,17 @@ function MessagesPanel({
   const hasPrev = messages?.isExistPrePage ?? false;
   const hasNext = messages?.isExistNextPage ?? false;
   return (
-    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
-      <div className="flex flex-wrap items-center justify-between mb-3 gap-2">
-        <h2 className="text-sm text-slate-400">
-          発言 ({day === 0 ? "プロローグ" : `${day}日目`} · {count}件)
-          {isPaging && totalPages > 0 && currentPage != null && (
-            <span className="ml-2 text-slate-500">
-              ({currentPage} / {totalPages} ページ)
-            </span>
-          )}
-        </h2>
-        <Pagination
-          isPaging={isPaging}
-          currentPage={currentPage}
-          totalPages={totalPages}
-          hasPrev={hasPrev}
-          hasNext={hasNext}
-          onSetPage={onSetPage}
-        />
-      </div>
-      {!messages || count === 0 ? (
-        <p className="text-slate-400 text-sm py-2">この日の閲覧可能な発言はありません</p>
-      ) : (
-        <ul className="space-y-2 max-h-[640px] overflow-y-auto pr-1">
-          {messages.list.map((m, i) => (
-            <li key={`${m.typeCode}-${m.number ?? i}`}>
-              <MessageCard message={m} participantsById={participantsById} />
-            </li>
-          ))}
-        </ul>
-      )}
-      {(hasPrev || hasNext) && (
-        <div className="flex justify-end mt-3">
+    <Panel>
+      <PanelHeading>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h2 className="text-sm m-0">
+            発言 ({day === 0 ? "プロローグ" : `${day}日目`} · {count}件)
+            {isPaging && totalPages > 0 && currentPage != null && (
+              <span className="ml-2 opacity-60">
+                ({currentPage} / {totalPages} ページ)
+              </span>
+            )}
+          </h2>
           <Pagination
             isPaging={isPaging}
             currentPage={currentPage}
@@ -680,8 +690,33 @@ function MessagesPanel({
             onSetPage={onSetPage}
           />
         </div>
-      )}
-    </section>
+      </PanelHeading>
+      <PanelBody>
+        {!messages || count === 0 ? (
+          <p className="opacity-80 m-0 py-2">この日の閲覧可能な発言はありません</p>
+        ) : (
+          <ul className="space-y-1 list-none p-0 m-0">
+            {messages.list.map((m, i) => (
+              <li key={`${m.typeCode}-${m.number ?? i}`}>
+                <MessageCard message={m} participantsById={participantsById} />
+              </li>
+            ))}
+          </ul>
+        )}
+        {(hasPrev || hasNext) && (
+          <div className="flex justify-end mt-3">
+            <Pagination
+              isPaging={isPaging}
+              currentPage={currentPage}
+              totalPages={totalPages}
+              hasPrev={hasPrev}
+              hasNext={hasNext}
+              onSetPage={onSetPage}
+            />
+          </div>
+        )}
+      </PanelBody>
+    </Panel>
   );
 }
 
@@ -706,7 +741,7 @@ function Pagination({
     return (
       <button
         type="button"
-        className="rounded border border-slate-600 px-2 py-0.5 text-xs text-slate-300 hover:bg-slate-800"
+        className="rounded-[3px] border border-mint-600 bg-night-500 px-2 py-0.5 text-[0.95em] text-mint-600 hover:bg-mint-600 hover:text-white"
         onClick={() => onSetPage(1)}
       >
         分割表示
@@ -715,21 +750,21 @@ function Pagination({
   }
   const cur = currentPage ?? 1;
   return (
-    <div className="flex items-center gap-1 text-xs">
+    <div className="flex items-center gap-1 text-[0.95em]">
       <button
         type="button"
-        className="rounded border border-slate-600 px-2 py-0.5 text-slate-200 disabled:opacity-40 hover:bg-slate-800"
+        className="rounded-[3px] border border-mint-600 bg-night-500 px-2 py-0.5 text-mint-600 disabled:opacity-40 hover:bg-mint-600 hover:text-white"
         onClick={() => onSetPage(cur - 1)}
         disabled={!hasPrev || cur <= 1}
       >
         ‹ 前
       </button>
-      <span className="px-1 text-slate-400">
+      <span className="px-1 opacity-80">
         {cur}/{totalPages || cur}
       </span>
       <button
         type="button"
-        className="rounded border border-slate-600 px-2 py-0.5 text-slate-200 disabled:opacity-40 hover:bg-slate-800"
+        className="rounded-[3px] border border-mint-600 bg-night-500 px-2 py-0.5 text-mint-600 disabled:opacity-40 hover:bg-mint-600 hover:text-white"
         onClick={() => onSetPage(cur + 1)}
         disabled={!hasNext}
       >
@@ -741,45 +776,34 @@ function Pagination({
 
 function FootstepsPanel({ footsteps }: { footsteps: VillageFootstepsView | null }) {
   return (
-    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
-      <h2 className="text-sm text-slate-400 mb-3">足音</h2>
-      {!footsteps || footsteps.list.length === 0 ? (
-        <p className="text-slate-400 text-sm py-2">表示できる足音はありません</p>
-      ) : (
-        <ul className="space-y-1 text-sm">
-          {footsteps.list.map((f, i) => (
-            <li key={`${f.day}-${f.roomNumbers}-${i}`} className="flex items-center gap-2">
-              <span className="text-slate-500 w-12 shrink-0">{f.day}日目</span>
-              <span className="font-mono">{f.roomNumbers}</span>
-              {f.registerChara && (
-                <span className="text-xs text-slate-400">
-                  by {f.registerChara.shortName}
-                </span>
-              )}
-            </li>
-          ))}
-        </ul>
-      )}
-    </section>
+    <Panel>
+      <PanelHeading>
+        <h2 className="text-sm m-0">足音</h2>
+      </PanelHeading>
+      <PanelBody>
+        {!footsteps || footsteps.list.length === 0 ? (
+          <p className="opacity-80 m-0 py-2">表示できる足音はありません</p>
+        ) : (
+          <ul className="space-y-1 text-[0.95em] list-none p-0 m-0">
+            {footsteps.list.map((f, i) => (
+              <li key={`${f.day}-${f.roomNumbers}-${i}`} className="flex items-center gap-2">
+                <span className="opacity-60 w-12 shrink-0">{f.day}日目</span>
+                <span className="font-mono">{f.roomNumbers}</span>
+                {f.registerChara && (
+                  <span className="text-[0.85em] opacity-80">
+                    by {f.registerChara.shortName}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </PanelBody>
+    </Panel>
   );
 }
 
 // ---------- utils ----------
-
-const STATUS_BADGE: Record<string, string> = {
-  募集中: "bg-emerald-600/30 text-emerald-100 border-emerald-500/40",
-  進行中: "bg-amber-600/30 text-amber-100 border-amber-500/40",
-  エピローグ: "bg-sky-600/30 text-sky-100 border-sky-500/40",
-  終了: "bg-slate-600/30 text-slate-200 border-slate-500/40",
-  廃村: "bg-rose-600/30 text-rose-100 border-rose-500/40",
-};
-
-function StatusBadge({ name }: { name: string }) {
-  const cls = STATUS_BADGE[name] ?? "bg-slate-700/40 text-slate-200 border-slate-500/40";
-  return (
-    <span className={`text-xs px-2 py-0.5 rounded border ${cls}`}>{name}</span>
-  );
-}
 
 function formatDateTime(iso: string): string {
   // backend が LocalDateTime を ISO 文字列で返す前提。Date 経由で MM/dd HH:mm 形式に整形。


### PR DESCRIPTION
closes .issues/25-step-13c-village-detail-design-restore.md
closes .issues/16-dead-ismiserabledead-operator-precedence.md
closes .issues/20-village-info-modal-restrictions.md
closes .issues/21-fetch-messages-signature-cleanup.md

## 変更内容

旧 `.old-thymeleaf/templates/village/*` + `bootstrap-override.css` の見た目を React 側に復元 (Step 13c)。本番計測ベース (Step 13b-fix 方法論) を踏襲。

### frontend

- **MessageCard**: `.message-*` variant 全種 (normal/werewolf/mason/lover/telepathy/owl/monologue/secret/grave/spectate/private-*/public-system/creator/action) を旧 hex 値 1:1 で復元。装飾タグ (`[[b]]`/`[[s]]`/`[[large]]`/`[[small]]`/`[[#color]]`/`[[ruby]]`/`[[netabare]]`/`[[cw]]`/`[[tp]]`) を React 要素にパース (dangerouslySetInnerHTML 不使用)。アンカー (`>>N` 系) を `.message-link` (blood-600) に。
- **RoomGridPanel**: `❤` を `HeartIcon` に置換 (絵文字禁止)、Panel + PanelBody 採用。
- **SituationPanel**: Panel + Table primitive (table-bordered table-condensed) に。
- **MessageFilter**: Modal primitive 採用、checkbox を旧 BS3 風に。
- **VillageInfoModal**: Modal primitive 採用 + `.issues/20` 同時解消 (発言制限 / キャラセット / ダミーキャラ名を表示)。
- **SayForm**: 旧 `.btn-saytypes` (dark bg + mint border + mint text、active で反転) に。装飾タグボタン 7 種 + 色 7 種 + 単発 `[[]]` を旧画面踏襲。
- **FooterMenuDock (新規)**: 旧 `#footer-menu.footer-menu-bottom` (bottom-fixed dock)。glyphicon を heroicons に置換、最上部 / 最下部 / 更新 / 抽出 / 情報 + 未投票時の投票ショートカット。
- **ActionPanel / ParticipateActions / RpActions**: Panel + 旧 `.form-horizontal` 風 + `btn-success` / `btn-default` (night/mint/bs-success の色トークン使用)。
- **villages.\$id.tsx**: 全体を Panel に揃え DayTabs を `.btn-saytypes` 風に、FooterMenuDock を組み込み。

### backend

- **VillageSettingsView**: `sayRestrictList` / `skillSayRestrictList` / `rpSayRestrictList` / `charachips` (id+name) / `dummyCharaName` を追加 (`.issues/20`)。constructor が `Charachips` を要求するようになったので VillageView の呼出を更新。
- **Dead.kt**: `isMiserableDead` 他 5 メソッドに括弧追加 (`.issues/16`、挙動差分なし)。

### absorbed issues

- **.issues/16**: Dead 演算子優先順位リファクタ (テスト passing)
- **.issues/20**: 村情報モーダル拡張 (発言制限 / キャラセット / ダミーキャラ名)
- **.issues/21**: `fetchVillageMessages` の `number | MessagesQuery` union 撤去

## 動作確認

- [x] `pnpm typecheck`
- [x] `pnpm test` (11 passed)
- [x] `pnpm build`
- [x] `./gradlew test` (backend、Dead 関連を含めて passing)
- [ ] **ユーザー手動確認依頼**: `/villages/:id` (進行中 / プロローグ / 終了) を本番 (`https://wolfort.net/wolf-mansion/village/:id`) と並べて視覚確認。とくに発言 bubble の色 / RoomGrid の死亡記号 / VillageInfoModal の発言制限テーブル / FooterMenuDock の bottom-fixed 表示。
- [ ] **ユーザー手動確認依頼**: `pnpm gen:api` で OpenAPI 型を再生成 (本 PR では手動更新済、再生成後の diff が空になることの確認)。
- [ ] **既知の制約**: `loud` / `rainbow` / `extra-small` テキスト装飾は backend にフラグ / 自動判定が必要なため本 PR ではスコープ外。`[[loud]]` のような自動装飾タグも未対応。

## 意図的スコープ外

- フォーム系 (`new-village.tsx` / `villages.\$id.settings.tsx` / `SettingsForm.tsx`) → Step 13d
- admin / creator / scrap → Step 13e
- 文字サイズ拡大 UI トグル → Step 13f
- `loud` / `rainbow` / `extra-small` 装飾 (backend フラグ未実装)

🤖 Generated with [Claude Code](https://claude.com/claude-code)