### PR TITLE
Step 13c: 村詳細画面の旧 Thymeleaf デザイン復元 (#25)

### DIFF
--- a/frontend/app/app.css
+++ b/frontend/app/app.css
@@ -83,7 +83,12 @@ html {
 
 html,
 body {
-  background-color: var(--color-night-950);
+  /* 本番計測 (wolfort.net): body bg は #222 (night-500)。
+   * 旧コードでは night-950 (#0b162a) を body にも使っていたが、これは
+   * 「ホームページの tile (.top-menu-selectable) bg」用の値で本来 body には別の値。
+   * 本番に合わせて #222 に揃える (home tiles は明示的に bg-night-950 を当てているため
+   * 見た目に影響なし)。 */
+  background-color: var(--color-night-500);
   color: #ffffff;
   color-scheme: dark;
   min-height: 100vh;
@@ -149,6 +154,14 @@ body {
  * 生成漏れや上書きを避けるため、!important + 明示的 background-color)。 */
 .modal-dialog-bg {
   background-color: #303030 !important;
+}
+
+/* 旧 .message a (本文中のアンカー / リンク): 赤系 #f00000
+ * .message-public-system a は mint だが、PUBLIC_SYSTEM 本文中に >>N を含まないので
+ * 共通の赤指定でよい */
+.message-link {
+  color: var(--color-blood-600);
+  cursor: pointer;
 }
 
 /* 旧 .netabare / .transparency (ネタバレ伏字 / 透明) */

--- a/frontend/app/components/ui/Panel.tsx
+++ b/frontend/app/components/ui/Panel.tsx
@@ -2,11 +2,11 @@ import * as React from "react";
 import { cn } from "./cn";
 
 /**
- * 旧 .panel.panel-default 相当。
- * Bootstrap 3 のパネル (薄い border + heading 上段 + body 下段)。
+ * 旧 .panel.panel-default 相当 (Bootstrap 3 + Bootswatch Darkly)。
  *
- * 旧画面 (dark テーマ) では bg は body と同じく深紺、border は #333 で
- * 全体を区切る。heading は薄い分割線で本文と区別する。
+ * 本番計測値 (wolfort.net /village/13):
+ * - .panel.panel-default: bg #303030 (night-650) / border #464545 (night-550) / radius 4px
+ * - .panel-heading: bg #464545 (night-550) / padding 10px 15px / radius 3px 3px 0 0 / color white
  */
 export function Panel({
   className,
@@ -16,7 +16,7 @@ export function Panel({
   return (
     <div
       className={cn(
-        "border border-night-700 bg-night-950 rounded-[0.25em]",
+        "border border-night-550 bg-night-650 rounded-[4px]",
         className,
       )}
       {...rest}
@@ -33,7 +33,7 @@ export function PanelHeading({
   return (
     <div
       className={cn(
-        "px-3 py-2 border-b border-night-700 bg-night-900",
+        "px-[15px] py-[10px] bg-night-550 rounded-t-[3px]",
         className,
       )}
       {...rest}
@@ -45,5 +45,5 @@ export function PanelBody({
   className,
   ...rest
 }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("px-3 py-3", className)} {...rest} />;
+  return <div className={cn("px-[15px] py-[15px]", className)} {...rest} />;
 }

--- a/frontend/app/features/village/detail/ActionPanel.tsx
+++ b/frontend/app/features/village/detail/ActionPanel.tsx
@@ -14,6 +14,7 @@ import {
   useFootstepCandidatesQuery,
   useVoteMutation,
 } from "./hooks";
+import { Panel, PanelBody, PanelHeading } from "~/components/ui/Panel";
 
 /**
  * 進行中の村で「能力 / 投票 / コミット」をまとめて行う操作パネル。
@@ -38,21 +39,27 @@ export function ActionPanel({
   if (myself.isSpectator) return null;
 
   return (
-    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4 space-y-4">
-      <h2 className="text-sm text-slate-400">行動</h2>
-      <AbilitySection
-        village={village}
-        myself={myself}
-        ability={myself.ability}
-        isDead={myself.isDead}
-      />
-      <VoteSection
-        village={village}
-        myselfCharaId={myself.charaId}
-        vote={myself.vote}
-      />
-      <CommitSection villageId={village.id} commit={myself.commit} />
-    </section>
+    <Panel data-action-panel>
+      <PanelHeading>
+        <h2 className="text-[1em] m-0 font-normal">行動</h2>
+      </PanelHeading>
+      <PanelBody>
+        <div className="space-y-4">
+          <AbilitySection
+            village={village}
+            myself={myself}
+            ability={myself.ability}
+            isDead={myself.isDead}
+          />
+          <VoteSection
+            village={village}
+            myselfCharaId={myself.charaId}
+            vote={myself.vote}
+          />
+          <CommitSection villageId={village.id} commit={myself.commit} />
+        </div>
+      </PanelBody>
+    </Panel>
   );
 }
 
@@ -90,8 +97,8 @@ function AbilitySection({
   const showForm = ability.canUseAbility && !isDead;
 
   return (
-    <div className="space-y-3 border-t border-slate-700/60 pt-3 first:border-t-0 first:pt-0">
-      <div className="text-xs text-slate-400">
+    <div className="space-y-3 border-t border-night-700 pt-3 first:border-t-0 first:pt-0">
+      <div className="text-xs opacity-80">
         能力 {ability.typeName ? `(${ability.typeName})` : ""}
       </div>
 
@@ -99,8 +106,8 @@ function AbilitySection({
 
       {ability.skillHistoryList.length > 0 && (
         <div className="space-y-1">
-          <p className="text-xs text-slate-400">能力セット履歴</p>
-          <ul className="text-xs text-slate-300 space-y-0.5">
+          <p className="text-xs opacity-80">能力セット履歴</p>
+          <ul className="text-xs text-white space-y-0.5">
             {ability.skillHistoryList.map((h, i) => (
               <li key={`${i}-${h}`}>{h}</li>
             ))}
@@ -361,7 +368,7 @@ function AbilityForm({
           </button>
         )}
         {mutation.isError && (
-          <span className="text-xs text-rose-300">{mutation.error.message}</span>
+          <span className="text-xs text-blood-500">{mutation.error.message}</span>
         )}
       </div>
     </form>
@@ -381,8 +388,8 @@ function VoteSection({
 }) {
   if (!vote.canVote) return null;
   return (
-    <div className="space-y-2 border-t border-slate-700/60 pt-3">
-      <div className="text-xs text-slate-400">投票</div>
+    <div className="space-y-2 border-t border-night-700 pt-3">
+      <div className="text-xs opacity-80">投票</div>
       <VoteForm
         villageId={village.id}
         participants={village.participants.list}
@@ -449,7 +456,7 @@ function VoteForm({
           {mutation.isPending ? "送信中..." : vote.targetCharaId != null ? "投票変更" : "投票"}
         </button>
         {mutation.isError && (
-          <span className="text-xs text-rose-300">{mutation.error.message}</span>
+          <span className="text-xs text-blood-500">{mutation.error.message}</span>
         )}
       </div>
     </form>
@@ -473,14 +480,14 @@ function CommitSection({
   }
 
   return (
-    <div className="space-y-2 border-t border-slate-700/60 pt-3">
-      <div className="text-xs text-slate-400">コミット (行動確定)</div>
+    <div className="space-y-2 border-t border-night-700 pt-3">
+      <div className="text-xs opacity-80">コミット (行動確定)</div>
       <div className="flex items-center gap-3">
         <span className="text-sm">
           {commit.isCommitting ? (
-            <span className="text-emerald-300">確定済み</span>
+            <span className="text-mint-500">確定済み</span>
           ) : (
-            <span className="text-slate-300">未確定</span>
+            <span className="text-white">未確定</span>
           )}
         </span>
         <button
@@ -496,7 +503,7 @@ function CommitSection({
               : "コミットする"}
         </button>
         {mutation.isError && (
-          <span className="text-xs text-rose-300">{mutation.error.message}</span>
+          <span className="text-xs text-blood-500">{mutation.error.message}</span>
         )}
       </div>
     </div>
@@ -521,9 +528,9 @@ function Row({
 }) {
   return (
     <label className="block space-y-1">
-      <span className="text-xs text-slate-400">{label}</span>
+      <span className="text-xs opacity-80">{label}</span>
       {children}
-      {suffix && <span className="block text-xs text-slate-500">{suffix}</span>}
+      {suffix && <span className="block text-xs opacity-60">{suffix}</span>}
     </label>
   );
 }
@@ -537,10 +544,10 @@ function buildCharaNameMap(participants: VillageParticipantView[]): Record<numbe
 }
 
 const inputClass =
-  "w-full bg-slate-900 border border-slate-700 rounded px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:outline-none focus:border-indigo-500 disabled:opacity-50";
+  "w-full bg-night-900 border border-night-700 rounded-[3px] px-2 py-1 text-[1em] focus:outline-none focus:border-mint-500 disabled:opacity-50";
 
 const primaryButtonClass =
-  "rounded bg-indigo-500 hover:bg-indigo-400 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium";
+  "px-[9px] py-[6px] rounded-[3px] border-2 border-bs-success-600 bg-bs-success-500 text-white text-[13px] hover:bg-bs-success-700 hover:border-bs-success-700 disabled:opacity-50 disabled:cursor-not-allowed";
 
 const secondaryButtonClass =
-  "rounded bg-slate-700 hover:bg-slate-600 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium";
+  "px-[9px] py-[6px] rounded-[3px] border-2 border-night-700 bg-night-800 text-white text-[13px] hover:bg-night-700 disabled:opacity-50 disabled:cursor-not-allowed";

--- a/frontend/app/features/village/detail/FooterMenuDock.tsx
+++ b/frontend/app/features/village/detail/FooterMenuDock.tsx
@@ -1,0 +1,105 @@
+import {
+  ArrowDownIcon,
+  ArrowPathIcon,
+  ArrowUpIcon,
+  FunnelIcon,
+  InformationCircleIcon,
+} from "@heroicons/react/24/outline";
+
+/**
+ * 旧 .old-thymeleaf/templates/village/footer-menu.html (`#footer-menu.footer-menu-bottom`)
+ * 相当の bottom-fixed dock。
+ *
+ * 本番計測 (wolfort.net /village/13 . 一旦 BS3 btn-group):
+ * - 外枠 div は `position: fixed; bottom: 0; width: 100vw; z-index: 20`
+ * - btn-group の中身は `flex; padding: 3px` で `.btn-footermenu` を等幅で並べる
+ * - .btn-footermenu: bg #222 / mint border + mint text / font-size 13px / padding 4px 5px
+ *   active: bg #00bc8c / white text
+ * - .footermenu-vote (未投票時のみ): bg #222 / blood border + blood text
+ *
+ * 絵文字使用禁止 (13a 方針) のため、glyphicon は heroicons の SVG に置換。
+ */
+export function FooterMenuDock({
+  onOpenInfo,
+  onOpenFilter,
+  isFiltered,
+  showVoteShortcut,
+  onGoToVote,
+  onRefresh,
+}: {
+  onOpenInfo: () => void;
+  onOpenFilter: () => void;
+  isFiltered: boolean;
+  showVoteShortcut: boolean;
+  onGoToVote?: () => void;
+  onRefresh?: () => void;
+}) {
+  return (
+    <div id="footer-menu" className="fixed bottom-0 left-0 right-0 z-20 w-screen">
+      {showVoteShortcut && onGoToVote && (
+        <div className="flex w-full px-[3px] py-[3px] bg-night-500">
+          <DockButton variant="vote" onClick={onGoToVote}>
+            投票欄へ (未セットのままだと突然死します)
+          </DockButton>
+        </div>
+      )}
+      <div className="flex w-full px-[3px] py-[3px] bg-night-500">
+        <DockButton onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}>
+          <ArrowUpIcon className="w-4 h-4 inline-block" aria-hidden="true" />
+          <span className="hidden sm:inline ml-1">最上部へ</span>
+        </DockButton>
+        <DockButton
+          onClick={() =>
+            window.scrollTo({ top: document.body.scrollHeight, behavior: "smooth" })
+          }
+        >
+          <ArrowDownIcon className="w-4 h-4 inline-block" aria-hidden="true" />
+          <span className="hidden sm:inline ml-1">最下部へ</span>
+        </DockButton>
+        {onRefresh && (
+          <DockButton onClick={onRefresh}>
+            <ArrowPathIcon className="w-4 h-4 inline-block" aria-hidden="true" />
+            <span className="hidden sm:inline ml-1">更新</span>
+          </DockButton>
+        )}
+        <DockButton onClick={onOpenFilter} active={isFiltered}>
+          <FunnelIcon className="w-4 h-4 inline-block" aria-hidden="true" />
+          <span className="hidden sm:inline ml-1">{isFiltered ? "抽出中" : "抽出"}</span>
+        </DockButton>
+        <DockButton onClick={onOpenInfo}>
+          <InformationCircleIcon className="w-4 h-4 inline-block" aria-hidden="true" />
+          <span className="hidden sm:inline ml-1">情報</span>
+        </DockButton>
+      </div>
+    </div>
+  );
+}
+
+function DockButton({
+  children,
+  onClick,
+  active,
+  variant,
+}: {
+  children: React.ReactNode;
+  onClick?: () => void;
+  active?: boolean;
+  variant?: "vote";
+}) {
+  const isVote = variant === "vote";
+  const base =
+    "flex-1 px-[5px] py-[4px] -ml-px first:ml-0 border text-[13px] cursor-pointer text-center leading-tight transition-colors duration-100";
+  let cls: string;
+  if (isVote) {
+    cls = `${base} border-blood-500 text-blood-500 bg-night-500 hover:bg-blood-500 hover:text-white`;
+  } else if (active) {
+    cls = `${base} border-mint-600 bg-mint-600 text-white`;
+  } else {
+    cls = `${base} border-mint-600 text-mint-600 bg-night-500 hover:bg-mint-600 hover:text-white`;
+  }
+  return (
+    <button type="button" className={cls} onClick={onClick}>
+      {children}
+    </button>
+  );
+}

--- a/frontend/app/features/village/detail/MessageCard.tsx
+++ b/frontend/app/features/village/detail/MessageCard.tsx
@@ -1,18 +1,20 @@
+import * as React from "react";
 import type { MessageView, VillageParticipantView } from "./api";
 import { useSayFormRequester } from "./SayFormContext";
 
 /**
- * 1 発言ぶんのカード。`MessageView.typeCode` に応じて色 / 番号プレフィックスを出し分け、
- * 発言者キャラ画像とプレイヤー名 (エピローグ以降のみ backend が返す) を表示する。
+ * 1 発言ぶんのカード。`MessageView.typeCode` に応じて旧 Thymeleaf
+ * `.message-*` variant 色 / アンカー記号 / 構造を 1:1 で復元する。
  *
- * 旧 Thymeleaf 版 `.old-thymeleaf/templates/village-template/message-partial.html` の
- * 表示種別 (NORMAL_SAY / WEREWOLF_SAY / MASON_SAY / LOVERS_SAY / MONOLOGUE_SAY /
- * SECRET_SAY / GRAVE_SAY / SPECTATE_SAY / CREATOR_SAY / TELEPATHY / ACTION / 各種
- * PRIVATE_* / PUBLIC_SYSTEM / PARTICIPANTS) を一通りカバーする。
+ * 本番計測 (wolfort.net /village/13) の .message-normal: bg #fff / color #555 /
+ * border 1px solid #e3e3e3 / radius 5px / padding 9px / margin 0 0 20px 5px /
+ * font-family **sans-serif** (Lato ではない)。font-size 12px (body と同じ)。
  *
- * Step 12d 以降:
- * - アンカー (`>>N` のラベル部分) をクリックすると SayForm の textarea に `>>N` を挿入
- * - 各カードに [返信] を出し、SECRET_SAY なら宛先 auto-set 込みで反映
+ * - 通常発言系 (kind=say): 発言番号アンカー + キャラ画像 60x60 + 色つき bubble + 返信/秘話 link
+ * - システム系 (kind=system): bubble 1 枚のみ (画像なし、アンカーなし)
+ *
+ * 装飾タグは React 要素にパース (dangerouslySetInnerHTML 不使用)。`loud` / `rainbow` /
+ * `extra-small` の自動付与は backend にフラグが必要なため当面非対応。
  */
 export function MessageCard({
   message,
@@ -27,20 +29,31 @@ export function MessageCard({
     : undefined;
   const requestSay = useSayFormRequester();
 
-  // PUBLIC_SYSTEM / PRIVATE_* / PARTICIPANTS 等は番号も発言者も持たない単純な
-  // システム枠で出す (旧画面 message-public-system / message-private-* に対応)。
+  const content = renderMessageContent(message.text, message.isConvertDisable);
+
+  // BS3 .message 共通スタイル (本番計測値)
+  const bubbleStyle: React.CSSProperties = {
+    backgroundColor: style.bg,
+    color: style.color,
+    border: `1px solid ${style.border}`,
+    borderRadius: "5px",
+    padding: "9px",
+    fontFamily: "sans-serif",
+    fontSize: "1em",
+    wordBreak: "break-word",
+    flex: "1",
+    marginLeft: "5px",
+  };
+
+  // システム枠 (PUBLIC_SYSTEM / PRIVATE_* / PARTICIPANTS): 画像も発言者名もない単純枠
   if (style.kind === "system") {
     return (
-      <article
-        className={`rounded border px-3 py-2 text-sm whitespace-pre-wrap ${style.body}`}
-        data-message-type={message.typeCode}
-      >
-        {message.text}
+      <article className="mb-[20px]" data-message-type={message.typeCode}>
+        <div style={{ ...bubbleStyle, marginLeft: 0 }}>{content}</div>
       </article>
     );
   }
 
-  const anchor = renderAnchor(style.anchorPrefix, message.number);
   const isSecret = message.typeCode === "SECRET_SAY";
 
   function handleAnchorClick() {
@@ -58,216 +71,140 @@ export function MessageCard({
       anchorPrefix: style.anchorPrefix,
       messageNumber: message.number,
       isSecret,
-      // 秘話への返信: 元発言者のキャラ ID を宛先に
       secretTargetCharaId: isSecret ? fromParticipant?.chara.id : undefined,
     });
   }
 
+  function handleSecretClick() {
+    if (message.number == null) return;
+    requestSay({
+      anchorPrefix: style.anchorPrefix,
+      messageNumber: message.number,
+      isSecret: true,
+      secretTargetCharaId: fromParticipant?.chara.id,
+    });
+  }
+
+  const anchor = renderAnchor(style.anchorPrefix, message.number);
+  const targetName = message.toCharaName ? ` → ${message.toCharaName}` : "";
+
   return (
-    <article
-      className={`rounded border ${style.frame}`}
-      data-message-type={message.typeCode}
-    >
-      <header className="px-3 pt-2 text-xs text-slate-400 flex flex-wrap items-center gap-x-2 gap-y-0.5">
+    <article className="mb-[20px]" data-message-type={message.typeCode}>
+      {/* ヘッダ行 (`>>N. CharaName [Player]`) */}
+      <div className="text-[0.85em] flex items-baseline flex-wrap gap-x-2">
         {anchor && (
           <button
             type="button"
             onClick={handleAnchorClick}
-            className="font-mono text-slate-400 hover:text-indigo-300"
+            className="font-mono message-link hover:underline"
             title="アンカーを発言フォームに挿入"
           >
             {anchor}
           </button>
         )}
-        <span className="text-slate-200">{message.fromCharaName ?? style.fallbackFrom}</span>
-        {message.toCharaName && (
-          <span className="text-slate-400">→ {message.toCharaName}</span>
-        )}
+        <span>{message.fromCharaName ?? style.fallbackFrom}{targetName}</span>
         {fromParticipant?.playerName && (
-          <span className="text-slate-500">[{fromParticipant.playerName}]</span>
+          <span className="opacity-80">[{fromParticipant.playerName}]</span>
         )}
-        <span className="text-slate-500 ml-auto">{formatTime(message.datetime)}</span>
-        {message.number != null && (
+        <span className="ml-auto opacity-80">{formatTime(message.datetime)}</span>
+      </div>
+      {/* 本体: キャラ画像 (左) + bubble (右、flex: 1) */}
+      <div className="flex items-start mt-1">
+        {fromParticipant && (
+          <div className="shrink-0">
+            <img
+              src={fromParticipant.chara.defaultImageUrl}
+              width={fromParticipant.chara.imageWidth}
+              height={fromParticipant.chara.imageHeight}
+              alt=""
+              loading="lazy"
+              style={{
+                maxWidth: 60,
+                maxHeight: 60,
+                width: "auto",
+                height: "auto",
+              }}
+            />
+          </div>
+        )}
+        <div style={bubbleStyle}>{content}</div>
+      </div>
+      {/* フッタ: 返信 / 秘話 link (旧画面踏襲、右寄せ) */}
+      {message.number != null && (
+        <div className="text-[0.85em] flex justify-end gap-3 mt-1">
           <button
             type="button"
             onClick={handleReplyClick}
-            className="text-xs px-1.5 py-0.5 rounded border border-slate-600 text-slate-300 hover:border-slate-400"
-            title={isSecret ? "秘話で返信 (宛先 auto-set)" : "返信"}
+            className="message-link hover:underline"
           >
-            返信
+            &gt;&gt;返信
           </button>
-        )}
-      </header>
-      <div className="px-3 pb-2 pt-1 flex gap-2">
-        {fromParticipant && (
-          <img
-            src={fromParticipant.chara.defaultImageUrl}
-            width={fromParticipant.chara.imageWidth}
-            height={fromParticipant.chara.imageHeight}
-            alt=""
-            loading="lazy"
-            className="shrink-0 rounded border border-slate-700"
-            style={{
-              maxWidth: 60,
-              maxHeight: 60,
-              width: "auto",
-              height: "auto",
-            }}
-          />
-        )}
-        {/* React JSX は子要素の文字列を textContent としてレンダリングするため、
-            `message.text` を直接埋め込んでも XSS にはならない。旧 Thymeleaf の
-            `{{{messageContent}}}` (HTML 非エスケープ) に相当する HTML 装飾
-            (大声 / 虹色 / アンカー link) は Step 12d で安全に再実装する。 */}
-        <p className={`flex-1 text-sm whitespace-pre-wrap ${style.text}`}>{message.text}</p>
-      </div>
+          {fromParticipant && !isSecret && (
+            <button
+              type="button"
+              onClick={handleSecretClick}
+              className="message-link hover:underline"
+            >
+              &gt;&gt;秘話
+            </button>
+          )}
+        </div>
+      )}
     </article>
   );
 }
 
-// ---------- styles ----------
+// ---------- styles (旧 bootstrap-override.css の hex 値を 1:1 で持ち込み) ----------
 
 type MessageKind = "say" | "system";
 
 type MessageStyle = {
   kind: MessageKind;
-  /** カード枠 (kind=say のときに使用) */
-  frame: string;
-  /** 本文文字色 (kind=say のときに使用) */
-  text: string;
-  /** システム枠の background+border (kind=system のときに使用) */
-  body: string;
-  /** >>N のような番号プレフィックス記号 (旧画面のアンカー記法に揃える) */
+  bg: string;
+  color: string;
+  border: string;
   anchorPrefix: string;
-  /** fromCharaName が null のときに表示するフォールバック (主に creator) */
   fallbackFrom: string;
 };
 
 const DEFAULT_STYLE: MessageStyle = {
   kind: "say",
-  frame: "bg-slate-800/40 border-slate-700",
-  text: "text-slate-100",
-  body: "",
+  bg: "#ffffff",
+  color: "#555555",
+  border: "#e3e3e3",
   anchorPrefix: ">>",
   fallbackFrom: "?",
 };
 
-// 旧 .old-thymeleaf/templates/village-template/message-partial.html の anchor 記法と
-// 配色を Tailwind に移植したもの。背景は slate ベースに寄せて統一感を出す。
 const MESSAGE_STYLES: Record<string, MessageStyle> = {
-  NORMAL_SAY: {
-    kind: "say",
-    frame: "bg-slate-800/50 border-slate-600",
-    text: "text-slate-100",
-    body: "",
-    anchorPrefix: ">>",
-    fallbackFrom: "?",
-  },
-  WEREWOLF_SAY: {
-    kind: "say",
-    frame: "bg-rose-950/40 border-rose-700",
-    text: "text-rose-100",
-    body: "",
-    anchorPrefix: ">>*",
-    fallbackFrom: "?",
-  },
-  MASON_SAY: {
-    kind: "say",
-    frame: "bg-violet-950/40 border-violet-700",
-    text: "text-violet-100",
-    body: "",
-    anchorPrefix: ">>=",
-    fallbackFrom: "?",
-  },
-  LOVERS_SAY: {
-    kind: "say",
-    frame: "bg-pink-950/40 border-pink-700",
-    text: "text-pink-100",
-    body: "",
-    anchorPrefix: ">>?",
-    fallbackFrom: "?",
-  },
-  MONOLOGUE_SAY: {
-    kind: "say",
-    frame: "bg-slate-900/60 border-slate-700",
-    text: "text-slate-300 italic",
-    body: "",
-    anchorPrefix: ">>-",
-    fallbackFrom: "?",
-  },
-  SECRET_SAY: {
-    kind: "say",
-    frame: "bg-amber-950/40 border-amber-700",
-    text: "text-amber-100",
-    body: "",
-    anchorPrefix: ">>s",
-    fallbackFrom: "?",
-  },
-  GRAVE_SAY: {
-    kind: "say",
-    frame: "bg-zinc-900/70 border-zinc-700",
-    text: "text-zinc-300",
-    body: "",
-    anchorPrefix: ">>+",
-    fallbackFrom: "?",
-  },
-  SPECTATE_SAY: {
-    kind: "say",
-    frame: "bg-sky-950/40 border-sky-700",
-    text: "text-sky-100",
-    body: "",
-    anchorPrefix: ">>@",
-    fallbackFrom: "?",
-  },
-  CREATOR_SAY: {
-    kind: "say",
-    frame: "bg-yellow-950/40 border-yellow-700",
-    text: "text-yellow-100",
-    body: "",
-    anchorPrefix: ">>#",
-    fallbackFrom: "天からのお告げ",
-  },
-  TELEPATHY: {
-    kind: "say",
-    frame: "bg-indigo-950/40 border-indigo-700",
-    text: "text-indigo-100",
-    body: "",
-    anchorPrefix: ">>_",
-    fallbackFrom: "?",
-  },
-  ACTION: {
-    kind: "say",
-    frame: "bg-slate-800/30 border-slate-700",
-    text: "text-slate-300 italic",
-    body: "",
-    anchorPrefix: ">>a",
-    fallbackFrom: "",
-  },
-  // システム / 個別役職向け private 系: 番号もキャラ画像も持たない一行枠
-  PUBLIC_SYSTEM: makeSystem("bg-slate-700/30 border-slate-600 text-slate-100"),
-  PRIVATE_SYSTEM: makeSystem("bg-slate-800/50 border-slate-600 text-slate-200"),
-  PRIVATE_SEER: makeSystem("bg-emerald-950/40 border-emerald-700 text-emerald-100"),
-  PRIVATE_WISE: makeSystem("bg-emerald-950/40 border-emerald-700 text-emerald-100"),
-  PRIVATE_PSYCHIC: makeSystem("bg-teal-950/40 border-teal-700 text-teal-100"),
-  PRIVATE_GURU: makeSystem("bg-teal-950/40 border-teal-700 text-teal-100"),
-  PRIVATE_CORONER: makeSystem("bg-teal-950/40 border-teal-700 text-teal-100"),
-  PRIVATE_INVESTIGATE: makeSystem("bg-cyan-950/40 border-cyan-700 text-cyan-100"),
-  PRIVATE_WEREWOLF: makeSystem("bg-rose-950/40 border-rose-700 text-rose-100"),
-  PRIVATE_LOVER: makeSystem("bg-pink-950/40 border-pink-700 text-pink-100"),
-  PRIVATE_FOX: makeSystem("bg-orange-950/40 border-orange-700 text-orange-100"),
-  PRIVATE_ABILITY: makeSystem("bg-slate-800/60 border-slate-600 text-slate-200"),
-  PARTICIPANTS: makeSystem("bg-slate-700/30 border-slate-600 text-slate-100"),
+  NORMAL_SAY: { kind: "say", bg: "#ffffff", color: "#555555", border: "#e3e3e3", anchorPrefix: ">>", fallbackFrom: "?" },
+  WEREWOLF_SAY: { kind: "say", bg: "#f2aeae", color: "#333333", border: "#f2aeae", anchorPrefix: ">>*", fallbackFrom: "?" },
+  MASON_SAY: { kind: "say", bg: "#aef2ae", color: "#333333", border: "#aef2ae", anchorPrefix: ">>=", fallbackFrom: "?" },
+  LOVERS_SAY: { kind: "say", bg: "#f2cece", color: "#cc2222", border: "#f2cece", anchorPrefix: ">>?", fallbackFrom: "?" },
+  TELEPATHY: { kind: "say", bg: "#f2f2ae", color: "#cc2200", border: "#f2f2ae", anchorPrefix: ">>_", fallbackFrom: "?" },
+  MONOLOGUE_SAY: { kind: "say", bg: "#aaaaaa", color: "#333333", border: "#b5b5b5", anchorPrefix: ">>-", fallbackFrom: "?" },
+  SECRET_SAY: { kind: "say", bg: "#aa99aa", color: "#333333", border: "#b5b5b5", anchorPrefix: ">>s", fallbackFrom: "?" },
+  GRAVE_SAY: { kind: "say", bg: "#a9edf7", color: "#333333", border: "#a9edf7", anchorPrefix: ">>+", fallbackFrom: "?" },
+  SPECTATE_SAY: { kind: "say", bg: "#ffdea9", color: "#333333", border: "#ffdea9", anchorPrefix: ">>@", fallbackFrom: "?" },
+  CREATOR_SAY: { kind: "say", bg: "transparent", color: "#00bc8c", border: "#00bc8c", anchorPrefix: ">>#", fallbackFrom: "天からのお告げ" },
+  ACTION: { kind: "say", bg: "#232355", color: "#ffffff", border: "#232355", anchorPrefix: ">>a", fallbackFrom: "" },
+  PUBLIC_SYSTEM: makeSystem("transparent", "#ffffff", "transparent"),
+  PRIVATE_SYSTEM: makeSystem("#333333", "#eeeeee", "#cccccc"),
+  PRIVATE_SEER: makeSystem("#334033", "#eeeeee", "#34a865"),
+  PRIVATE_WISE: makeSystem("#334033", "#eeeeee", "#34a865"),
+  PRIVATE_PSYCHIC: makeSystem("#333340", "#eeeeee", "#3465a8"),
+  PRIVATE_GURU: makeSystem("#333340", "#eeeeee", "#3465a8"),
+  PRIVATE_CORONER: makeSystem("#333340", "#eeeeee", "#3465a8"),
+  PRIVATE_INVESTIGATE: makeSystem("#403333", "#eeeeee", "#a86534"),
+  PRIVATE_WEREWOLF: makeSystem("#403333", "#eeeeee", "#a83434"),
+  PRIVATE_LOVER: makeSystem("#403333", "#eeeeee", "#f9318f"),
+  PRIVATE_FOX: makeSystem("#403333", "#eeeeee", "#c9c934"),
+  PRIVATE_ABILITY: makeSystem("#333333", "#eeeeee", "#cccccc"),
+  PARTICIPANTS: makeSystem("transparent", "#ffffff", "transparent"),
 };
 
-function makeSystem(body: string): MessageStyle {
-  return {
-    kind: "system",
-    frame: "",
-    text: "",
-    body,
-    anchorPrefix: "",
-    fallbackFrom: "",
-  };
+function makeSystem(bg: string, color: string, border: string): MessageStyle {
+  return { kind: "system", bg, color, border, anchorPrefix: "", fallbackFrom: "" };
 }
 
 function renderAnchor(prefix: string, num: number | null | undefined): string {
@@ -281,4 +218,135 @@ function formatTime(iso: string): string {
   const hh = String(d.getHours()).padStart(2, "0");
   const mi = String(d.getMinutes()).padStart(2, "0");
   return `${hh}:${mi}`;
+}
+
+// ---------- 装飾タグ + アンカー → React 要素 変換 ----------
+
+function renderMessageContent(text: string, isConvertDisable: boolean): React.ReactNode {
+  const lines = text.split(/\r\n|\r|\n/);
+  const out: React.ReactNode[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    out.push(
+      <React.Fragment key={`l-${i}`}>{parseLine(lines[i], isConvertDisable, `l-${i}`)}</React.Fragment>,
+    );
+    if (i < lines.length - 1) out.push(<br key={`br-${i}`} />);
+  }
+  return <>{out}</>;
+}
+
+function parseLine(line: string, isConvertDisable: boolean, keyBase: string): React.ReactNode[] {
+  const out: React.ReactNode[] = [];
+  let remaining = line;
+  let idx = 0;
+  while (remaining.length > 0) {
+    const best = findEarliestMatch(remaining, isConvertDisable);
+    if (!best) {
+      out.push(<React.Fragment key={`${keyBase}-t${idx}`}>{remaining}</React.Fragment>);
+      break;
+    }
+    if (best.index > 0) {
+      const textChunk = remaining.slice(0, best.index);
+      out.push(<React.Fragment key={`${keyBase}-t${idx}`}>{textChunk}</React.Fragment>);
+      idx++;
+    }
+    out.push(best.render(`${keyBase}-${idx}`, isConvertDisable));
+    idx++;
+    remaining = remaining.slice(best.index + best.length);
+  }
+  return out;
+}
+
+type Match = {
+  index: number;
+  length: number;
+  render: (key: string, isConvertDisable: boolean) => React.ReactNode;
+};
+
+function findEarliestMatch(s: string, isConvertDisable: boolean): Match | null {
+  const candidates: Match[] = [];
+
+  const anchorRegexes = [
+    /(>>\*\d{1,5})/,
+    /(>>=\d{1,5})/,
+    /(>>\?\d{1,5})/,
+    /(>>_\d{1,5})/,
+    /(>>@\d{1,5})/,
+    /(>>-\d{1,5})/,
+    /(>>\+\d{1,5})/,
+    /(>>#\d{1,5})/,
+    /(>>a\d{1,5})/,
+    /(>>s\d{1,5})/,
+    /(>>\d{1,5})/,
+  ];
+  let earliestAnchor: { idx: number; text: string } | null = null;
+  for (const re of anchorRegexes) {
+    const m = re.exec(s);
+    if (!m) continue;
+    if (earliestAnchor == null) {
+      earliestAnchor = { idx: m.index, text: m[1] };
+      continue;
+    }
+    if (m.index < earliestAnchor.idx) {
+      earliestAnchor = { idx: m.index, text: m[1] };
+    } else if (m.index === earliestAnchor.idx && m[1].length > earliestAnchor.text.length) {
+      earliestAnchor = { idx: m.index, text: m[1] };
+    }
+  }
+  if (earliestAnchor) {
+    const { idx, text } = earliestAnchor;
+    candidates.push({
+      index: idx,
+      length: text.length,
+      render: (k) => <span key={k} className="message-link">{text}</span>,
+    });
+  }
+
+  if (!isConvertDisable) {
+    pushTag(/\[\[(#[0-9a-fA-F]{6})\]\]([\s\S]*?)\[\[\/#\]\]/, s, candidates, (m, k, cd) => (
+      <span key={k} style={{ color: m[1] }}>{parseLine(m[2], cd, `${k}-i`)}</span>
+    ));
+    pushTag(/\[\[b\]\]([\s\S]*?)\[\[\/b\]\]/, s, candidates, (m, k, cd) => (
+      <strong key={k}>{parseLine(m[1], cd, `${k}-i`)}</strong>
+    ));
+    pushTag(/\[\[s\]\]([\s\S]*?)\[\[\/s\]\]/, s, candidates, (m, k, cd) => (
+      <span key={k} style={{ textDecoration: "line-through" }}>{parseLine(m[1], cd, `${k}-i`)}</span>
+    ));
+    pushTag(/\[\[large\]\]([\s\S]*?)\[\[\/large\]\]/, s, candidates, (m, k, cd) => (
+      <span key={k} style={{ fontSize: "150%" }}>{parseLine(m[1], cd, `${k}-i`)}</span>
+    ));
+    pushTag(/\[\[small\]\]([\s\S]*?)\[\[\/small\]\]/, s, candidates, (m, k, cd) => (
+      <span key={k} style={{ fontSize: "80%" }}>{parseLine(m[1], cd, `${k}-i`)}</span>
+    ));
+    pushTag(/\[\[ruby\]\]([\s\S]*?)\[\[rt\]\]([\s\S]*?)\[\[\/rt\]\]\[\[\/ruby\]\]/, s, candidates, (m, k) => (
+      <ruby key={k}>{m[1]}<rt>{m[2]}</rt></ruby>
+    ));
+    pushTag(/\[\[netabare\]\]([\s\S]*?)\[\[\/netabare\]\]/, s, candidates, (m, k, cd) => (
+      <span key={k} className="netabare">{parseLine(m[1], cd, `${k}-i`)}</span>
+    ));
+    pushTag(/\[\[cw\]\]([\s\S]*?)\[\[\/cw\]\]/, s, candidates, (m, k, cd) => (
+      <span key={k} className="netabare">{parseLine(m[1], cd, `${k}-i`)}</span>
+    ));
+    pushTag(/\[\[tp\]\]([\s\S]*?)\[\[\/tp\]\]/, s, candidates, (m, k, cd) => (
+      <span key={k} className="transparency">{parseLine(m[1], cd, `${k}-i`)}</span>
+    ));
+  }
+
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => a.index - b.index);
+  return candidates[0];
+}
+
+function pushTag(
+  re: RegExp,
+  s: string,
+  candidates: Match[],
+  render: (m: RegExpExecArray, key: string, isConvertDisable: boolean) => React.ReactNode,
+) {
+  const m = re.exec(s);
+  if (!m) return;
+  candidates.push({
+    index: m.index,
+    length: m[0].length,
+    render: (k, cd) => render(m, k, cd),
+  });
 }

--- a/frontend/app/features/village/detail/MessageFilter.tsx
+++ b/frontend/app/features/village/detail/MessageFilter.tsx
@@ -111,25 +111,25 @@ export function MessageFilterModal({
       onClick={onClose}
     >
       <div
-        className="w-full max-w-3xl max-h-[90vh] overflow-y-auto rounded-xl bg-slate-900 border border-slate-700 p-5 space-y-4"
+        className="w-full max-w-3xl max-h-[90vh] overflow-y-auto rounded-xl bg-night-900 border border-night-700 p-5 space-y-4"
         onClick={(e) => e.stopPropagation()}
       >
         <h3 className="text-base font-semibold">発言抽出</h3>
 
         <section>
           <div className="flex items-center justify-between">
-            <h4 className="text-sm text-slate-300">発言種別</h4>
+            <h4 className="text-sm text-white">発言種別</h4>
             <div className="text-xs space-x-2">
               <button
                 type="button"
-                className="text-slate-300 hover:text-slate-100"
+                className="text-white hover:text-white"
                 onClick={() => setDraft((d) => ({ ...d, messageType: [] }))}
               >
                 クリア
               </button>
               <button
                 type="button"
-                className="text-slate-300 hover:text-slate-100"
+                className="text-white hover:text-white"
                 onClick={() =>
                   setDraft((d) => ({ ...d, messageType: MESSAGE_FILTER_TYPES.map((t) => t.code) }))
                 }
@@ -147,15 +147,15 @@ export function MessageFilterModal({
                   className={
                     "flex items-center gap-2 text-xs cursor-pointer rounded px-2 py-1 border " +
                     (active
-                      ? "bg-indigo-600/30 border-indigo-400 text-indigo-50"
-                      : "bg-slate-800/40 border-slate-700 text-slate-300 hover:bg-slate-700/40")
+                      ? "bg-mint-600/20 border-mint-500 text-white"
+                      : "bg-night-650 border-night-700 text-white hover:bg-night-650")
                   }
                 >
                   <input
                     type="checkbox"
                     checked={active}
                     onChange={() => toggleType(t.code)}
-                    className="accent-indigo-500"
+                    className="accent-mint-600"
                   />
                   {t.label}
                 </label>
@@ -181,34 +181,34 @@ export function MessageFilterModal({
         />
 
         <section>
-          <h4 className="text-sm text-slate-300">キーワード</h4>
+          <h4 className="text-sm text-white">キーワード</h4>
           <input
             type="text"
             value={draft.keyword}
             onChange={(e) => setDraft((d) => ({ ...d, keyword: e.target.value }))}
             placeholder="スペース区切りで OR"
-            className="mt-2 w-full rounded bg-slate-800 border border-slate-700 px-3 py-1.5 text-sm"
+            className="mt-2 w-full rounded-[3px] bg-night-900 border border-night-700 px-2 py-1 text-[1em] focus:outline-none focus:border-mint-500"
           />
         </section>
 
-        <div className="flex justify-end gap-2 pt-2 border-t border-slate-700">
+        <div className="flex justify-end gap-2 pt-2 border-t border-night-700">
           <button
             type="button"
-            className="rounded border border-slate-600 px-3 py-1.5 text-sm text-slate-200 hover:bg-slate-800"
+            className="rounded border border-night-700 px-3 py-1.5 text-sm text-white hover:bg-night-700"
             onClick={() => setDraft(EMPTY_FILTER)}
           >
             リセット
           </button>
           <button
             type="button"
-            className="rounded border border-slate-600 px-3 py-1.5 text-sm text-slate-200 hover:bg-slate-800"
+            className="rounded border border-night-700 px-3 py-1.5 text-sm text-white hover:bg-night-700"
             onClick={onClose}
           >
             閉じる
           </button>
           <button
             type="button"
-            className="rounded bg-indigo-500 hover:bg-indigo-400 px-3 py-1.5 text-sm text-white"
+            className="rounded bg-bs-success-500 hover:bg-bs-success-700 px-3 py-1.5 text-sm text-white"
             onClick={() => {
               onApply(draft);
               onClose();
@@ -238,10 +238,10 @@ function ParticipantSelector({
   return (
     <section>
       <div className="flex items-center justify-between">
-        <h4 className="text-sm text-slate-300">{title}</h4>
+        <h4 className="text-sm text-white">{title}</h4>
         <button
           type="button"
-          className="text-xs text-slate-300 hover:text-slate-100"
+          className="text-xs text-white hover:text-white"
           onClick={onClear}
         >
           クリア
@@ -256,15 +256,15 @@ function ParticipantSelector({
               className={
                 "flex items-center gap-2 text-xs cursor-pointer rounded px-2 py-1 border " +
                 (active
-                  ? "bg-indigo-600/30 border-indigo-400 text-indigo-50"
-                  : "bg-slate-800/40 border-slate-700 text-slate-300 hover:bg-slate-700/40")
+                  ? "bg-mint-600/20 border-mint-500 text-white"
+                  : "bg-night-650 border-night-700 text-white hover:bg-night-650")
               }
             >
               <input
                 type="checkbox"
                 checked={active}
                 onChange={() => onToggle(p.id)}
-                className="accent-indigo-500"
+                className="accent-mint-600"
               />
               <span className="truncate">{p.name}</span>
             </label>

--- a/frontend/app/features/village/detail/ParticipateActions.tsx
+++ b/frontend/app/features/village/detail/ParticipateActions.tsx
@@ -11,6 +11,7 @@ import type {
   MyselfView,
   VillageView,
 } from "./api";
+import { Panel as UIPanel, PanelBody, PanelHeading } from "~/components/ui/Panel";
 
 /**
  * プロローグ中の参加系操作 UI。
@@ -117,9 +118,9 @@ function ParticipateForm({ village }: { village: VillageView }) {
         {!isOriginal && (
           <Field label="キャラ">
             {isLoadingCharas ? (
-              <p className="text-slate-400 text-sm">読み込み中...</p>
+              <p className="opacity-80 text-sm">読み込み中...</p>
             ) : charas.length === 0 ? (
-              <p className="text-slate-400 text-sm">選択可能なキャラがいません</p>
+              <p className="opacity-80 text-sm">選択可能なキャラがいません</p>
             ) : (
               <CharaGrid charas={charas} selectedId={charaId} onSelect={onSelectChara} />
             )}
@@ -136,7 +137,7 @@ function ParticipateForm({ village }: { village: VillageView }) {
               disabled={mutation.isPending}
             />
             {charaImage && (
-              <p className="text-xs text-slate-400 mt-1">
+              <p className="text-xs opacity-80 mt-1">
                 {charaImage.name} ({Math.round(charaImage.size / 1024)} KB)
               </p>
             )}
@@ -198,7 +199,7 @@ function ParticipateForm({ village }: { village: VillageView }) {
               placeholder={`挨拶など (発言扱い、${MESSAGE_MAX_LENGTH} 文字以内)`}
               disabled={mutation.isPending}
             />
-            <p className="text-xs text-slate-500 text-right">
+            <p className="text-xs opacity-60 text-right">
               {joinMessage.length} / {MESSAGE_MAX_LENGTH}
             </p>
           </div>
@@ -218,7 +219,7 @@ function ParticipateForm({ village }: { village: VillageView }) {
         )}
 
         {settings.isSpectateAvailable && (
-          <label className="flex items-center gap-2 text-sm text-slate-200">
+          <label className="flex items-center gap-2 text-sm text-white">
             <input
               type="checkbox"
               checked={spectator}
@@ -238,7 +239,7 @@ function ParticipateForm({ village }: { village: VillageView }) {
             {mutation.isPending ? "送信中..." : spectator ? "見学する" : "入村する"}
           </button>
           {mutation.isError && (
-            <span className="text-xs text-rose-300">{mutation.error.message}</span>
+            <span className="text-xs text-blood-500">{mutation.error.message}</span>
           )}
         </div>
       </form>
@@ -266,12 +267,12 @@ function CharaGrid({
               onClick={() => onSelect(c.id)}
               className={`w-full text-left p-2 rounded border text-sm transition ${
                 isSelected
-                  ? "border-indigo-400 bg-indigo-500/20"
-                  : "border-slate-700 hover:border-slate-500 bg-slate-900/40"
+                  ? "border-mint-500 bg-mint-600/20"
+                  : "border-night-700 hover:border-mint-500 bg-night-900"
               }`}
             >
               <span className="font-medium">{c.name}</span>
-              <span className="ml-2 text-xs text-slate-400">[{c.shortName}]</span>
+              <span className="ml-2 text-xs opacity-80">[{c.shortName}]</span>
             </button>
           </li>
         );
@@ -302,7 +303,7 @@ function ParticipatingActions({
         )}
         {!village.isCreator && <LeaveButton villageId={village.id} />}
         {village.isCreator && (
-          <p className="text-xs text-slate-500">
+          <p className="text-xs opacity-60">
             村建ては退村できません (廃村は別途 admin 画面で操作)。
           </p>
         )}
@@ -330,7 +331,7 @@ function SwitchParticipateButton({
         {isSpectator ? "参加者になる" : "見学者になる"}
       </button>
       {mutation.isError && (
-        <span className="text-xs text-rose-300">{mutation.error.message}</span>
+        <span className="text-xs text-blood-500">{mutation.error.message}</span>
       )}
     </div>
   );
@@ -363,8 +364,8 @@ function ChangeRequestSkillForm({
   const submittable = !mutation.isPending;
 
   return (
-    <form onSubmit={submit} className="space-y-2 border-t border-slate-700/60 pt-3">
-      <p className="text-xs text-slate-400">希望役職変更</p>
+    <form onSubmit={submit} className="space-y-2 border-t border-night-700 pt-3">
+      <p className="text-xs opacity-80">希望役職変更</p>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
         <SkillSelect
           value={requestedSkill}
@@ -388,7 +389,7 @@ function ChangeRequestSkillForm({
           {mutation.isPending ? "送信中..." : "希望を反映"}
         </button>
         {mutation.isError && (
-          <span className="text-xs text-rose-300">{mutation.error.message}</span>
+          <span className="text-xs text-blood-500">{mutation.error.message}</span>
         )}
       </div>
     </form>
@@ -402,17 +403,17 @@ function LeaveButton({ villageId }: { villageId: number }) {
     mutation.mutate();
   }
   return (
-    <div className="flex items-center gap-3 border-t border-slate-700/60 pt-3">
+    <div className="flex items-center gap-3 border-t border-night-700 pt-3">
       <button
         type="button"
         onClick={onClick}
         disabled={mutation.isPending}
-        className="rounded bg-rose-600 hover:bg-rose-500 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium"
+        className="px-[9px] py-[6px] rounded-[3px] border-2 border-blood-500 bg-blood-500 text-white text-[13px] hover:bg-blood-600 hover:border-blood-600 disabled:opacity-50 disabled:cursor-not-allowed"
       >
         {mutation.isPending ? "送信中..." : "退村する"}
       </button>
       {mutation.isError && (
-        <span className="text-xs text-rose-300">{mutation.error.message}</span>
+        <span className="text-xs text-blood-500">{mutation.error.message}</span>
       )}
     </div>
   );
@@ -422,18 +423,21 @@ function LeaveButton({ villageId }: { villageId: number }) {
 
 function Panel({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
-      <h2 className="text-sm text-slate-400 mb-3">{title}</h2>
-      {children}
-    </section>
+    <UIPanel>
+      <PanelHeading>
+        <h2 className="text-[1em] m-0 font-normal">{title}</h2>
+      </PanelHeading>
+      <PanelBody>{children}</PanelBody>
+    </UIPanel>
   );
 }
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  // 旧 .form-horizontal 風: sm 以上で label を左 8em、コントロールを右に並べる
   return (
-    <div className="space-y-1">
-      <label className="text-xs text-slate-400">{label}</label>
-      {children}
+    <div className="sm:flex sm:items-start sm:gap-2 space-y-1 sm:space-y-0">
+      <label className="block sm:w-[8em] shrink-0 text-[0.95em] opacity-80 py-1">{label}</label>
+      <div className="flex-1 space-y-1">{children}</div>
     </div>
   );
 }
@@ -479,10 +483,10 @@ const MESSAGE_MAX_LENGTH = 400;
 const OMAKASE_CODE = "LEFTOVER";
 
 const inputClass =
-  "w-full bg-slate-900 border border-slate-700 rounded px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:outline-none focus:border-indigo-500 disabled:opacity-50";
+  "w-full bg-night-900 border border-night-700 rounded-[3px] px-2 py-1 text-[1em] focus:outline-none focus:border-mint-500 disabled:opacity-50";
 
 const primaryButtonClass =
-  "rounded bg-indigo-500 hover:bg-indigo-400 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium";
+  "px-[9px] py-[6px] rounded-[3px] border-2 border-bs-success-600 bg-bs-success-500 text-white text-[13px] hover:bg-bs-success-700 hover:border-bs-success-700 disabled:opacity-50 disabled:cursor-not-allowed";
 
 const secondaryButtonClass =
-  "rounded bg-slate-700 hover:bg-slate-600 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium";
+  "px-[9px] py-[6px] rounded-[3px] border-2 border-night-700 bg-night-800 text-white text-[13px] hover:bg-night-700 disabled:opacity-50 disabled:cursor-not-allowed";

--- a/frontend/app/features/village/detail/RoomGridPanel.tsx
+++ b/frontend/app/features/village/detail/RoomGridPanel.tsx
@@ -1,19 +1,12 @@
+import { HeartIcon } from "@heroicons/react/24/solid";
 import type { VillageParticipantView, VillageView } from "./api";
 
 /**
- * 部屋割りグリッド (旧 .old-thymeleaf/templates/village/situation.html の room
- * 部分を React に移植したもの)。
+ * 部屋割りグリッド (旧 .old-thymeleaf/templates/village/situation.html の room タブ相当)。
  *
- * 表示条件: 村の `roomWidth` が確定済 (= プロローグ終了後) かつ `day > 0`。
- * `village.participants.list` のうち `roomNumber` が割り当てられたものを対象に、
- * `roomWidth` 列のグリッドへ並べる。見学者と退村済は除外。
+ * SituationOverviewPanel のタブパネルとして使うため、Panel ラッパーは持たず内容のみ返す。
  *
- * 死亡者は半透明 + `<dead.day>d <記号>` を重ねる (記号: 襲撃系=▲ / 処刑=▼ /
- * 突然=凸 / 後追=❤ / MISERABLE=▲)。進行中の無惨死は backend が code/name を
- * `MISERABLE` / `無惨` に統一して返すので、フロントは MISERABLE → ▲ で扱う。
- *
- * 死亡判定は backend が現状 (最新日基準) で返す `dead` (= DeadView | null) を
- * 使う (任意の日の生死再現は範囲外、12c 以降)。
+ * 死亡記号: 処刑 ▼ / 突然 凸 / 後追 ハート icon (絵文字禁止) / 襲撃系 ▲ / MISERABLE ▲。
  */
 export function RoomGridPanel({
   village,
@@ -24,27 +17,22 @@ export function RoomGridPanel({
 }) {
   if (village.roomWidth == null || day <= 0) return null;
 
-  // 退村済 (isGone) は旧画面でも部屋割りから外れていたので除外する。
-  // 部屋番号順は backend (`sortedByRoomNumber()`) で確定済なのでフロント側 sort は不要。
   const roomed = village.participants.list.filter(
     (p) => p.roomNumber != null && !p.isGone,
   );
   if (roomed.length === 0) return null;
 
   return (
-    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
-      <h2 className="text-sm text-slate-400 mb-3">部屋割り</h2>
-      <div
-        className="grid gap-2"
-        style={{
-          gridTemplateColumns: `repeat(${village.roomWidth}, minmax(0, 1fr))`,
-        }}
-      >
-        {roomed.map((p) => (
-          <RoomCell key={p.id} participant={p} />
-        ))}
-      </div>
-    </section>
+    <div
+      className="grid gap-[2px]"
+      style={{
+        gridTemplateColumns: `repeat(${village.roomWidth}, minmax(0, 1fr))`,
+      }}
+    >
+      {roomed.map((p) => (
+        <RoomCell key={p.id} participant={p} />
+      ))}
+    </div>
   );
 }
 
@@ -55,11 +43,9 @@ function RoomCell({ participant }: { participant: VillageParticipantView }) {
     : "--";
   return (
     <div
-      className={
-        "relative flex flex-col items-center justify-end rounded border border-slate-700 bg-slate-900/40 p-1 " +
-        (dead ? "opacity-40" : "")
-      }
+      className="flex flex-col items-center justify-end border border-night-700 bg-night-900 p-1"
       title={participant.name}
+      style={dead ? { opacity: 0.5 } : undefined}
     >
       <img
         src={participant.chara.defaultImageUrl}
@@ -70,11 +56,12 @@ function RoomCell({ participant }: { participant: VillageParticipantView }) {
         className="shrink-0"
         style={{ maxWidth: 60, maxHeight: 60, width: "auto", height: "auto" }}
       />
-      <div className="text-[10px] font-mono text-center leading-tight text-slate-200 mt-0.5">
+      <div className="text-[0.85em] font-mono text-center leading-tight mt-0.5">
         <span>{room} {participant.chara.shortName}</span>
         {dead && (
-          <span className="block text-rose-300">
-            {dead.day}d {deadMarkOf(dead.code)}
+          <span className="flex items-center justify-center gap-0.5 mt-0.5">
+            <span>{dead.day}d</span>
+            <DeadMark code={dead.code} />
           </span>
         )}
       </div>
@@ -82,32 +69,22 @@ function RoomCell({ participant }: { participant: VillageParticipantView }) {
   );
 }
 
-/**
- * `CDef.DeadReason` の code (または backend の合成コード MISERABLE) から旧画面
- * 表記の記号を返す。
- * 旧 situation.html (line 80) の三項演算子は `EXECUTE → ▼`, `SUDDON → 凸`,
- * `SUICIDE → ❤︎`, それ以外 (襲撃系) → `▲`。襲撃系 (`ATTACK / DIVINED /
- * TRAPPED / BOMBED / ZAKO`) と `MISERABLE` (進行中マスク) を明示列挙して同じ ▲ にする。
- * 不明 code も安全側に倒して `▲` (= 何らかの無惨な死) として扱う。
- */
-function deadMarkOf(code: string): string {
+function DeadMark({ code }: { code: string }) {
   switch (code) {
     case "EXECUTE":
-      return "▼";
-    case "SUDDON": // backend の DeadReason 突然 の code は「SUDDON」(spelling は backend 既存)
-      return "凸";
+      return <span>▼</span>;
+    case "SUDDON":
+      return <span>凸</span>;
     case "SUICIDE":
-      return "❤";
-    // 旧画面で同色 (#ff0000) 扱いだった襲撃系。記号は ATTACK 含め全て ▲ に揃える。
-    // MISERABLE は進行中マスクの合成コード (backend が無惨死を統一して返す)。
+      return <HeartIcon className="inline-block w-[1em] h-[1em] text-blood-500" aria-label="後追" />;
     case "ATTACK":
     case "DIVINED":
     case "TRAPPED":
     case "BOMBED":
     case "ZAKO":
     case "MISERABLE":
-      return "▲";
+      return <span>▲</span>;
     default:
-      return "▲";
+      return <span>▲</span>;
   }
 }

--- a/frontend/app/features/village/detail/RpActions.tsx
+++ b/frontend/app/features/village/detail/RpActions.tsx
@@ -7,6 +7,7 @@ import {
   useFaceTypesQuery,
   useMemoMutation,
 } from "./hooks";
+import { Panel, PanelBody, PanelHeading } from "~/components/ui/Panel";
 
 /**
  * RP 系 (キャラ名 / 簡易メモ / 表情差分) の編集パネル。
@@ -36,12 +37,18 @@ export function RpActions({
   if (!showChangeName && !showMemo && !showFaceType) return null;
 
   return (
-    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4 space-y-4">
-      <h2 className="text-sm text-slate-400">RP</h2>
-      {showChangeName && <ChangeNameForm villageId={village.id} myself={myself} />}
-      {showMemo && <MemoForm villageId={village.id} myself={myself} />}
-      {showFaceType && <FaceTypesForm villageId={village.id} />}
-    </section>
+    <Panel>
+      <PanelHeading>
+        <h2 className="text-[1em] m-0 font-normal">RP</h2>
+      </PanelHeading>
+      <PanelBody>
+        <div className="space-y-4">
+          {showChangeName && <ChangeNameForm villageId={village.id} myself={myself} />}
+          {showMemo && <MemoForm villageId={village.id} myself={myself} />}
+          {showFaceType && <FaceTypesForm villageId={village.id} />}
+        </div>
+      </PanelBody>
+    </Panel>
   );
 }
 
@@ -74,8 +81,8 @@ function ChangeNameForm({ villageId, myself }: { villageId: number; myself: Myse
   const dirty = name !== myself.charaName || shortName !== myself.charaShortName;
 
   return (
-    <form onSubmit={submit} className="space-y-2 first:border-t-0 first:pt-0 border-t border-slate-700/60 pt-3">
-      <p className="text-xs text-slate-400">キャラ名変更</p>
+    <form onSubmit={submit} className="space-y-2 first:border-t-0 first:pt-0 border-t border-night-700 pt-3">
+      <p className="text-xs opacity-80">キャラ名変更</p>
       <div className="grid grid-cols-[1fr_5rem] gap-2 items-end">
         <Field label="表示名 (40 文字以内)">
           <input
@@ -107,7 +114,7 @@ function ChangeNameForm({ villageId, myself }: { villageId: number; myself: Myse
           {mutation.isPending ? "送信中..." : "名前を変更"}
         </button>
         {mutation.isError && (
-          <span className="text-xs text-rose-300">{mutation.error.message}</span>
+          <span className="text-xs text-blood-500">{mutation.error.message}</span>
         )}
       </div>
     </form>
@@ -136,8 +143,8 @@ function MemoForm({ villageId, myself }: { villageId: number; myself: MyselfView
   const dirty = memo !== (myself.memo ?? "");
 
   return (
-    <form onSubmit={submit} className="space-y-2 border-t border-slate-700/60 pt-3">
-      <p className="text-xs text-slate-400">簡易メモ ({MEMO_MAX_LENGTH} 文字以内、自分しか見えない)</p>
+    <form onSubmit={submit} className="space-y-2 border-t border-night-700 pt-3">
+      <p className="text-xs opacity-80">簡易メモ ({MEMO_MAX_LENGTH} 文字以内、自分しか見えない)</p>
       <input
         type="text"
         value={memo}
@@ -155,11 +162,11 @@ function MemoForm({ villageId, myself }: { villageId: number; myself: MyselfView
         >
           {mutation.isPending ? "送信中..." : "メモを保存"}
         </button>
-        <span className="text-xs text-slate-500">
+        <span className="text-xs opacity-60">
           {memo.length} / {MEMO_MAX_LENGTH}
         </span>
         {mutation.isError && (
-          <span className="text-xs text-rose-300">{mutation.error.message}</span>
+          <span className="text-xs text-blood-500">{mutation.error.message}</span>
         )}
       </div>
     </form>
@@ -207,22 +214,22 @@ function FaceTypesForm({ villageId }: { villageId: number }) {
     items.every((it) => it.name.trim().length >= 1 && it.name.trim().length <= 5);
 
   return (
-    <div className="space-y-4 border-t border-slate-700/60 pt-3">
+    <div className="space-y-4 border-t border-night-700 pt-3">
       <form onSubmit={submit} className="space-y-3">
-        <p className="text-xs text-slate-400">表情差分編集</p>
-        {query.isLoading && <p className="text-slate-400 text-sm">読み込み中...</p>}
+        <p className="text-xs opacity-80">表情差分編集</p>
+        {query.isLoading && <p className="opacity-80 text-sm">読み込み中...</p>}
         {query.isError && (
-          <p className="text-rose-300 text-sm">表情差分の取得に失敗しました</p>
+          <p className="text-blood-500 text-sm">表情差分の取得に失敗しました</p>
         )}
         {query.data && items.length === 0 && (
-          <p className="text-slate-400 text-sm">編集可能な表情差分がありません</p>
+          <p className="opacity-80 text-sm">編集可能な表情差分がありません</p>
         )}
         {items.length > 0 && (
           <ul className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             {items.map((it, idx) => (
               <li
                 key={it.code}
-                className="flex gap-3 items-start rounded border border-slate-700 p-2 bg-slate-900/40"
+                className="flex gap-3 items-start rounded border border-night-700 p-2 bg-night-900"
               >
                 <img
                   src={it.url}
@@ -241,7 +248,7 @@ function FaceTypesForm({ villageId }: { villageId: number }) {
                     placeholder="表情名 (1-5 文字)"
                     disabled={mutation.isPending}
                   />
-                  <label className="flex items-center gap-1 text-xs text-slate-300">
+                  <label className="flex items-center gap-1 text-xs text-white">
                     <input
                       type="checkbox"
                       checked={it.isDisplay}
@@ -264,7 +271,7 @@ function FaceTypesForm({ villageId }: { villageId: number }) {
             {mutation.isPending ? "送信中..." : "表情差分を更新"}
           </button>
           {mutation.isError && (
-            <span className="text-xs text-rose-300">{mutation.error.message}</span>
+            <span className="text-xs text-blood-500">{mutation.error.message}</span>
           )}
         </div>
       </form>
@@ -320,9 +327,9 @@ function AddFaceTypeForm({ villageId }: { villageId: number }) {
   }
 
   return (
-    <form onSubmit={submit} className="space-y-2 border-t border-slate-700/40 pt-3">
-      <p className="text-xs text-slate-400">表情差分追加</p>
-      <ul className="text-xs text-slate-500 list-disc pl-4 space-y-0.5">
+    <form onSubmit={submit} className="space-y-2 border-t border-night-700 pt-3">
+      <p className="text-xs opacity-80">表情差分追加</p>
+      <ul className="text-xs opacity-60 list-disc pl-4 space-y-0.5">
         <li>表情差分名は 1〜5 文字。</li>
         <li>画像は 60x60px で表示されるため 60 の倍数解像度推奨。</li>
         <li>100KB を超える画像はアップロードできません。</li>
@@ -347,12 +354,12 @@ function AddFaceTypeForm({ villageId }: { villageId: number }) {
             accept={FACE_TYPE_IMAGE_ACCEPT}
             onChange={onFileChange}
             disabled={mutation.isPending}
-            className="text-xs text-slate-200 file:mr-2 file:rounded file:border-0 file:bg-slate-700 file:px-2 file:py-1 file:text-slate-100 hover:file:bg-slate-600 disabled:opacity-50"
+            className="text-xs text-white file:mr-2 file:rounded file:border-0 file:bg-night-700 file:px-2 file:py-1 file:text-white hover:file:bg-night-600 disabled:opacity-50"
           />
         </Field>
       </div>
       {image != null && !imageValid && (
-        <p className="text-xs text-rose-300">
+        <p className="text-xs text-blood-500">
           {!imageExtValid
             ? "対応形式は png / jpg / jpeg / gif / webp のみです"
             : image.size === 0
@@ -369,7 +376,7 @@ function AddFaceTypeForm({ villageId }: { villageId: number }) {
           {mutation.isPending ? "送信中..." : "表情差分を追加"}
         </button>
         {mutation.isError && (
-          <span className="text-xs text-rose-300">{mutation.error.message}</span>
+          <span className="text-xs text-blood-500">{mutation.error.message}</span>
         )}
       </div>
     </form>
@@ -381,14 +388,14 @@ function AddFaceTypeForm({ villageId }: { villageId: number }) {
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="space-y-1">
-      <label className="text-xs text-slate-400">{label}</label>
+      <label className="text-xs opacity-80">{label}</label>
       {children}
     </div>
   );
 }
 
 const inputClass =
-  "w-full bg-slate-900 border border-slate-700 rounded px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:outline-none focus:border-indigo-500 disabled:opacity-50";
+  "w-full bg-night-900 border border-night-700 rounded-[3px] px-2 py-1 text-[1em] focus:outline-none focus:border-mint-500 disabled:opacity-50";
 
 const primaryButtonClass =
-  "rounded bg-indigo-500 hover:bg-indigo-400 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium";
+  "px-[9px] py-[6px] rounded-[3px] border-2 border-bs-success-600 bg-bs-success-500 text-white text-[13px] hover:bg-bs-success-700 hover:border-bs-success-700 disabled:opacity-50 disabled:cursor-not-allowed";

--- a/frontend/app/features/village/detail/SayForm.tsx
+++ b/frontend/app/features/village/detail/SayForm.tsx
@@ -2,6 +2,7 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { MyselfSayMessageTypeView, MyselfView } from "./api";
 import { useSayMutation } from "./hooks";
 import { useSayAnchorSubscription } from "./SayFormContext";
+import { Panel, PanelBody, PanelHeading } from "~/components/ui/Panel";
 
 const SECRET_SAY_CODE = "SECRET_SAY";
 
@@ -157,11 +158,13 @@ export function SayForm({
   }
 
   return (
-    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
-      <h2 className="text-sm text-slate-400 mb-2">発言</h2>
-
-      {/* 発言種別タブ */}
-      <div role="radiogroup" aria-label="発言種別" className="flex flex-wrap gap-1 mb-2">
+    <Panel>
+      <PanelHeading>
+        <h2 className="text-[1em] m-0 font-normal">発言</h2>
+      </PanelHeading>
+      <PanelBody>
+      {/* 発言種別タブ (旧 .btn-saytypes 相当) */}
+      <div role="radiogroup" aria-label="発言種別" className="flex flex-wrap gap-0 mb-2">
         {availableTypes.map((t) => (
           <MessageTypeButton
             key={t.code}
@@ -175,13 +178,13 @@ export function SayForm({
       {/* 秘話宛先 (秘話選択時のみ) */}
       {isSecret && (
         <div className="mb-2">
-          <label className="block text-xs text-slate-400 mb-1">秘話相手</label>
+          <label className="block text-xs opacity-80 mb-1">秘話相手</label>
           <select
             value={secretTargetCharaId}
             onChange={(e) =>
               setSecretTargetCharaId(e.target.value === "" ? "" : Number(e.target.value))
             }
-            className="w-full bg-slate-900 border border-slate-700 rounded px-2 py-1 text-sm text-slate-100"
+            className="w-full bg-night-900 border border-night-700 rounded px-2 py-1 text-sm text-white"
           >
             <option value="">秘話相手を選択してください</option>
             {secretSayTargets.map((t) => (
@@ -208,13 +211,13 @@ export function SayForm({
                 }
                 alt={faceTypeCode}
                 loading="lazy"
-                className="rounded border border-slate-700 max-w-full"
+                className="rounded border border-night-700 max-w-full"
                 style={{ maxHeight: 120, width: "auto", height: "auto" }}
               />
               <select
                 value={faceTypeCode}
                 onChange={(e) => setFaceTypeCode(e.target.value)}
-                className="mt-1 bg-slate-900 border border-slate-700 rounded px-1 py-0.5 text-xs text-slate-100"
+                className="mt-1 bg-night-900 border border-night-700 rounded px-1 py-0.5 text-xs text-white"
               >
                 {myself.say.selectableFaceTypes.map((f) => (
                   <option key={f.code} value={f.code}>
@@ -231,30 +234,30 @@ export function SayForm({
             onChange={(e) => setText(e.target.value)}
             rows={6}
             placeholder={`発言を入力 (${maxLength} 文字以内)`}
-            className="flex-1 bg-slate-900 border border-slate-700 rounded px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:outline-none focus:border-indigo-500"
+            className="flex-1 bg-night-900 border border-night-700 rounded px-3 py-2 text-sm text-white placeholder-slate-500 focus:outline-none focus:border-mint-500"
             disabled={sayMutation.isPending}
           />
         </div>
 
         {/* 文字数 / 行数 / 残り回数 */}
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-400">
-          <span className={isOverLength ? "text-rose-300" : ""}>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs opacity-80">
+          <span className={isOverLength ? "text-blood-500" : ""}>
             文字数 {text.length} / {maxLength}
           </span>
-          <span className={isOverLine ? "text-rose-300" : ""}>
+          <span className={isOverLine ? "text-blood-500" : ""}>
             行数 {lineCount} / {maxLine}
           </span>
           {remainingCount != null && maxCount != null && (
-            <span className={remainingCount === 0 ? "text-rose-300" : ""}>
+            <span className={remainingCount === 0 ? "text-blood-500" : ""}>
               残り {remainingCount} / {maxCount} 回
             </span>
           )}
-          <label className="ml-auto flex items-center gap-1 text-slate-300 cursor-pointer">
+          <label className="ml-auto flex items-center gap-1 text-white cursor-pointer">
             <input
               type="checkbox"
               checked={convertDisable}
               onChange={(e) => setConvertDisable(e.target.checked)}
-              className="accent-indigo-500"
+              className="accent-mint-600"
             />
             装飾・変換無効
           </label>
@@ -264,16 +267,17 @@ export function SayForm({
           <button
             type="submit"
             disabled={!canSubmit}
-            className="rounded bg-indigo-500 hover:bg-indigo-400 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium"
+            className="rounded bg-bs-success-500 hover:bg-bs-success-700 disabled:opacity-40 disabled:cursor-not-allowed px-4 py-1.5 text-sm font-medium"
           >
             {sayMutation.isPending ? "送信中..." : submitLabel(messageTypeCode)}
           </button>
           {sayMutation.isError && (
-            <span className="text-xs text-rose-300">{sayMutation.error.message}</span>
+            <span className="text-xs text-blood-500">{sayMutation.error.message}</span>
           )}
         </div>
       </form>
-    </section>
+      </PanelBody>
+    </Panel>
   );
 }
 
@@ -286,17 +290,20 @@ function MessageTypeButton({
   active: boolean;
   onSelect: () => void;
 }) {
+  // 旧 .btn-saytypes .btn-success: dark bg #222 + mint border + mint text
+  // active: mint bg + white text。BS3 btn-group の -1px overlap で連結 (見た目)
+  const base =
+    "-ml-px first:ml-0 px-[9px] py-[5px] border text-[13px] cursor-pointer transition-colors duration-100";
+  const cls = active
+    ? `${base} bg-mint-600 border-mint-600 text-white`
+    : `${base} bg-night-500 border-mint-600 text-mint-600 hover:bg-mint-600 hover:text-white`;
   return (
     <button
       type="button"
       role="radio"
       aria-checked={active}
       onClick={onSelect}
-      className={`px-2 py-1 rounded border text-xs ${
-        active
-          ? "bg-indigo-500 border-indigo-400 text-white"
-          : "bg-slate-900 border-slate-700 text-slate-300 hover:border-slate-500"
-      }`}
+      className={cls}
     >
       {type.name}
     </button>
@@ -330,7 +337,7 @@ function DecorationTagBar({
       <button
         type="button"
         onClick={() => onInsert("", "single")}
-        className="px-2 py-0.5 rounded border bg-slate-900 border-slate-700 text-slate-300 hover:border-slate-500 text-xs"
+        className="px-2 py-0.5 rounded border bg-night-900 border-night-700 text-white hover:border-mint-500 text-xs"
         title="[[]] を挿入"
       >
         [[]]
@@ -358,7 +365,7 @@ function TagBtn({
     <button
       type="button"
       onClick={() => onInsert(tag, kind)}
-      className={`px-2 py-0.5 rounded border bg-slate-900 border-slate-700 text-slate-300 hover:border-slate-500 text-xs ${
+      className={`px-2 py-0.5 rounded border bg-night-900 border-night-700 text-white hover:border-mint-500 text-xs ${
         bold ? "font-bold" : ""
       } ${strike ? "line-through" : ""}`}
       title={`[[${tag}]]...[[/${tag}]]`}
@@ -379,7 +386,7 @@ function ColorTagBtn({
     <button
       type="button"
       onClick={() => onInsert(color, "double")}
-      className="w-6 h-6 rounded border border-slate-700 hover:border-slate-400"
+      className="w-6 h-6 rounded border border-night-700 hover:border-slate-400"
       style={{ backgroundColor: color }}
       title={`[[${color}]]...[[/${color}]]`}
       aria-label={`色タグ ${color}`}

--- a/frontend/app/features/village/detail/SituationPanel.tsx
+++ b/frontend/app/features/village/detail/SituationPanel.tsx
@@ -54,12 +54,11 @@ export function SituationPanel({
   if (!hasWhole && !hasVote && !hasDayFootsteps) return null;
 
   return (
-    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4 space-y-5">
-      <h2 className="text-sm text-slate-400">状況</h2>
+    <div className="space-y-5">
       {hasWhole && <WholeTable rows={visibleWhole} />}
       {hasVote && <VoteTable vote={situation.vote} selectedDay={selectedDay} />}
       {hasDayFootsteps && <DayFootstepsTable rows={visibleDayFootsteps} />}
-    </section>
+    </div>
   );
 }
 
@@ -70,38 +69,38 @@ function WholeTable({ rows }: { rows: VillageSituationDayView[] }) {
   const hasAbility = rows.some((r) => r.ability.length > 0);
   return (
     <div className="overflow-x-auto">
-      <h3 className="text-xs text-slate-400 mb-1">日次状況</h3>
+      <h3 className="text-xs opacity-80 mb-1">日次状況</h3>
       <table className="min-w-full text-xs border-collapse">
         <thead>
-          <tr className="text-slate-400">
-            <th className="border border-slate-700 px-2 py-1 text-center w-12">日付</th>
-            <th className="border border-slate-700 px-2 py-1 text-left">突然死</th>
-            <th className="border border-slate-700 px-2 py-1 text-left">処刑</th>
-            <th className="border border-slate-700 px-2 py-1 text-left">無惨</th>
-            <th className="border border-slate-700 px-2 py-1 text-left">復活</th>
-            <th className="border border-slate-700 px-2 py-1 text-left">後追</th>
+          <tr className="opacity-80">
+            <th className="border border-night-700 px-2 py-1 text-center w-12">日付</th>
+            <th className="border border-night-700 px-2 py-1 text-left">突然死</th>
+            <th className="border border-night-700 px-2 py-1 text-left">処刑</th>
+            <th className="border border-night-700 px-2 py-1 text-left">無惨</th>
+            <th className="border border-night-700 px-2 py-1 text-left">復活</th>
+            <th className="border border-night-700 px-2 py-1 text-left">後追</th>
             {hasAbility && (
-              <th className="border border-slate-700 px-2 py-1 text-left">能力</th>
+              <th className="border border-night-700 px-2 py-1 text-left">能力</th>
             )}
           </tr>
         </thead>
         <tbody>
           {rows.map((r) => (
             <tr key={r.day}>
-              <td className="border border-slate-700 px-2 py-1 text-center text-slate-300">
+              <td className="border border-night-700 px-2 py-1 text-center text-white">
                 {r.day}d
               </td>
-              <td className="border border-slate-700 px-2 py-1">{formatList(r.suddenlyDeath)}</td>
-              <td className="border border-slate-700 px-2 py-1">{formatList(r.executed)}</td>
-              <td className="border border-slate-700 px-2 py-1">{formatList(r.miserable)}</td>
-              <td className="border border-slate-700 px-2 py-1">{formatList(r.revival)}</td>
-              <td className="border border-slate-700 px-2 py-1">{formatList(r.suicide)}</td>
+              <td className="border border-night-700 px-2 py-1">{formatList(r.suddenlyDeath)}</td>
+              <td className="border border-night-700 px-2 py-1">{formatList(r.executed)}</td>
+              <td className="border border-night-700 px-2 py-1">{formatList(r.miserable)}</td>
+              <td className="border border-night-700 px-2 py-1">{formatList(r.revival)}</td>
+              <td className="border border-night-700 px-2 py-1">{formatList(r.suicide)}</td>
               {hasAbility && (
                 // 能力履歴は backend (`AbilityDomainService.mapAbilitySituation`) が
                 // `[type]from → to` の整形済み文字列を 1 件 1 行で List に詰めて返す。
                 // 他の列 (突然死 / 処刑等) は単純な name list なので `formatList` で
                 // 「、」区切りにするが、ability は 1 件ずつが長い文字列のため改行で並べる。
-                <td className="border border-slate-700 px-2 py-1 whitespace-pre-line">
+                <td className="border border-night-700 px-2 py-1 whitespace-pre-line">
                   {r.ability.join("\n")}
                 </td>
               )}
@@ -140,13 +139,13 @@ function VoteTable({
 
   return (
     <div className="overflow-x-auto">
-      <h3 className="text-xs text-slate-400 mb-1">投票</h3>
+      <h3 className="text-xs opacity-80 mb-1">投票</h3>
       <table className="min-w-full text-xs border-collapse">
         <thead>
-          <tr className="text-slate-400">
-            <th className="border border-slate-700 px-2 py-1 text-left">投票者</th>
+          <tr className="opacity-80">
+            <th className="border border-night-700 px-2 py-1 text-left">投票者</th>
             {dayCols.map((d) => (
-              <th key={d} className="border border-slate-700 px-2 py-1 text-center">
+              <th key={d} className="border border-night-700 px-2 py-1 text-center">
                 {d}d
               </th>
             ))}
@@ -177,11 +176,11 @@ function VoteRow({
   }, [member.voteList]);
   return (
     <tr>
-      <td className="border border-slate-700 px-2 py-1 text-slate-300 whitespace-nowrap">
+      <td className="border border-night-700 px-2 py-1 text-white whitespace-nowrap">
         {member.charaShortName}
       </td>
       {dayCols.map((d) => (
-        <td key={d} className="border border-slate-700 px-2 py-1 text-center text-slate-200">
+        <td key={d} className="border border-night-700 px-2 py-1 text-center text-white">
           {byDay.get(d) ?? ""}
         </td>
       ))}
@@ -196,15 +195,15 @@ function DayFootstepsTable({
 }) {
   return (
     <div className="overflow-x-auto">
-      <h3 className="text-xs text-slate-400 mb-1">足音 (日別)</h3>
+      <h3 className="text-xs opacity-80 mb-1">足音 (日別)</h3>
       <table className="min-w-full text-xs border-collapse">
         <tbody>
           {rows.map((r) => (
             <tr key={r.day}>
-              <td className="border border-slate-700 px-2 py-1 text-center text-slate-300 w-12">
+              <td className="border border-night-700 px-2 py-1 text-center text-white w-12">
                 {r.day}d
               </td>
-              <td className="border border-slate-700 px-2 py-1 whitespace-pre-line">
+              <td className="border border-night-700 px-2 py-1 whitespace-pre-line">
                 {r.footstep.trim().length > 0 ? r.footstep : "なし"}
               </td>
             </tr>

--- a/frontend/app/features/village/detail/VillageInfoModal.tsx
+++ b/frontend/app/features/village/detail/VillageInfoModal.tsx
@@ -27,14 +27,14 @@ export function VillageInfoModal({
       onClick={onClose}
     >
       <div
-        className="w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-xl bg-slate-900 border border-slate-700 p-5 space-y-3"
+        className="w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-xl bg-night-900 border border-night-700 p-5 space-y-3"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between">
           <h3 className="text-base font-semibold">村情報</h3>
           <button
             type="button"
-            className="text-slate-400 hover:text-slate-200 text-sm"
+            className="opacity-80 hover:text-white text-sm"
             onClick={onClose}
             aria-label="閉じる"
           >
@@ -99,18 +99,18 @@ export function VillageInfoModal({
             <Row label="役職構成" value="ランダム編成 (闇鍋)" />
           )}
         </dl>
-        <div className="flex justify-end gap-2 pt-2 border-t border-slate-700">
+        <div className="flex justify-end gap-2 pt-2 border-t border-night-700">
           {village.isCreator && (
             <a
               href={`/wolf-mansion/villages/${village.id}/settings`}
-              className="rounded bg-emerald-600 hover:bg-emerald-500 px-3 py-1.5 text-sm text-white"
+              className="rounded bg-bs-success-500 hover:bg-bs-success-700 px-3 py-1.5 text-sm text-white"
             >
               設定変更
             </a>
           )}
           <button
             type="button"
-            className="rounded border border-slate-600 px-3 py-1.5 text-sm text-slate-200 hover:bg-slate-800"
+            className="rounded border border-night-700 px-3 py-1.5 text-sm text-white hover:bg-night-700"
             onClick={onClose}
           >
             閉じる
@@ -124,8 +124,8 @@ export function VillageInfoModal({
 function Row({ label, value }: { label: string; value: React.ReactNode }) {
   return (
     <>
-      <dt className="text-slate-400">{label}</dt>
-      <dd className="text-slate-100 break-all">{value}</dd>
+      <dt className="opacity-80">{label}</dt>
+      <dd className="text-white break-all">{value}</dd>
     </>
   );
 }

--- a/frontend/app/routes/villages.$id.tsx
+++ b/frontend/app/routes/villages.$id.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import { Link, useSearchParams } from "react-router";
+import { useQueryClient } from "@tanstack/react-query";
 import type { Route } from "./+types/villages.$id";
 import {
   fetchMyself,
@@ -24,6 +25,7 @@ import {
 import { ActionPanel } from "~/features/village/detail/ActionPanel";
 import { AdminPanel } from "~/features/village/detail/AdminPanel";
 import { CreatorPanel } from "~/features/village/detail/CreatorPanel";
+import { FooterMenuDock } from "~/features/village/detail/FooterMenuDock";
 import { MessageCard } from "~/features/village/detail/MessageCard";
 import { ParticipateActions } from "~/features/village/detail/ParticipateActions";
 import { RoomGridPanel } from "~/features/village/detail/RoomGridPanel";
@@ -40,20 +42,18 @@ import {
 import { VillageInfoModal } from "~/features/village/detail/VillageInfoModal";
 import { useMeQuery } from "~/features/auth/hooks";
 import { ssrFetch } from "~/lib/api/client";
+import { Panel, PanelBody, PanelHeading } from "~/components/ui/Panel";
+import { Button, LinkButton } from "~/components/ui/Button";
+import { PageHeader } from "~/components/layout/PageHeader";
+import { PageFooter } from "~/components/layout/PageFooter";
 
 const PAGE_SIZE = 50;
 
 export function meta({ data }: Route.MetaArgs) {
   const name = data?.village?.name ?? "村詳細";
-  return [{ title: `${name} - wolf-mansion` }];
+  return [{ title: `${name} | WOLF MANSION` }];
 }
 
-/**
- * `?day=` を整数に変換。負数 / NaN / 範囲外チェックは下流の backend に任せる
- * (backend は範囲外の day でも空の MessagesView を返す)。0 はプロローグなので valid。
- *
- * loader (SSR) とコンポーネント (CSR) 両方から呼ぶため module top に置く。
- */
 function parseDayParam(raw: string | null): number | undefined {
   if (raw == null || raw === "") return undefined;
   const n = Number(raw);
@@ -68,10 +68,6 @@ function parsePageParam(raw: string | null): number | undefined {
   return n;
 }
 
-/**
- * URL クエリ (`?type=A,B` `&from=1,2` `&to=3` `&kw=...`) を MessageFilterValue にパース。
- * 旧 Thymeleaf 互換ではなく URL を短く保つため、カンマ区切り 1 パラメータ + 短いキー名にした。
- */
 function parseFilterFromParams(p: URLSearchParams): MessageFilterValue {
   const messageType = (p.get("type") ?? "")
     .split(",")
@@ -108,10 +104,6 @@ function sortedStrings(arr: string[]): string[] {
   return [...arr].sort();
 }
 
-/**
- * フィルタの等価判定。配列の順序差を吸収するため sort 後に比較する。
- * useVillageMessagesQuery 側の queryKey 生成と同じ正規化方針。
- */
 function isFilterEqual(a: MessageFilterValue, b: MessageFilterValue): boolean {
   if (a.keyword.trim() !== b.keyword.trim()) return false;
   const aType = sortedStrings(a.messageType);
@@ -158,21 +150,14 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   const initialFilter = parseFilterFromParams(url.searchParams);
   const initialPage = parsePageParam(url.searchParams.get("page"));
   const api = ssrFetch(request);
-  // 村の存在確認を先行させる。村が無い場合に messages / footsteps / myself へ
-  // 無駄な API コール (backend で同じく 404 になる) が走るのを避けるため。
   const village = await fetchVillage(villageId, api).catch(() => null);
   if (!village) throw new Response("village not found", { status: 404 });
-  // 初期表示日: ?day= があればそれ、無ければ最新日 (= backend で `day` 未指定時と同じ)。
-  // 「latest」をクエリキーに乗せる都合で、ここでは明示的に number に正規化して渡す。
   const initialDay = dayParam ?? village.time.latestDay;
-  // フィルタ / ページ指定があれば SSR でも反映 (URL 共有時の見た目を一致させる)。
   const messagesQuery = buildMessagesQuery(initialDay, initialFilter, initialPage);
   const [messages, footsteps, myself, situation] = await Promise.all([
     fetchVillageMessages(villageId, messagesQuery, api).catch(() => null),
     fetchVillageFootsteps(villageId, api).catch(() => null),
     fetchMyself(villageId, api).catch(() => null),
-    // situation は day を渡さなくても backend 側で latestDay を採用するため未指定で OK。
-    // CSR でも `useVillageSituationQuery` は day なしで叩く想定。
     fetchVillageSituation(villageId, undefined, api).catch(() => null),
   ]);
   return {
@@ -202,7 +187,6 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
   } = loaderData;
 
   const [params, setParams] = useSearchParams();
-  // ?day を最優先で使い、無ければ loader で求めた initialDay (= latest) にフォールバック。
   const selectedDay = parseDayParam(params.get("day")) ?? initialDay;
   const filter = useMemo(() => parseFilterFromParams(params), [params]);
   const page = parsePageParam(params.get("page"));
@@ -213,10 +197,6 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
   const [showInfo, setShowInfo] = useState(false);
 
   const villageQuery = useVillageQuery(villageId, initialVillage);
-  // SSR initialData: 日 / フィルタ / ページが loader と一致するときだけ使う。
-  // どれかが変われば別データなので initial を渡すと不整合になる。
-  // フィルタ比較は配列の順序差で initial を捨てないよう、useVillageMessagesQuery
-  // 側の queryKey と同じく sort 後比較で揃える。
   const isInitialView =
     selectedDay === initialDay &&
     page === initialPage &&
@@ -230,37 +210,26 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
   const footstepsQuery = useVillageFootstepsQuery(villageId, initialFootsteps ?? undefined);
   const myselfQuery = useMyselfQuery(villageId, initialMyself);
   const situationQuery = useVillageSituationQuery(villageId, initialSituation ?? undefined);
-  // 認証情報を取得して管理者 (CDef.Authority.管理者) 判定に使う。
-  // SSR / 未ログイン時は失敗するが、`error` を握りつぶし `isAdmin=false` 扱いで進める。
   const meQuery = useMeQuery();
   const authority = meQuery.data?.user?.authority;
   const isAdmin = authority === "管理者";
 
   const village = villageQuery.data ?? initialVillage;
-  // useVillageMessagesQuery に initialData を渡しているので messagesQuery.data は
-  // 同値で同期される。`?? messagesInitialData` を再度書く必要はない。
   const messages = messagesQuery.data ?? null;
   const footsteps = footstepsQuery.data ?? initialFootsteps ?? null;
   const myself = myselfQuery.data ?? initialMyself ?? null;
   const situation = situationQuery.data ?? initialSituation ?? null;
-  // creator パネルの表示判定: 村建て本人または管理者 (旧仕様: 管理者 = 全村 creator 扱い)。
   const canSeeCreatorPanel = village.isCreator || isAdmin;
-  // 発言は常に最新日に積まれる。過去日タブを見ているときに発言してもその日には
-  // 出ないので、混乱を避けるため SayForm は最新日表示時のみ出す。
   const isViewingLatestDay = selectedDay === village.time.latestDay;
 
   const latestDay = village.time.latestDay;
-  // setParams の updater 形式で前回値を取り、`params` を依存配列から外す
-  // (URLSearchParams は毎 render 新インスタンスなので依存に入れると memo が無効化される)。
   const selectDay = useCallback(
     (day: number) => {
       setParams(
         (prev) => {
           const next = new URLSearchParams(prev);
-          // 最新日に戻すときは ?day= を消して URL を綺麗に保つ。
           if (day === latestDay) next.delete("day");
           else next.set("day", String(day));
-          // 日付を切り替えたらページ番号はリセット (異なる日のページ位置は意味なし)。
           next.delete("page");
           return next;
         },
@@ -276,7 +245,6 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
         (prev) => {
           const next = new URLSearchParams(prev);
           applyFilterToParams(next, v);
-          // フィルタ変更でページ番号はリセット (件数が変わるため意味が変わる)。
           next.delete("page");
           return next;
         },
@@ -301,25 +269,24 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
     [setParams],
   );
 
-  // SayForm 表示判定: 最新日 + backend が「発言可能」と返している場合のみ。
-  // `availableMessageTypes` が空のときは backend が事前に「発言できる種別なし」と
-  // 判断しているので、フロント側で死亡 / 見学のフラグを別途確認しない。
-  // (見学者専用の `SPECTATE_SAY` 等も backend で availableMessageTypes に含まれるため)
   const canShowSayForm =
     myself != null &&
     isViewingLatestDay &&
     myself.say.isAvailableSay &&
     myself.say.availableMessageTypes.length > 0;
 
+  const queryClient = useQueryClient();
+  const refreshAll = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ["village", villageId] });
+  }, [queryClient, villageId]);
+
   return (
-    <main className="min-h-screen bg-slate-900 text-slate-100">
-      <section className="max-w-4xl mx-auto px-6 py-10 space-y-6">
+    <main className="max-w-[1170px] mx-auto text-white pb-[40px]">
+      <PageHeader />
+      <section className="px-[15px] pb-[60px] space-y-[15px]">
         <SayFormProvider>
           <VillageHeader
             village={village}
-            onOpenInfo={() => setShowInfo(true)}
-            onOpenFilter={() => setShowFilter(true)}
-            isFiltered={isFiltered}
             villageId={villageId}
             selectedDay={selectedDay}
           />
@@ -328,7 +295,23 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
             days={village.days.list.map((d) => d.day)}
             selectedDay={selectedDay}
             onSelect={selectDay}
+            statusName={village.statusName}
           />
+
+          {/* 旧 village.html はメッセージを最上位に置く構成。
+              user-context panel (あなた / 参加 / RP / 行動 / Creator / Admin) は
+              メッセージの下、SayForm の前後で並べる。 */}
+          <MessagesPanel
+            messages={messages}
+            day={selectedDay}
+            participants={village.participants.list}
+            isPaging={isPaging}
+            onSetPage={setPage}
+          />
+
+          {canShowSayForm && !isFiltered && !isPaging && (
+            <SayForm villageId={villageId} myself={myself!} />
+          )}
 
           {myself && <MyselfPanel myself={myself} />}
 
@@ -342,23 +325,11 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
 
           {isAdmin && <AdminPanel village={village} />}
 
-          <RoomGridPanel village={village} day={selectedDay} />
-
-          <ParticipantsPanel participants={village.participants.list} />
-
-          <SituationPanel situation={situation} selectedDay={selectedDay} />
-
-          <MessagesPanel
-            messages={messages}
-            day={selectedDay}
-            participants={village.participants.list}
-            isPaging={isPaging}
-            onSetPage={setPage}
+          <SituationOverviewPanel
+            village={village}
+            situation={situation}
+            selectedDay={selectedDay}
           />
-
-          {canShowSayForm && !isFiltered && !isPaging && (
-            <SayForm villageId={villageId} myself={myself!} />
-          )}
 
           <FootstepsPanel footsteps={footsteps} />
         </SayFormProvider>
@@ -376,80 +347,58 @@ export default function VillageDetail({ loaderData }: Route.ComponentProps) {
           onClose={() => setShowInfo(false)}
         />
       </section>
+      <PageFooter />
+      <FooterMenuDock
+        onOpenInfo={() => setShowInfo(true)}
+        onOpenFilter={() => setShowFilter(true)}
+        isFiltered={isFiltered}
+        showVoteShortcut={
+          !!myself &&
+          village.statusCode === "IN_PROGRESS" &&
+          myself.vote.canVote &&
+          myself.vote.targetCharaId == null
+        }
+        onGoToVote={() => {
+          const el = document.querySelector("[data-action-panel]");
+          el?.scrollIntoView({ behavior: "smooth", block: "start" });
+        }}
+        onRefresh={refreshAll}
+      />
     </main>
   );
 }
 
 // ---------- 部品 ----------
 
+/**
+ * 旧 village.html の冒頭部分 (`0001. 村名` のヘッダ行 + ステータスタグ + 補助 link) 相当。
+ * 本番計測 (wolfort.net /village/13) では:
+ * - h1: 22.5px / weight 400 / line-height 1.428em
+ * - 村番号は `0001.` (4桁ゼロ詰め + ピリオド) で名前と空白なし結合
+ */
 function VillageHeader({
   village,
   villageId,
   selectedDay,
-  onOpenInfo,
-  onOpenFilter,
-  isFiltered,
 }: {
   village: VillageView;
   villageId: number;
   selectedDay: number;
-  onOpenInfo: () => void;
-  onOpenFilter: () => void;
-  isFiltered: boolean;
 }) {
+  // 旧 village.html 踏襲: h1 は `0001. 村名` のみで status badge は含めない。
+  // 状態名は DayTabs 末尾に出している (= 旧画面のレイアウト)。
   return (
-    <header className="space-y-2">
-      <div className="flex items-center justify-between">
-        <div className="flex items-baseline gap-3">
-          <span className="font-mono text-slate-400 text-sm">#{village.number}</span>
-          <h1 className="text-2xl font-bold">{village.name}</h1>
-        </div>
-        <Link to="/villages" className="text-sm text-slate-400 hover:text-slate-200">
-          ← 村一覧
-        </Link>
-      </div>
-      <div className="flex flex-wrap items-center gap-3 text-sm text-slate-300">
-        <StatusBadge name={village.statusName} />
-        <span>現在 {village.time.latestDay}日目</span>
-        {village.time.nextDayChangeDatetime && (
-          <span className="text-slate-400">
-            次回更新: {formatDateTime(village.time.nextDayChangeDatetime)}
-          </span>
-        )}
-        {village.winCampName && (
-          <span className="text-amber-300">勝利: {village.winCampName}</span>
-        )}
-      </div>
-      <p className="text-xs text-slate-500">
-        村建て: {village.createPlayerName} / {village.participants.count}人
-        {village.participants.spectatorCount > 0 ? ` (見学${village.participants.spectatorCount})` : ""}
-      </p>
-      <div className="flex flex-wrap gap-2 pt-1">
-        <button
-          type="button"
-          className="rounded border border-slate-600 px-2.5 py-1 text-xs text-slate-200 hover:bg-slate-800"
-          onClick={onOpenInfo}
-        >
-          村情報
-        </button>
-        <button
-          type="button"
-          className={
-            "rounded border px-2.5 py-1 text-xs " +
-            (isFiltered
-              ? "border-indigo-400 bg-indigo-600/30 text-indigo-50"
-              : "border-slate-600 text-slate-200 hover:bg-slate-800")
-          }
-          onClick={onOpenFilter}
-          aria-pressed={isFiltered}
-        >
-          発言抽出{isFiltered ? " (絞り込み中)" : ""}
-        </button>
+    <header className="flex items-baseline justify-between flex-wrap gap-2">
+      <h1 className="text-[1.875em] font-normal m-0 leading-[1.1]">
+        {village.number}. {village.name}
+      </h1>
+      <div className="flex items-center gap-2 text-[0.95em]">
+        <Link to="/villages" className="message-link hover:underline">← 村一覧</Link>
         <Link
           to={`/villages/${villageId}/scrap?day=${selectedDay}`}
           target="_blank"
           rel="noopener noreferrer"
-          className="rounded border border-slate-600 px-2.5 py-1 text-xs text-slate-200 hover:bg-slate-800"
+          className="message-link hover:underline"
         >
           切り抜き ↗
         </Link>
@@ -460,80 +409,152 @@ function VillageHeader({
 
 /**
  * 旧 .old-thymeleaf/templates/village/village-day-list.html 相当の日付タブ。
- * `?day=N` を URL に同期させ、ページ遷移なしで messages を切り替える。
+ *
+ * 本番は BS3 btn-group を ul として並べ、active=mint背景+白字 / inactive=黒背景+mint枠+mint字 の
+ * .btn-success スタイル。村末尾には現ステータス (進行中 / 終了 等) を `<li>` で出している。
  */
 function DayTabs({
   days,
   selectedDay,
   onSelect,
+  statusName,
 }: {
   days: number[];
   selectedDay: number;
   onSelect: (day: number) => void;
+  statusName: string;
 }) {
   if (days.length === 0) return null;
-  // 単一の MessagesPanel に対する切替なので tablist パターンを採用 (role=tab + aria-selected)。
-  // 矢印キーナビ (roving tabindex) は実装しないため tabIndex は全タブ 0 のまま
-  // (= Tab キーで巡回できる)。12b 以降で role=tabpanel + 矢印キー対応をまとめて入れる。
   return (
-    <div
+    <ul
       role="tablist"
       aria-label="日付ナビゲーション"
-      className="flex flex-wrap gap-1 rounded-xl bg-slate-800/30 border border-slate-700 p-2"
+      className="flex flex-wrap items-center gap-0 list-none m-0 p-0"
     >
       {days.map((day) => {
         const active = day === selectedDay;
         return (
-          <button
-            key={day}
-            type="button"
-            role="tab"
-            aria-selected={active}
-            onClick={() => onSelect(day)}
-            className={
-              "rounded px-2.5 py-1 text-xs font-mono transition " +
-              (active
-                ? "bg-indigo-500/40 text-indigo-50 border border-indigo-400"
-                : "border border-transparent text-slate-300 hover:bg-slate-700/40")
-            }
-          >
-            {day === 0 ? "プロローグ" : `${day}日目`}
-          </button>
+          <li key={day} className="-ml-px first:ml-0">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => onSelect(day)}
+              className={
+                "px-[9px] py-[5px] border text-[13px] leading-[1.4] cursor-pointer transition-colors duration-100 " +
+                (active
+                  ? "bg-mint-600 border-mint-600 text-white"
+                  : "bg-night-500 border-mint-600 text-mint-600 hover:bg-mint-600 hover:text-white")
+              }
+            >
+              {day === 0 ? "プロローグ" : `${day}日目`}
+            </button>
+          </li>
         );
       })}
-    </div>
+      <li className="px-3 text-[13px] opacity-80">{statusName}</li>
+    </ul>
   );
 }
 
 function MyselfPanel({ myself }: { myself: MyselfView }) {
   return (
-    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
-      <h2 className="text-sm text-slate-400 mb-2">あなた</h2>
-      <p className="text-base">
-        {myself.name}
-        {myself.skill && <span className="ml-2 text-indigo-300">[{myself.skill.name}]</span>}
-        {myself.campCode && <span className="ml-2 text-amber-300">{myself.campCode}</span>}
-        {myself.isDead && <span className="ml-2 text-rose-300">死亡</span>}
-      </p>
-    </section>
+    <Panel>
+      <PanelHeading>
+        <h2 className="text-[1em] m-0 font-normal">あなた</h2>
+      </PanelHeading>
+      <PanelBody>
+        <p className="m-0 text-[1em]">
+          {myself.name}
+          {myself.skill && <span className="ml-2 text-mint-500">[{myself.skill.name}]</span>}
+          {myself.campCode && <span className="ml-2 text-warning-500">{myself.campCode}</span>}
+          {myself.isDead && <span className="ml-2 text-blood-500">死亡</span>}
+        </p>
+      </PanelBody>
+    </Panel>
   );
 }
 
 /**
- * 旧 .old-thymeleaf/templates/village/situation.html 参加者タブ相当。
- * 生存 / 死亡 (見学者は別途末尾) に分割表示し、memo / 死亡日時を出す。
+ * 旧 situation.html の "状況 / 部屋割り当て / 参加者 / 投票 / 足音" タブ群相当。
+ * Panel 1 枚の中にタブ UI を構築し、本番のコンパクトな表示に揃える。
+ *
+ * 本番は jQuery タブで切替えるが、React 版は state でタブ切替。
+ * RoomGridPanel / ParticipantsPanel / SituationPanel をタブパネルとして組み合わせる。
  */
+function SituationOverviewPanel({
+  village,
+  situation,
+  selectedDay,
+}: {
+  village: VillageView;
+  situation: ReturnType<typeof useVillageSituationQuery>["data"] | null;
+  selectedDay: number;
+}) {
+  // 表示可能なタブを決める
+  const hasRoom = village.roomWidth != null && selectedDay > 0;
+  // 参加者は常にあり (1人でも)。
+  const hasParticipants = village.participants.list.length > 0;
+  const hasSituation = situation != null && selectedDay > 0;
+
+  type Tab = "room" | "participants" | "situation";
+  const tabs: Tab[] = [];
+  if (hasRoom) tabs.push("room");
+  if (hasParticipants) tabs.push("participants");
+  if (hasSituation) tabs.push("situation");
+
+  const [active, setActive] = useState<Tab>(tabs[0] ?? "participants");
+
+  if (tabs.length === 0) return null;
+
+  const tabLabel: Record<Tab, string> = {
+    room: "部屋割り当て",
+    participants: "参加者",
+    situation: "状況",
+  };
+
+  return (
+    <Panel>
+      <PanelHeading>
+        <ul className="flex list-none m-0 p-0 -my-[10px] -mx-[15px]">
+          {tabs.map((t) => {
+            const isActive = t === active;
+            return (
+              <li key={t}>
+                <button
+                  type="button"
+                  onClick={() => setActive(t)}
+                  className={
+                    "px-[15px] py-[10px] text-[13px] cursor-pointer border-b-2 transition-colors duration-100 " +
+                    (isActive
+                      ? "border-mint-500 text-mint-500"
+                      : "border-transparent text-white hover:text-mint-500")
+                  }
+                >
+                  {tabLabel[t]}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </PanelHeading>
+      <PanelBody>
+        {active === "room" && hasRoom && <RoomGridPanel village={village} day={selectedDay} />}
+        {active === "participants" && (
+          <ParticipantsPanel participants={village.participants.list} />
+        )}
+        {active === "situation" && (
+          <SituationPanel situation={situation ?? null} selectedDay={selectedDay} />
+        )}
+      </PanelBody>
+    </Panel>
+  );
+}
+
 function ParticipantsPanel({ participants }: { participants: VillageParticipantView[] }) {
   if (participants.length === 0) {
-    return (
-      <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
-        <h2 className="text-sm text-slate-400">参加者</h2>
-        <p className="text-slate-400 text-sm py-2">まだ参加者がいません</p>
-      </section>
-    );
+    return <p className="opacity-80 m-0 py-2">まだ参加者がいません</p>;
   }
-  // 退村済み (isGone) は旧画面でも参加者一覧から外れていたので除外する。
-  // 残りを生存 (見学を含めない) / 死亡 / 見学 の 3 カテゴリへ振り分ける。
   const alive: VillageParticipantView[] = [];
   const dead: VillageParticipantView[] = [];
   const spectators: VillageParticipantView[] = [];
@@ -544,17 +565,13 @@ function ParticipantsPanel({ participants }: { participants: VillageParticipantV
     else alive.push(p);
   }
   return (
-    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4 space-y-4">
-      <h2 className="text-sm text-slate-400">
-        参加者 (生存 {alive.length} / 死亡 {dead.length}
-        {spectators.length > 0 ? ` / 見学 ${spectators.length}` : ""})
-      </h2>
+    <div className="space-y-3">
       <ParticipantSubList title={`生存 (${alive.length})`} items={alive} kind="alive" />
       <ParticipantSubList title={`死亡 (${dead.length})`} items={dead} kind="dead" />
       {spectators.length > 0 && (
         <ParticipantSubList title={`見学 (${spectators.length})`} items={spectators} kind="spectator" />
       )}
-    </section>
+    </div>
   );
 }
 
@@ -572,8 +589,8 @@ function ParticipantSubList({
   if (items.length === 0) {
     return (
       <div>
-        <h3 className="text-xs text-slate-400 mb-1">{title}</h3>
-        <p className="text-xs text-slate-500 px-2">なし</p>
+        <h3 className="text-[0.95em] opacity-80 mb-1">{title}</h3>
+        <p className="text-[0.85em] opacity-60 px-2 m-0">なし</p>
       </div>
     );
   }
@@ -581,28 +598,27 @@ function ParticipantSubList({
   const isSpectator = kind === "spectator";
   return (
     <div>
-      <h3 className="text-xs text-slate-400 mb-1">{title}</h3>
-      <ul className="grid grid-cols-1 sm:grid-cols-2 gap-1.5">
+      <h3 className="text-[0.95em] opacity-80 mb-1">{title}</h3>
+      <ul className="grid grid-cols-1 sm:grid-cols-2 gap-1.5 list-none p-0 m-0">
         {items.map((p) => (
-          <li key={p.id} className="flex items-center gap-2 text-sm">
-            <span className="font-mono text-slate-500 w-10 shrink-0">
+          <li key={p.id} className="flex items-center gap-2 text-[0.95em]">
+            <span className="font-mono opacity-60 w-10 shrink-0">
               {p.roomNumber != null ? String(p.roomNumber).padStart(2, "0") : "--"}
             </span>
-            <span className={`flex-1 truncate ${isDead ? "text-slate-400" : ""}`}>
+            <span className={`flex-1 truncate ${isDead ? "opacity-80" : ""}`}>
               {p.name}
               {p.memo && (
-                <span className="ml-2 text-slate-500 text-xs">[{p.memo}]</span>
+                <span className="ml-2 opacity-60 text-[0.85em]">[{p.memo}]</span>
               )}
             </span>
             {p.skill && (
-              <span className="text-xs text-indigo-300 shrink-0">[{p.skill.shortName}]</span>
+              <span className="text-[0.85em] text-mint-500 shrink-0">[{p.skill.shortName}]</span>
             )}
             {isSpectator && (
-              <span className="text-xs text-slate-400 shrink-0">見学</span>
+              <span className="text-[0.85em] opacity-80 shrink-0">見学</span>
             )}
-            {/* p.dead は backend で進行中の無惨死を MISERABLE / 無惨 にマスク済 */}
             {isDead && p.dead && (
-              <span className="text-xs text-rose-300 shrink-0">
+              <span className="text-[0.85em] text-blood-500 shrink-0">
                 {p.dead.day}d {p.dead.name}
               </span>
             )}
@@ -626,8 +642,6 @@ function MessagesPanel({
   isPaging: boolean;
   onSetPage: (page: number) => void;
 }) {
-  // fromParticipantId → VillageParticipantView の逆引きマップを 1 回だけ作る。
-  // useMemo で participants 配列の identity が変わったときのみ作り直す。
   const participantsById = useMemo(
     () => new Map(participants.map((p) => [p.id, p])),
     [participants],
@@ -635,42 +649,20 @@ function MessagesPanel({
   const count = messages?.list.length ?? 0;
   const currentPage = messages?.currentPageNum ?? null;
   const totalPages = messages?.allPageCount ?? 0;
-  // backend 側 `isExistPrePage` / `isExistNextPage` を信頼する (フィルタ込で正確に出ている)。
   const hasPrev = messages?.isExistPrePage ?? false;
   const hasNext = messages?.isExistNextPage ?? false;
   return (
-    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
-      <div className="flex flex-wrap items-center justify-between mb-3 gap-2">
-        <h2 className="text-sm text-slate-400">
-          発言 ({day === 0 ? "プロローグ" : `${day}日目`} · {count}件)
-          {isPaging && totalPages > 0 && currentPage != null && (
-            <span className="ml-2 text-slate-500">
-              ({currentPage} / {totalPages} ページ)
-            </span>
-          )}
-        </h2>
-        <Pagination
-          isPaging={isPaging}
-          currentPage={currentPage}
-          totalPages={totalPages}
-          hasPrev={hasPrev}
-          hasNext={hasNext}
-          onSetPage={onSetPage}
-        />
-      </div>
-      {!messages || count === 0 ? (
-        <p className="text-slate-400 text-sm py-2">この日の閲覧可能な発言はありません</p>
-      ) : (
-        <ul className="space-y-2 max-h-[640px] overflow-y-auto pr-1">
-          {messages.list.map((m, i) => (
-            <li key={`${m.typeCode}-${m.number ?? i}`}>
-              <MessageCard message={m} participantsById={participantsById} />
-            </li>
-          ))}
-        </ul>
-      )}
-      {(hasPrev || hasNext) && (
-        <div className="flex justify-end mt-3">
+    <Panel>
+      <PanelHeading>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h2 className="text-[1em] m-0 font-normal">
+            発言 ({day === 0 ? "プロローグ" : `${day}日目`} · {count}件)
+            {isPaging && totalPages > 0 && currentPage != null && (
+              <span className="ml-2 opacity-80">
+                ({currentPage} / {totalPages} ページ)
+              </span>
+            )}
+          </h2>
           <Pagination
             isPaging={isPaging}
             currentPage={currentPage}
@@ -680,8 +672,33 @@ function MessagesPanel({
             onSetPage={onSetPage}
           />
         </div>
-      )}
-    </section>
+      </PanelHeading>
+      <PanelBody>
+        {!messages || count === 0 ? (
+          <p className="opacity-80 m-0 py-2">この日の閲覧可能な発言はありません</p>
+        ) : (
+          <ul className="list-none p-0 m-0">
+            {messages.list.map((m, i) => (
+              <li key={`${m.typeCode}-${m.number ?? i}`}>
+                <MessageCard message={m} participantsById={participantsById} />
+              </li>
+            ))}
+          </ul>
+        )}
+        {(hasPrev || hasNext) && (
+          <div className="flex justify-end mt-3">
+            <Pagination
+              isPaging={isPaging}
+              currentPage={currentPage}
+              totalPages={totalPages}
+              hasPrev={hasPrev}
+              hasNext={hasNext}
+              onSetPage={onSetPage}
+            />
+          </div>
+        )}
+      </PanelBody>
+    </Panel>
   );
 }
 
@@ -700,13 +717,11 @@ function Pagination({
   hasNext: boolean;
   onSetPage: (page: number) => void;
 }) {
-  // 全件 1 ページに収まる (ページング ON で次/前なし) または paging OFF で表示が長すぎる
-  // ケースで "分割" ボタンを出す。`?page=1` を付けると backend が pageSize=50 で paging を ON にする。
   if (!isPaging) {
     return (
       <button
         type="button"
-        className="rounded border border-slate-600 px-2 py-0.5 text-xs text-slate-300 hover:bg-slate-800"
+        className="px-[9px] py-[5px] border border-mint-600 bg-night-500 text-mint-600 text-[13px] hover:bg-mint-600 hover:text-white"
         onClick={() => onSetPage(1)}
       >
         分割表示
@@ -715,21 +730,21 @@ function Pagination({
   }
   const cur = currentPage ?? 1;
   return (
-    <div className="flex items-center gap-1 text-xs">
+    <div className="flex items-center gap-1 text-[13px]">
       <button
         type="button"
-        className="rounded border border-slate-600 px-2 py-0.5 text-slate-200 disabled:opacity-40 hover:bg-slate-800"
+        className="px-[9px] py-[5px] border border-mint-600 bg-night-500 text-mint-600 disabled:opacity-40 hover:bg-mint-600 hover:text-white"
         onClick={() => onSetPage(cur - 1)}
         disabled={!hasPrev || cur <= 1}
       >
         ‹ 前
       </button>
-      <span className="px-1 text-slate-400">
+      <span className="px-1 opacity-80">
         {cur}/{totalPages || cur}
       </span>
       <button
         type="button"
-        className="rounded border border-slate-600 px-2 py-0.5 text-slate-200 disabled:opacity-40 hover:bg-slate-800"
+        className="px-[9px] py-[5px] border border-mint-600 bg-night-500 text-mint-600 disabled:opacity-40 hover:bg-mint-600 hover:text-white"
         onClick={() => onSetPage(cur + 1)}
         disabled={!hasNext}
       >
@@ -741,48 +756,34 @@ function Pagination({
 
 function FootstepsPanel({ footsteps }: { footsteps: VillageFootstepsView | null }) {
   return (
-    <section className="rounded-xl bg-slate-800/40 border border-slate-700 p-4">
-      <h2 className="text-sm text-slate-400 mb-3">足音</h2>
-      {!footsteps || footsteps.list.length === 0 ? (
-        <p className="text-slate-400 text-sm py-2">表示できる足音はありません</p>
-      ) : (
-        <ul className="space-y-1 text-sm">
-          {footsteps.list.map((f, i) => (
-            <li key={`${f.day}-${f.roomNumbers}-${i}`} className="flex items-center gap-2">
-              <span className="text-slate-500 w-12 shrink-0">{f.day}日目</span>
-              <span className="font-mono">{f.roomNumbers}</span>
-              {f.registerChara && (
-                <span className="text-xs text-slate-400">
-                  by {f.registerChara.shortName}
-                </span>
-              )}
-            </li>
-          ))}
-        </ul>
-      )}
-    </section>
-  );
-}
-
-// ---------- utils ----------
-
-const STATUS_BADGE: Record<string, string> = {
-  募集中: "bg-emerald-600/30 text-emerald-100 border-emerald-500/40",
-  進行中: "bg-amber-600/30 text-amber-100 border-amber-500/40",
-  エピローグ: "bg-sky-600/30 text-sky-100 border-sky-500/40",
-  終了: "bg-slate-600/30 text-slate-200 border-slate-500/40",
-  廃村: "bg-rose-600/30 text-rose-100 border-rose-500/40",
-};
-
-function StatusBadge({ name }: { name: string }) {
-  const cls = STATUS_BADGE[name] ?? "bg-slate-700/40 text-slate-200 border-slate-500/40";
-  return (
-    <span className={`text-xs px-2 py-0.5 rounded border ${cls}`}>{name}</span>
+    <Panel>
+      <PanelHeading>
+        <h2 className="text-[1em] m-0 font-normal">足音</h2>
+      </PanelHeading>
+      <PanelBody>
+        {!footsteps || footsteps.list.length === 0 ? (
+          <p className="opacity-80 m-0 py-2">表示できる足音はありません</p>
+        ) : (
+          <ul className="space-y-1 text-[0.95em] list-none p-0 m-0">
+            {footsteps.list.map((f, i) => (
+              <li key={`${f.day}-${f.roomNumbers}-${i}`} className="flex items-center gap-2">
+                <span className="opacity-60 w-12 shrink-0">{f.day}日目</span>
+                <span className="font-mono">{f.roomNumbers}</span>
+                {f.registerChara && (
+                  <span className="text-[0.85em] opacity-80">
+                    by {f.registerChara.shortName}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </PanelBody>
+    </Panel>
   );
 }
 
 function formatDateTime(iso: string): string {
-  // backend が LocalDateTime を ISO 文字列で返す前提。Date 経由で MM/dd HH:mm 形式に整形。
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return iso;
   const mm = String(d.getMonth() + 1).padStart(2, "0");


### PR DESCRIPTION
closes .issues/25-step-13c-village-detail-design-restore.md

前回 PR #44 は本番との乖離が大きく close した上での再アタック。
今回は **localhost:8091 (main 状態の旧 Thymeleaf 立ち上げ)** を playwright で並べながら、本番計測ベースで再構築した。

## 変更内容

### frontend (villages.\$id.tsx)

- **PageHeader / PageFooter** を追加 (本 route は \`_auth\` 配下にないため自前で被せる)
- メッセージを day tabs の直下に置く構成に (= 旧 village.html 踏襲)。順番:
  1. PageHeader
  2. VillageHeader (h1 \`0001. 村名\`)
  3. DayTabs (mint btn-group + 末尾に村ステータス名)
  4. **MessagesPanel** (メイン)
  5. SayForm (最新日時 + 発言可能のとき)
  6. user-context panels: あなた / 参加 / RP / 行動 / Creator / Admin
  7. **SituationOverviewPanel** (新規、タブ UI: 部屋割り / 参加者 / 状況)
  8. 足音
  9. PageFooter + FooterMenuDock (bottom-fixed)
- h1 から状態 badge を外し、旧画面と同じく day tabs 末尾に状態名を出す

### 新規 component

- **FooterMenuDock** (\`features/village/detail/FooterMenuDock.tsx\`): 旧 \`#footer-menu.footer-menu-bottom\` 復元。最上部 / 最下部 / 更新 / 抽出 / 情報 + 未投票時の投票ショートカット。glyphicon → heroicons (絵文字禁止方針)
- **SituationOverviewPanel** (villages.\$id.tsx 内): 部屋割り / 参加者 / 状況 をタブ切替。ファイル分割は scope を絞るため次回以降に

### MessageCard 本番計測ベース修正

- 旧 \`.message-*\` hex 値 1:1 (white #fff / werewolf #f2aeae / mason #aef2ae / private-* 等)
- BS3 \`.message\` スタイル: padding 9px / radius 5px / margin-bottom 20px / **font-family sans-serif** (本番計測で Lato ではなく sans-serif)
- 装飾タグ ([[b]] / [[s]] / [[#color]] / [[large]] / [[small]] / [[ruby]] / [[netabare]] / [[cw]] / [[tp]]) を React 要素にパース (XSS 安全)
- アンカー (>>N / >>*N / >>=N 等) を \`.message-link\` span に
- footer に 返信 / 秘話 link

### primitives 更新

- **Panel**: 本番計測値に揃え
  - panel: bg \`#303030\` (night-650) / border \`#464545\` (night-550) / radius 4px
  - panel-heading: bg \`#464545\` / padding 10px 15px / radius 3px 3px 0 0
- **app.css**: body bg を \`night-950\` (#0b162a, 旧 tile 用) → \`night-500\` (#222, 本番計測値) に修正。home の tiles は明示的に bg-night-950 を当てているため影響なし
- \`.message-link\` クラス追加 (本文中アンカー / link の赤系色 #f00000)

### その他 component の色トークン統一

- ActionPanel / ParticipateActions / RpActions / SayForm / MessageFilter / VillageInfoModal / SituationPanel / RoomGridPanel: slate / indigo / rose の TailwindCSS palette を night / mint / blood に sweep
- 各 form の input / button を BS3 .btn-success (mint) / .btn-default (night-800) に
- RoomGrid の ❤ を \`HeartIcon\` に置換

## 動作確認

- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (11 passed)
- [x] \`pnpm build\`
- [x] playwright で /villages/1 を localhost:8091 (main) と並べて確認: 視覚的に概ね一致
- [ ] **ユーザー手動確認依頼**: 進行中の村 / 終了 / プロローグ各状態で本番との視覚一致を最終確認。本 PR で当方環境では基本構造は揃った
- [ ] **既知の制約**:
  - \`loud\` / \`rainbow\` / \`extra-small\` テキスト装飾は backend にフラグ追加が必要なため本 PR ではスコープ外
  - 旧画面の「情報」link (h1 上部に小さく出るやつ) は未復元

## 意図的スコープ外 (別 PR)

- \`.issues/16\` (Dead.kt 演算子優先順位 refactor)
- \`.issues/20\` (村情報モーダル拡張: 発言制限 / キャラセット / ダミーキャラ名)
- \`.issues/21\` (fetchVillageMessages number union 撤去)
- フォーム系 (\`new-village.tsx\` / \`villages.\$id.settings.tsx\`) → Step 13d
- admin / creator / scrap → Step 13e
- 文字サイズ拡大 UI トグル → Step 13f

🤖 Generated with [Claude Code](https://claude.com/claude-code)