### PR TITLE
feat: Step 3.1 認証REST化(1) — JWT基盤 + /api/v1/auth/{login,refresh,logout,me} (step-3.1)

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -45,6 +45,10 @@ dependencies {
     implementation("org.apache.commons:commons-collections4:4.4")
     // jackson
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    // jwt (jjwt)
+    implementation("io.jsonwebtoken:jjwt-api:0.12.6")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
 
     // test
     testImplementation("org.jetbrains.kotlin:kotlin-test")

--- a/backend/src/main/kotlin/com/ort/app/api/auth/AuthController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/auth/AuthController.kt
@@ -1,0 +1,85 @@
+package com.ort.app.api.auth
+
+import com.ort.app.api.auth.request.LoginRequest
+import com.ort.app.api.auth.response.MeResponse
+import com.ort.app.application.coordinator.AuthCoordinator
+import com.ort.app.application.coordinator.AuthTokens
+import com.ort.app.fw.exception.WolfMansionAuthException
+import com.ort.app.fw.security.jwt.AuthCookieFactory
+import com.ort.app.fw.security.jwt.JwtPrincipal
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpHeaders
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.CookieValue
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/auth")
+class AuthController(
+    private val authCoordinator: AuthCoordinator,
+    private val authCookieFactory: AuthCookieFactory,
+) {
+    /** ID / パスワードで認証し、access + refresh Cookie をセットする。失敗は 401。 */
+    @PostMapping("/login")
+    fun login(
+        @RequestBody @Validated request: LoginRequest,
+        response: HttpServletResponse,
+    ): MeResponse {
+        val tokens = authCoordinator.login(request.userId!!, request.password!!)
+        writeAuthCookies(response, tokens)
+        return MeResponse(tokens.principal)
+    }
+
+    /** refresh Cookie から新しい access + refresh を発行する (使い捨て rotation)。 */
+    @PostMapping("/refresh")
+    fun refresh(
+        @CookieValue(name = AuthCookieFactory.REFRESH_TOKEN, required = false) refreshToken: String?,
+        response: HttpServletResponse,
+    ): MeResponse {
+        if (refreshToken.isNullOrBlank()) throw WolfMansionAuthException("リフレッシュトークンがありません")
+        val tokens = authCoordinator.refresh(refreshToken)
+        writeAuthCookies(response, tokens)
+        return MeResponse(tokens.principal)
+    }
+
+    /** 両 Cookie を消去し、DB 側の refresh token も失効させる。 */
+    @PostMapping("/logout")
+    fun logout(
+        @CookieValue(name = AuthCookieFactory.REFRESH_TOKEN, required = false) refreshToken: String?,
+        response: HttpServletResponse,
+    ): ResponseEntity<Void> {
+        authCoordinator.logout(refreshToken)
+        response.addHeader(HttpHeaders.SET_COOKIE, authCookieFactory.clearAccessTokenCookie().toString())
+        response.addHeader(HttpHeaders.SET_COOKIE, authCookieFactory.clearRefreshTokenCookie().toString())
+        return ResponseEntity.noContent().build()
+    }
+
+    /** 現在のログインプレイヤー情報。未認証は SecurityConfig により 401 (ProblemDetail)。 */
+    @GetMapping("/me")
+    fun me(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+    ): MeResponse {
+        val authenticated = principal ?: throw WolfMansionAuthException("認証が必要です")
+        return MeResponse(authenticated)
+    }
+
+    private fun writeAuthCookies(
+        response: HttpServletResponse,
+        tokens: AuthTokens,
+    ) {
+        response.addHeader(
+            HttpHeaders.SET_COOKIE,
+            authCookieFactory.accessTokenCookie(tokens.accessToken, tokens.accessTokenMaxAge).toString(),
+        )
+        response.addHeader(
+            HttpHeaders.SET_COOKIE,
+            authCookieFactory.refreshTokenCookie(tokens.refreshToken, tokens.refreshTokenMaxAge).toString(),
+        )
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/auth/request/LoginRequest.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/auth/request/LoginRequest.kt
@@ -1,0 +1,14 @@
+package com.ort.app.api.auth.request
+
+import jakarta.validation.constraints.NotNull
+
+/**
+ * ログインリクエスト。緩和後ポリシーに合わせ **password の形式バリデーションはしない** (NotNull のみ)。
+ * 形式チェックを残すと緩和後パスワードでログイン不能になるため。
+ */
+data class LoginRequest(
+    @field:NotNull
+    val userId: String? = null,
+    @field:NotNull
+    val password: String? = null,
+)

--- a/backend/src/main/kotlin/com/ort/app/api/auth/response/MeResponse.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/auth/response/MeResponse.kt
@@ -1,0 +1,18 @@
+package com.ort.app.api.auth.response
+
+import com.ort.app.fw.security.jwt.JwtPrincipal
+
+/**
+ * 現在のログインプレイヤーの最小情報。login / refresh / me で共通して返す。
+ */
+data class MeResponse(
+    val playerId: Int,
+    val name: String,
+    val authorities: List<String>,
+) {
+    constructor(principal: JwtPrincipal) : this(
+        playerId = principal.playerId,
+        name = principal.name,
+        authorities = principal.authorities,
+    )
+}

--- a/backend/src/main/kotlin/com/ort/app/application/coordinator/AuthCoordinator.kt
+++ b/backend/src/main/kotlin/com/ort/app/application/coordinator/AuthCoordinator.kt
@@ -1,0 +1,100 @@
+package com.ort.app.application.coordinator
+
+import com.ort.app.domain.model.auth.PlayerAuth
+import com.ort.app.domain.model.auth.PlayerAuthRepository
+import com.ort.app.domain.model.auth.RefreshTokenRepository
+import com.ort.app.fw.exception.WolfMansionAuthException
+import com.ort.app.fw.security.jwt.JwtPrincipal
+import com.ort.app.fw.security.jwt.JwtTokenProvider
+import com.ort.app.fw.security.jwt.RefreshTokenFactory
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.time.LocalDateTime
+
+/**
+ * 認証ユースケースのトランザクション境界。login / refresh / logout を担う。
+ * - access token = JWT (短命)、refresh token = 不透明な乱数 (DB にハッシュ保存、使い捨て rotation)
+ * - 資格情報誤りはユーザー存在を区別しない文言で 401
+ */
+@Service
+class AuthCoordinator(
+    private val playerAuthRepository: PlayerAuthRepository,
+    private val refreshTokenRepository: RefreshTokenRepository,
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val refreshTokenFactory: RefreshTokenFactory,
+    private val passwordEncoder: PasswordEncoder,
+) {
+    @Transactional(rollbackFor = [Exception::class])
+    fun login(
+        userId: String,
+        rawPassword: String,
+    ): AuthTokens {
+        val playerAuth = playerAuthRepository.findByName(userId)
+        if (playerAuth == null || !passwordEncoder.matches(rawPassword, playerAuth.passwordHash)) {
+            throw WolfMansionAuthException("ユーザIDまたはパスワードが違います")
+        }
+        return issueTokens(playerAuth)
+    }
+
+    @Transactional(rollbackFor = [Exception::class])
+    fun refresh(rawRefreshToken: String): AuthTokens {
+        val now = LocalDateTime.now()
+        val tokenHash = refreshTokenFactory.hash(rawRefreshToken)
+        val refreshToken =
+            refreshTokenRepository.findByHash(tokenHash)
+                ?: throw WolfMansionAuthException(INVALID_REFRESH)
+        if (refreshToken.isUsed) {
+            // rotation 済みトークンの再提示 = 漏洩疑い。当該プレイヤーの未失効トークンを全て失効させる
+            refreshTokenRepository.revokeAllByPlayer(refreshToken.playerId, now)
+            throw WolfMansionAuthException(INVALID_REFRESH)
+        }
+        if (!refreshToken.isUsable(now)) throw WolfMansionAuthException(INVALID_REFRESH)
+        // 使い捨て: 旧トークンを使用済みにし、新トークンを発行する
+        refreshTokenRepository.markUsed(refreshToken.id, now)
+        val playerAuth =
+            playerAuthRepository.findById(refreshToken.playerId)
+                ?: throw WolfMansionAuthException(INVALID_REFRESH)
+        return issueTokens(playerAuth)
+    }
+
+    @Transactional(rollbackFor = [Exception::class])
+    fun logout(rawRefreshToken: String?) {
+        if (rawRefreshToken.isNullOrBlank()) return
+        val refreshToken = refreshTokenRepository.findByHash(refreshTokenFactory.hash(rawRefreshToken)) ?: return
+        if (refreshToken.revokedDatetime == null) {
+            refreshTokenRepository.revoke(refreshToken.id, LocalDateTime.now())
+        }
+    }
+
+    private fun issueTokens(playerAuth: PlayerAuth): AuthTokens {
+        val accessToken =
+            jwtTokenProvider.issueAccessToken(
+                playerId = playerAuth.playerId,
+                name = playerAuth.name,
+                authorities = playerAuth.authorities,
+                now = Instant.now(),
+            )
+        val rawRefreshToken = refreshTokenFactory.generate()
+        val refreshValidity = jwtTokenProvider.refreshTokenValidity()
+        val now = LocalDateTime.now()
+        refreshTokenRepository.insert(
+            playerId = playerAuth.playerId,
+            tokenHash = refreshTokenFactory.hash(rawRefreshToken),
+            issuedDatetime = now,
+            expiresDatetime = now.plus(refreshValidity),
+        )
+        return AuthTokens(
+            principal = JwtPrincipal(playerAuth.playerId, playerAuth.name, playerAuth.authorities),
+            accessToken = accessToken,
+            accessTokenMaxAge = jwtTokenProvider.accessTokenValidity(),
+            refreshToken = rawRefreshToken,
+            refreshTokenMaxAge = refreshValidity,
+        )
+    }
+
+    companion object {
+        private const val INVALID_REFRESH = "リフレッシュトークンが無効です"
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/application/coordinator/AuthCoordinator.kt
+++ b/backend/src/main/kotlin/com/ort/app/application/coordinator/AuthCoordinator.kt
@@ -10,8 +10,8 @@ import com.ort.app.fw.security.jwt.RefreshTokenFactory
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.Instant
 import java.time.LocalDateTime
+import java.time.ZoneId
 
 /**
  * 認証ユースケースのトランザクション境界。login / refresh / logout を担う。
@@ -38,7 +38,9 @@ class AuthCoordinator(
         return issueTokens(playerAuth)
     }
 
-    @Transactional(rollbackFor = [Exception::class])
+    // 漏洩検知の revokeAllByPlayer は throw 後もコミットさせる必要があるため、
+    // WolfMansionAuthException ではロールバックしない (それ以外の例外ではロールバックする)。
+    @Transactional(rollbackFor = [Exception::class], noRollbackFor = [WolfMansionAuthException::class])
     fun refresh(rawRefreshToken: String): AuthTokens {
         val now = LocalDateTime.now()
         val tokenHash = refreshTokenFactory.hash(rawRefreshToken)
@@ -51,8 +53,11 @@ class AuthCoordinator(
             throw WolfMansionAuthException(INVALID_REFRESH)
         }
         if (!refreshToken.isUsable(now)) throw WolfMansionAuthException(INVALID_REFRESH)
-        // 使い捨て: 旧トークンを使用済みにし、新トークンを発行する
-        refreshTokenRepository.markUsed(refreshToken.id, now)
+        // 使い捨て: 未使用のものだけをアトミックに使用済みにする。
+        // 並行リクエストに先を越された (= 二重消費) 場合は false → このリクエストは拒否する。
+        if (!refreshTokenRepository.markUsed(refreshToken.id, now)) {
+            throw WolfMansionAuthException(INVALID_REFRESH)
+        }
         val playerAuth =
             playerAuthRepository.findById(refreshToken.playerId)
                 ?: throw WolfMansionAuthException(INVALID_REFRESH)
@@ -61,6 +66,8 @@ class AuthCoordinator(
 
     @Transactional(rollbackFor = [Exception::class])
     fun logout(rawRefreshToken: String?) {
+        // access token (JWT) は stateless のためサーバー側では失効できない (発行から 15 分間は有効なまま)。
+        // ここで失効させるのは DB 管理下の refresh token のみ。クライアントは両 Cookie を消す。
         if (rawRefreshToken.isNullOrBlank()) return
         val refreshToken = refreshTokenRepository.findByHash(refreshTokenFactory.hash(rawRefreshToken)) ?: return
         if (refreshToken.revokedDatetime == null) {
@@ -69,16 +76,20 @@ class AuthCoordinator(
     }
 
     private fun issueTokens(playerAuth: PlayerAuth): AuthTokens {
+        // 1 トランザクション内で時刻を統一 (JWT の iat と refresh の issued_datetime を揃える)
+        val now = LocalDateTime.now()
+        val nowInstant = now.atZone(ZoneId.systemDefault()).toInstant()
+        // 肥大化抑制: 当該プレイヤーの期限切れトークンを掃除してから新規発行する
+        refreshTokenRepository.deleteExpiredByPlayer(playerAuth.playerId, now)
         val accessToken =
             jwtTokenProvider.issueAccessToken(
                 playerId = playerAuth.playerId,
                 name = playerAuth.name,
                 authorities = playerAuth.authorities,
-                now = Instant.now(),
+                now = nowInstant,
             )
         val rawRefreshToken = refreshTokenFactory.generate()
         val refreshValidity = jwtTokenProvider.refreshTokenValidity()
-        val now = LocalDateTime.now()
         refreshTokenRepository.insert(
             playerId = playerAuth.playerId,
             tokenHash = refreshTokenFactory.hash(rawRefreshToken),

--- a/backend/src/main/kotlin/com/ort/app/application/coordinator/AuthCoordinator.kt
+++ b/backend/src/main/kotlin/com/ort/app/application/coordinator/AuthCoordinator.kt
@@ -53,14 +53,17 @@ class AuthCoordinator(
             throw WolfMansionAuthException(INVALID_REFRESH)
         }
         if (!refreshToken.isUsable(now)) throw WolfMansionAuthException(INVALID_REFRESH)
+        // プレイヤー取得は markUsed より前に行う (null なら旧トークンを消費せずに弾けるため、
+        // noRollbackFor 下でも "旧トークンだけ使用済み・新トークン未発行" の中途半端なコミットを避けられる)。
+        // FK 上 REFRESH_TOKEN は PLAYER に従属し削除フローも無いため、通常 null にはならない防御的処理。
+        val playerAuth =
+            playerAuthRepository.findById(refreshToken.playerId)
+                ?: throw WolfMansionAuthException(INVALID_REFRESH)
         // 使い捨て: 未使用のものだけをアトミックに使用済みにする。
         // 並行リクエストに先を越された (= 二重消費) 場合は false → このリクエストは拒否する。
         if (!refreshTokenRepository.markUsed(refreshToken.id, now)) {
             throw WolfMansionAuthException(INVALID_REFRESH)
         }
-        val playerAuth =
-            playerAuthRepository.findById(refreshToken.playerId)
-                ?: throw WolfMansionAuthException(INVALID_REFRESH)
         return issueTokens(playerAuth)
     }
 

--- a/backend/src/main/kotlin/com/ort/app/application/coordinator/AuthTokens.kt
+++ b/backend/src/main/kotlin/com/ort/app/application/coordinator/AuthTokens.kt
@@ -1,0 +1,16 @@
+package com.ort.app.application.coordinator
+
+import com.ort.app.fw.security.jwt.JwtPrincipal
+import java.time.Duration
+
+/**
+ * 認証成功時に発行するトークン一式 (Controller が Cookie に載せる)。
+ * [refreshToken] は生の値 (Cookie 用)。DB にはハッシュのみ保存済み。
+ */
+data class AuthTokens(
+    val principal: JwtPrincipal,
+    val accessToken: String,
+    val accessTokenMaxAge: Duration,
+    val refreshToken: String,
+    val refreshTokenMaxAge: Duration,
+)

--- a/backend/src/main/kotlin/com/ort/app/domain/model/auth/PlayerAuth.kt
+++ b/backend/src/main/kotlin/com/ort/app/domain/model/auth/PlayerAuth.kt
@@ -1,0 +1,11 @@
+package com.ort.app.domain.model.auth
+
+/**
+ * 認証に必要な最小情報。パスワードハッシュを含むため Player ドメインモデルとは分離する。
+ */
+data class PlayerAuth(
+    val playerId: Int,
+    val name: String,
+    val passwordHash: String,
+    val authorities: List<String>,
+)

--- a/backend/src/main/kotlin/com/ort/app/domain/model/auth/PlayerAuthRepository.kt
+++ b/backend/src/main/kotlin/com/ort/app/domain/model/auth/PlayerAuthRepository.kt
@@ -1,0 +1,9 @@
+package com.ort.app.domain.model.auth
+
+interface PlayerAuthRepository {
+    /** ログイン ID (プレイヤー名) で認証用情報を取得。存在しなければ null。 */
+    fun findByName(name: String): PlayerAuth?
+
+    /** プレイヤー ID で認証用情報を取得 (refresh 時の access token 再発行用)。存在しなければ null。 */
+    fun findById(playerId: Int): PlayerAuth?
+}

--- a/backend/src/main/kotlin/com/ort/app/domain/model/auth/RefreshToken.kt
+++ b/backend/src/main/kotlin/com/ort/app/domain/model/auth/RefreshToken.kt
@@ -1,0 +1,27 @@
+package com.ort.app.domain.model.auth
+
+import java.time.LocalDateTime
+
+/**
+ * リフレッシュトークン。値そのものは保持せず、SHA-256 ハッシュ ([tokenHash]) のみ DB 管理する。
+ * 使い捨て rotation: refresh のたびに [usedDatetime] を立てて旧トークンを無効化し、新トークンを発行する。
+ */
+data class RefreshToken(
+    val id: Int,
+    val playerId: Int,
+    val tokenHash: String,
+    val issuedDatetime: LocalDateTime,
+    val expiresDatetime: LocalDateTime,
+    val usedDatetime: LocalDateTime?,
+    val revokedDatetime: LocalDateTime?,
+) {
+    /** rotation 済 (= 一度使われた)。使用済みトークンの再提示は漏洩疑い。 */
+    val isUsed: Boolean get() = usedDatetime != null
+
+    val isRevoked: Boolean get() = revokedDatetime != null
+
+    fun isExpired(now: LocalDateTime): Boolean = !now.isBefore(expiresDatetime)
+
+    /** refresh に使える状態か (未使用・未失効・未期限切れ)。 */
+    fun isUsable(now: LocalDateTime): Boolean = !isUsed && !isRevoked && !isExpired(now)
+}

--- a/backend/src/main/kotlin/com/ort/app/domain/model/auth/RefreshTokenRepository.kt
+++ b/backend/src/main/kotlin/com/ort/app/domain/model/auth/RefreshTokenRepository.kt
@@ -12,11 +12,15 @@ interface RefreshTokenRepository {
 
     fun findByHash(tokenHash: String): RefreshToken?
 
-    /** rotation: 使用済みとしてマーク (再利用不可にする)。 */
+    /**
+     * rotation: 未使用のものだけを使用済みにする (条件付き更新)。
+     * 実際に未使用→使用済みへ遷移できたら true。並行リクエストに先を越されていたら false。
+     * (findByHash → markUsed 間の TOCTOU 競合で二重消費しないためのアトミック更新)
+     */
     fun markUsed(
         id: Int,
         usedDatetime: LocalDateTime,
-    )
+    ): Boolean
 
     /** 失効させる (ログアウト等)。 */
     fun revoke(
@@ -28,5 +32,14 @@ interface RefreshTokenRepository {
     fun revokeAllByPlayer(
         playerId: Int,
         revokedDatetime: LocalDateTime,
+    )
+
+    /**
+     * 当該プレイヤーの期限切れトークンを物理削除する (テーブル肥大化の抑制)。
+     * 使用済みでも未期限切れのものは漏洩検知に必要なため残す (期限切れは isUsable で弾かれるので削除して安全)。
+     */
+    fun deleteExpiredByPlayer(
+        playerId: Int,
+        now: LocalDateTime,
     )
 }

--- a/backend/src/main/kotlin/com/ort/app/domain/model/auth/RefreshTokenRepository.kt
+++ b/backend/src/main/kotlin/com/ort/app/domain/model/auth/RefreshTokenRepository.kt
@@ -1,0 +1,32 @@
+package com.ort.app.domain.model.auth
+
+import java.time.LocalDateTime
+
+interface RefreshTokenRepository {
+    fun insert(
+        playerId: Int,
+        tokenHash: String,
+        issuedDatetime: LocalDateTime,
+        expiresDatetime: LocalDateTime,
+    ): RefreshToken
+
+    fun findByHash(tokenHash: String): RefreshToken?
+
+    /** rotation: 使用済みとしてマーク (再利用不可にする)。 */
+    fun markUsed(
+        id: Int,
+        usedDatetime: LocalDateTime,
+    )
+
+    /** 失効させる (ログアウト等)。 */
+    fun revoke(
+        id: Int,
+        revokedDatetime: LocalDateTime,
+    )
+
+    /** 漏洩疑い時: 当該プレイヤーの未失効トークンを全て失効させる。 */
+    fun revokeAllByPlayer(
+        playerId: Int,
+        revokedDatetime: LocalDateTime,
+    )
+}

--- a/backend/src/main/kotlin/com/ort/app/fw/exception/RestApiExceptionHandler.kt
+++ b/backend/src/main/kotlin/com/ort/app/fw/exception/RestApiExceptionHandler.kt
@@ -1,0 +1,51 @@
+package com.ort.app.fw.exception
+
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+/**
+ * REST API (`@RestController`) 専用の例外ハンドラ。エラーを ProblemDetail (RFC 7807) に統一する。
+ * 既存の SSR (`@Controller`) には適用されない (annotations 限定)。
+ */
+@RestControllerAdvice(annotations = [RestController::class])
+class RestApiExceptionHandler {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    @ExceptionHandler(WolfMansionAuthException::class)
+    fun handleAuth(e: WolfMansionAuthException): ProblemDetail =
+        problem(HttpStatus.UNAUTHORIZED, e.message ?: "認証に失敗しました", "authentication_failed")
+
+    @ExceptionHandler(WolfMansionBusinessException::class)
+    fun handleBusiness(e: WolfMansionBusinessException): ProblemDetail =
+        problem(HttpStatus.BAD_REQUEST, e.message ?: "リクエストを処理できません", "business_error")
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleValidation(e: MethodArgumentNotValidException): ProblemDetail {
+        val detail =
+            e.bindingResult.fieldErrors
+                .joinToString(", ") { "${it.field}: ${it.defaultMessage}" }
+                .ifBlank { "入力内容が不正です" }
+        return problem(HttpStatus.BAD_REQUEST, detail, "validation_error")
+    }
+
+    @ExceptionHandler(Exception::class)
+    fun handleOther(e: Exception): ProblemDetail {
+        logger.error(e.message, e)
+        return problem(HttpStatus.INTERNAL_SERVER_ERROR, "サーバーエラーが発生しました", "internal_error")
+    }
+
+    private fun problem(
+        status: HttpStatus,
+        detail: String,
+        error: String,
+    ): ProblemDetail {
+        val problem = ProblemDetail.forStatusAndDetail(status, detail)
+        problem.setProperty("error", error)
+        return problem
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/fw/exception/WolfMansionAuthException.kt
+++ b/backend/src/main/kotlin/com/ort/app/fw/exception/WolfMansionAuthException.kt
@@ -1,0 +1,9 @@
+package com.ort.app.fw.exception
+
+/**
+ * 認証失敗 (資格情報誤り / refresh token 無効 等)。REST API では 401 にマップする。
+ * ユーザー存在の有無は区別しない文言にすること (列挙を助長しない)。
+ */
+class WolfMansionAuthException(
+    message: String,
+) : RuntimeException(message)

--- a/backend/src/main/kotlin/com/ort/app/fw/security/WolfMansionWebSecurityConfig.kt
+++ b/backend/src/main/kotlin/com/ort/app/fw/security/WolfMansionWebSecurityConfig.kt
@@ -1,20 +1,63 @@
 package com.ort.app.fw.security
 
+import com.ort.app.fw.security.jwt.JwtAuthenticationEntryPoint
+import com.ort.app.fw.security.jwt.JwtAuthenticationFilter
+import com.ort.app.fw.security.jwt.JwtTokenProvider
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.annotation.Order
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler
 
 @Configuration
 @EnableWebSecurity
 class WolfMansionWebSecurityConfig {
+    /**
+     * REST API チェーン (`/api/v1` 配下)。JWT による stateless 認証。
+     * 移行期間は本チェーンと既存 SSR チェーン ([webFilterChain]) が共存する。
+     */
     @Bean
-    fun filterChain(
+    @Order(1)
+    fun apiFilterChain(
+        http: HttpSecurity,
+        jwtTokenProvider: JwtTokenProvider,
+        jwtAuthenticationEntryPoint: JwtAuthenticationEntryPoint,
+    ): SecurityFilterChain {
+        http
+            .securityMatcher("/api/v1/**")
+            .csrf { it.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .authorizeHttpRequests { auth ->
+                auth
+                    .requestMatchers(
+                        "/api/v1/auth/login",
+                        "/api/v1/auth/refresh",
+                        "/api/v1/auth/logout",
+                    ).permitAll()
+                    .anyRequest()
+                    .authenticated()
+            }.exceptionHandling { it.authenticationEntryPoint(jwtAuthenticationEntryPoint) }
+            .addFilterBefore(
+                JwtAuthenticationFilter(jwtTokenProvider),
+                UsernamePasswordAuthenticationFilter::class.java,
+            )
+        return http.build()
+    }
+
+    /**
+     * 既存 SSR チェーン (`/api/v1` 配下 以外すべて)。セッション + formLogin。
+     * 旧 Thymeleaf 画面と公開 API (`/api/login` 等) は Step 10 までこの構成で動かす。
+     */
+    @Bean
+    @Order(2)
+    fun webFilterChain(
         http: HttpSecurity,
         userInfoService: UserInfoService,
     ): SecurityFilterChain {

--- a/backend/src/main/kotlin/com/ort/app/fw/security/jwt/AuthCookieFactory.kt
+++ b/backend/src/main/kotlin/com/ort/app/fw/security/jwt/AuthCookieFactory.kt
@@ -1,0 +1,55 @@
+package com.ort.app.fw.security.jwt
+
+import jakarta.servlet.ServletContext
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.ResponseCookie
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+/**
+ * 認証 Cookie (access / refresh) の組み立て。
+ * - access: `Path=/` (frontend と backend の両方へ送る)
+ * - refresh: `Path=<contextPath>/api/v1/auth` (auth エンドポイントにのみ送る)
+ * いずれも HttpOnly / SameSite=Lax。Secure は profile 連動 (`jwt.cookie-secure`)。
+ */
+@Component
+class AuthCookieFactory(
+    private val servletContext: ServletContext,
+    @Value("\${jwt.cookie-secure:false}") private val secure: Boolean,
+) {
+    fun accessTokenCookie(
+        value: String,
+        maxAge: Duration,
+    ): ResponseCookie = build(ACCESS_TOKEN, value, "/", maxAge)
+
+    fun refreshTokenCookie(
+        value: String,
+        maxAge: Duration,
+    ): ResponseCookie = build(REFRESH_TOKEN, value, refreshTokenPath(), maxAge)
+
+    fun clearAccessTokenCookie(): ResponseCookie = build(ACCESS_TOKEN, "", "/", Duration.ZERO)
+
+    fun clearRefreshTokenCookie(): ResponseCookie = build(REFRESH_TOKEN, "", refreshTokenPath(), Duration.ZERO)
+
+    private fun refreshTokenPath(): String = "${servletContext.contextPath}/api/v1/auth"
+
+    private fun build(
+        name: String,
+        value: String,
+        path: String,
+        maxAge: Duration,
+    ): ResponseCookie =
+        ResponseCookie
+            .from(name, value)
+            .httpOnly(true)
+            .secure(secure)
+            .path(path)
+            .sameSite("Lax")
+            .maxAge(maxAge)
+            .build()
+
+    companion object {
+        const val ACCESS_TOKEN = "access_token"
+        const val REFRESH_TOKEN = "refresh_token"
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/fw/security/jwt/JwtAuthenticationEntryPoint.kt
+++ b/backend/src/main/kotlin/com/ort/app/fw/security/jwt/JwtAuthenticationEntryPoint.kt
@@ -1,0 +1,33 @@
+package com.ort.app.fw.security.jwt
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ProblemDetail
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+import java.nio.charset.StandardCharsets
+
+/**
+ * 認証必須エンドポイントに未認証アクセスした場合に 401 を ProblemDetail (RFC 7807) で返す。
+ */
+@Component
+class JwtAuthenticationEntryPoint(
+    private val objectMapper: ObjectMapper,
+) : AuthenticationEntryPoint {
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException,
+    ) {
+        val problem = ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, "認証が必要です")
+        problem.setProperty("error", "unauthorized")
+        response.status = HttpStatus.UNAUTHORIZED.value()
+        response.contentType = MediaType.APPLICATION_PROBLEM_JSON_VALUE
+        response.characterEncoding = StandardCharsets.UTF_8.name()
+        objectMapper.writeValue(response.outputStream, problem)
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/fw/security/jwt/JwtAuthenticationFilter.kt
+++ b/backend/src/main/kotlin/com/ort/app/fw/security/jwt/JwtAuthenticationFilter.kt
@@ -1,0 +1,43 @@
+package com.ort.app.fw.security.jwt
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource
+import org.springframework.web.filter.OncePerRequestFilter
+
+/**
+ * access token Cookie を検証して SecurityContext に認証情報を詰める。
+ * `/api/v1` 配下チェーン専用 (SecurityConfig で手動構築・登録するため `@Component` にはしない)。
+ * トークンが無い/不正でもここでは弾かず後段の認可判定に委ねる (公開エンドポイントを通すため)。
+ */
+class JwtAuthenticationFilter(
+    private val jwtTokenProvider: JwtTokenProvider,
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val token = resolveAccessToken(request)
+        if (token != null && SecurityContextHolder.getContext().authentication == null) {
+            val principal = jwtTokenProvider.parseAccessToken(token)
+            if (principal != null) {
+                val authorities = principal.authorities.map { SimpleGrantedAuthority(it) }
+                val authentication = UsernamePasswordAuthenticationToken(principal, null, authorities)
+                authentication.details = WebAuthenticationDetailsSource().buildDetails(request)
+                SecurityContextHolder.getContext().authentication = authentication
+            }
+        }
+        filterChain.doFilter(request, response)
+    }
+
+    private fun resolveAccessToken(request: HttpServletRequest): String? =
+        request.cookies
+            ?.firstOrNull { it.name == AuthCookieFactory.ACCESS_TOKEN }
+            ?.value
+            ?.ifBlank { null }
+}

--- a/backend/src/main/kotlin/com/ort/app/fw/security/jwt/JwtPrincipal.kt
+++ b/backend/src/main/kotlin/com/ort/app/fw/security/jwt/JwtPrincipal.kt
@@ -1,0 +1,10 @@
+package com.ort.app.fw.security.jwt
+
+/**
+ * JWT から復元される認証済みプリンシパル。SecurityContext に格納され、`@AuthenticationPrincipal` で取得できる。
+ */
+data class JwtPrincipal(
+    val playerId: Int,
+    val name: String,
+    val authorities: List<String>,
+)

--- a/backend/src/main/kotlin/com/ort/app/fw/security/jwt/JwtTokenProvider.kt
+++ b/backend/src/main/kotlin/com/ort/app/fw/security/jwt/JwtTokenProvider.kt
@@ -1,0 +1,77 @@
+package com.ort.app.fw.security.jwt
+
+import io.jsonwebtoken.JwtException
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.nio.charset.StandardCharsets
+import java.time.Duration
+import java.time.Instant
+import java.util.Date
+import javax.crypto.SecretKey
+
+/**
+ * access token (JWT/HS256) の発行・検証を担う。refresh token は JWT ではなく不透明な乱数 ([RefreshTokenFactory])。
+ */
+@Component
+class JwtTokenProvider(
+    @Value("\${jwt.secret}") secret: String,
+    @Value("\${jwt.access-token-validity-minutes:15}") private val accessTokenValidityMinutes: Long,
+    @Value("\${jwt.refresh-token-validity-days:14}") private val refreshTokenValidityDays: Long,
+) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+    private val key: SecretKey = Keys.hmacShaKeyFor(secret.toByteArray(StandardCharsets.UTF_8))
+
+    fun accessTokenValidity(): Duration = Duration.ofMinutes(accessTokenValidityMinutes)
+
+    fun refreshTokenValidity(): Duration = Duration.ofDays(refreshTokenValidityDays)
+
+    fun issueAccessToken(
+        playerId: Int,
+        name: String,
+        authorities: List<String>,
+        now: Instant = Instant.now(),
+    ): String =
+        Jwts
+            .builder()
+            .subject(playerId.toString())
+            .claim(CLAIM_NAME, name)
+            .claim(CLAIM_AUTHORITIES, authorities)
+            .issuedAt(Date.from(now))
+            .expiration(Date.from(now.plus(accessTokenValidity())))
+            // HS256 を明示 (signWith(key) は鍵長から alg を自動選択するため非決定的になる)。鍵は 256bit 以上必須
+            .signWith(key, Jwts.SIG.HS256)
+            .compact()
+
+    /** access token を検証し principal を返す。署名不正・期限切れ・不正形式は null。 */
+    fun parseAccessToken(token: String): JwtPrincipal? {
+        return try {
+            val claims =
+                Jwts
+                    .parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token)
+                    .payload
+            val playerId = claims.subject?.toIntOrNull() ?: return null
+
+            @Suppress("UNCHECKED_CAST")
+            val authorities = (claims[CLAIM_AUTHORITIES] as? List<String>) ?: emptyList()
+            val name = claims[CLAIM_NAME] as? String ?: ""
+            JwtPrincipal(playerId = playerId, name = name, authorities = authorities)
+        } catch (e: JwtException) {
+            logger.debug("invalid access token: {}", e.message)
+            null
+        } catch (e: IllegalArgumentException) {
+            logger.debug("invalid access token: {}", e.message)
+            null
+        }
+    }
+
+    companion object {
+        private const val CLAIM_NAME = "name"
+        private const val CLAIM_AUTHORITIES = "authorities"
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/fw/security/jwt/RefreshTokenFactory.kt
+++ b/backend/src/main/kotlin/com/ort/app/fw/security/jwt/RefreshTokenFactory.kt
@@ -1,0 +1,29 @@
+package com.ort.app.fw.security.jwt
+
+import org.springframework.stereotype.Component
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.Base64
+
+/**
+ * refresh token の生成とハッシュ化。
+ * トークンそのものは Cookie でクライアントに渡し、DB には SHA-256 ハッシュ (hex 64 文字) のみ保存する。
+ */
+@Component
+class RefreshTokenFactory {
+    private val secureRandom = SecureRandom()
+
+    /** 256bit の乱数を URL-safe Base64 (パディング無し) で返す。 */
+    fun generate(): String {
+        val bytes = ByteArray(32)
+        secureRandom.nextBytes(bytes)
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+    }
+
+    /** SHA-256 hex (64 文字)。`REFRESH_TOKEN.TOKEN_HASH` (CHAR(64)) に対応。 */
+    fun hash(value: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(value.toByteArray(StandardCharsets.UTF_8))
+        return digest.joinToString("") { "%02x".format(it) }
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/infrastructure/datasource/PlayerAuthDataSource.kt
+++ b/backend/src/main/kotlin/com/ort/app/infrastructure/datasource/PlayerAuthDataSource.kt
@@ -1,0 +1,35 @@
+package com.ort.app.infrastructure.datasource
+
+import com.ort.app.domain.model.auth.PlayerAuth
+import com.ort.app.domain.model.auth.PlayerAuthRepository
+import com.ort.dbflute.exbhv.PlayerBhv
+import org.springframework.stereotype.Repository
+
+@Repository
+class PlayerAuthDataSource(
+    private val playerBhv: PlayerBhv,
+) : PlayerAuthRepository {
+    override fun findByName(name: String): PlayerAuth? {
+        val optPlayer =
+            playerBhv.selectEntity {
+                it.query().setPlayerName_Equal(name)
+            }
+        return optPlayer.map { toPlayerAuth(it) }.orElse(null)
+    }
+
+    override fun findById(playerId: Int): PlayerAuth? {
+        val optPlayer =
+            playerBhv.selectEntity {
+                it.query().setPlayerId_Equal(playerId)
+            }
+        return optPlayer.map { toPlayerAuth(it) }.orElse(null)
+    }
+
+    private fun toPlayerAuth(player: com.ort.dbflute.exentity.Player): PlayerAuth =
+        PlayerAuth(
+            playerId = player.playerId,
+            name = player.playerName,
+            passwordHash = player.playerPassword,
+            authorities = listOf(player.authorityCodeAsAuthority.code()),
+        )
+}

--- a/backend/src/main/kotlin/com/ort/app/infrastructure/datasource/RefreshTokenDataSource.kt
+++ b/backend/src/main/kotlin/com/ort/app/infrastructure/datasource/RefreshTokenDataSource.kt
@@ -1,0 +1,79 @@
+package com.ort.app.infrastructure.datasource
+
+import com.ort.app.domain.model.auth.RefreshToken
+import com.ort.app.domain.model.auth.RefreshTokenRepository
+import com.ort.dbflute.exbhv.RefreshTokenBhv
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+import com.ort.dbflute.exentity.RefreshToken as DbRefreshToken
+
+@Repository
+class RefreshTokenDataSource(
+    private val refreshTokenBhv: RefreshTokenBhv,
+) : RefreshTokenRepository {
+    override fun insert(
+        playerId: Int,
+        tokenHash: String,
+        issuedDatetime: LocalDateTime,
+        expiresDatetime: LocalDateTime,
+    ): RefreshToken {
+        val entity = DbRefreshToken()
+        entity.playerId = playerId
+        entity.tokenHash = tokenHash
+        entity.issuedDatetime = issuedDatetime
+        entity.expiresDatetime = expiresDatetime
+        refreshTokenBhv.insert(entity)
+        return mapToModel(entity)
+    }
+
+    override fun findByHash(tokenHash: String): RefreshToken? {
+        val optToken =
+            refreshTokenBhv.selectEntity {
+                it.query().setTokenHash_Equal(tokenHash)
+            }
+        return if (optToken.isPresent) mapToModel(optToken.get()) else null
+    }
+
+    override fun markUsed(
+        id: Int,
+        usedDatetime: LocalDateTime,
+    ) {
+        val entity = DbRefreshToken()
+        entity.refreshTokenId = id
+        entity.usedDatetime = usedDatetime
+        refreshTokenBhv.update(entity)
+    }
+
+    override fun revoke(
+        id: Int,
+        revokedDatetime: LocalDateTime,
+    ) {
+        val entity = DbRefreshToken()
+        entity.refreshTokenId = id
+        entity.revokedDatetime = revokedDatetime
+        refreshTokenBhv.update(entity)
+    }
+
+    override fun revokeAllByPlayer(
+        playerId: Int,
+        revokedDatetime: LocalDateTime,
+    ) {
+        val entity = DbRefreshToken()
+        entity.revokedDatetime = revokedDatetime
+        refreshTokenBhv.queryUpdate(entity) {
+            it.query().setPlayerId_Equal(playerId)
+            it.query().setRevokedDatetime_IsNull()
+        }
+    }
+
+    private fun mapToModel(entity: DbRefreshToken): RefreshToken =
+        RefreshToken(
+            id = entity.refreshTokenId,
+            playerId = entity.playerId,
+            tokenHash = entity.tokenHash,
+            issuedDatetime = entity.issuedDatetime,
+            expiresDatetime = entity.expiresDatetime,
+            usedDatetime = entity.usedDatetime,
+            revokedDatetime = entity.revokedDatetime,
+        )
+}

--- a/backend/src/main/kotlin/com/ort/app/infrastructure/datasource/RefreshTokenDataSource.kt
+++ b/backend/src/main/kotlin/com/ort/app/infrastructure/datasource/RefreshTokenDataSource.kt
@@ -37,17 +37,24 @@ class RefreshTokenDataSource(
     override fun markUsed(
         id: Int,
         usedDatetime: LocalDateTime,
-    ) {
+    ): Boolean {
+        // 条件付き UPDATE (used_datetime IS NULL のときだけ)。queryUpdate は更新件数を返す。
+        // entity にセットした列 (+ 共通更新列) のみが更新され、未セット列は NULL 上書きされない。
         val entity = DbRefreshToken()
-        entity.refreshTokenId = id
         entity.usedDatetime = usedDatetime
-        refreshTokenBhv.update(entity)
+        val updatedCount =
+            refreshTokenBhv.queryUpdate(entity) {
+                it.query().setRefreshTokenId_Equal(id)
+                it.query().setUsedDatetime_IsNull()
+            }
+        return updatedCount > 0
     }
 
     override fun revoke(
         id: Int,
         revokedDatetime: LocalDateTime,
     ) {
+        // PK 指定の partial update。DBFlute はセットした列 (revoked_datetime + 共通更新列) のみ更新する。
         val entity = DbRefreshToken()
         entity.refreshTokenId = id
         entity.revokedDatetime = revokedDatetime
@@ -63,6 +70,16 @@ class RefreshTokenDataSource(
         refreshTokenBhv.queryUpdate(entity) {
             it.query().setPlayerId_Equal(playerId)
             it.query().setRevokedDatetime_IsNull()
+        }
+    }
+
+    override fun deleteExpiredByPlayer(
+        playerId: Int,
+        now: LocalDateTime,
+    ) {
+        refreshTokenBhv.queryDelete {
+            it.query().setPlayerId_Equal(playerId)
+            it.query().setExpiresDatetime_LessThan(now)
         }
     }
 

--- a/backend/src/main/resources/config/application-playground.yml
+++ b/backend/src/main/resources/config/application-playground.yml
@@ -60,3 +60,9 @@ discord:
 microsoft:
   translator:
     key: ${WOLF_MANSION_MICROSOFT_TRANSLATOR_KEY}
+
+jwt:
+  secret: ${WOLF_MANSION_JWT_SECRET}
+  access-token-validity-minutes: 15
+  refresh-token-validity-days: 14
+  cookie-secure: true

--- a/backend/src/main/resources/config/application-production.yml
+++ b/backend/src/main/resources/config/application-production.yml
@@ -60,3 +60,9 @@ discord:
 microsoft:
   translator:
     key: ${WOLF_MANSION_MICROSOFT_TRANSLATOR_KEY}
+
+jwt:
+  secret: ${WOLF_MANSION_JWT_SECRET}
+  access-token-validity-minutes: 15
+  refresh-token-validity-days: 14
+  cookie-secure: true

--- a/backend/src/main/resources/config/application.yml
+++ b/backend/src/main/resources/config/application.yml
@@ -49,4 +49,12 @@ discord:
 
 microsoft:
   translator:
-    key: 
+    key:
+
+jwt:
+  # HS256 署名鍵。本番は環境変数必須。ローカルは dev 既定値 (32 バイト以上)
+  secret: ${WOLF_MANSION_JWT_SECRET:wolf-mansion-local-dev-secret-change-me-please-0123456789abcdef}
+  access-token-validity-minutes: 15
+  refresh-token-validity-days: 14
+  # ローカル (http) では Secure Cookie を無効化
+  cookie-secure: false

--- a/backend/src/test/kotlin/com/ort/app/application/coordinator/AuthCoordinatorTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/application/coordinator/AuthCoordinatorTest.kt
@@ -165,7 +165,12 @@ private class FakeRefreshTokenRepository : RefreshTokenRepository {
     override fun markUsed(
         id: Int,
         usedDatetime: LocalDateTime,
-    ) = replace(id) { it.copy(usedDatetime = usedDatetime) }
+    ): Boolean {
+        val index = tokens.indexOfFirst { it.id == id }
+        if (index < 0 || tokens[index].usedDatetime != null) return false
+        tokens[index] = tokens[index].copy(usedDatetime = usedDatetime)
+        return true
+    }
 
     override fun revoke(
         id: Int,
@@ -179,6 +184,13 @@ private class FakeRefreshTokenRepository : RefreshTokenRepository {
         tokens.replaceAll {
             if (it.playerId == playerId && it.revokedDatetime == null) it.copy(revokedDatetime = revokedDatetime) else it
         }
+    }
+
+    override fun deleteExpiredByPlayer(
+        playerId: Int,
+        now: LocalDateTime,
+    ) {
+        tokens.removeAll { it.playerId == playerId && it.expiresDatetime.isBefore(now) }
     }
 
     fun hasAny(): Boolean = tokens.isNotEmpty()

--- a/backend/src/test/kotlin/com/ort/app/application/coordinator/AuthCoordinatorTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/application/coordinator/AuthCoordinatorTest.kt
@@ -1,0 +1,193 @@
+package com.ort.app.application.coordinator
+
+import com.ort.app.domain.model.auth.PlayerAuth
+import com.ort.app.domain.model.auth.PlayerAuthRepository
+import com.ort.app.domain.model.auth.RefreshToken
+import com.ort.app.domain.model.auth.RefreshTokenRepository
+import com.ort.app.fw.exception.WolfMansionAuthException
+import com.ort.app.fw.security.jwt.JwtTokenProvider
+import com.ort.app.fw.security.jwt.RefreshTokenFactory
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import java.time.LocalDateTime
+
+internal class AuthCoordinatorTest {
+    private val encoder = BCryptPasswordEncoder()
+    private val jwt = JwtTokenProvider("test-secret-key-for-jwt-hs256-aaaaaaaaaaaaaaaaaaaa", 15, 14)
+    private val refreshFactory = RefreshTokenFactory()
+
+    private val alice =
+        PlayerAuth(
+            playerId = 1,
+            name = "alice",
+            passwordHash = encoder.encode("correct-horse"),
+            authorities = listOf("ROLE_PLAYER"),
+        )
+
+    private fun newCoordinator(tokenRepo: FakeRefreshTokenRepository): AuthCoordinator =
+        AuthCoordinator(
+            playerAuthRepository = FakePlayerAuthRepository(listOf(alice)),
+            refreshTokenRepository = tokenRepo,
+            jwtTokenProvider = jwt,
+            refreshTokenFactory = refreshFactory,
+            passwordEncoder = encoder,
+        )
+
+    @Test
+    fun login_success_issues_usable_refresh_token() {
+        val repo = FakeRefreshTokenRepository()
+        val tokens = newCoordinator(repo).login("alice", "correct-horse")
+
+        assertEquals(1, tokens.principal.playerId)
+        assertEquals("alice", tokens.principal.name)
+        val stored = repo.findByHash(refreshFactory.hash(tokens.refreshToken))
+        assertTrue(stored != null && stored.isUsable(LocalDateTime.now()))
+    }
+
+    @Test
+    fun login_with_wrong_password_throws() {
+        assertThrows<WolfMansionAuthException> {
+            newCoordinator(FakeRefreshTokenRepository()).login("alice", "wrong")
+        }
+    }
+
+    @Test
+    fun login_with_unknown_user_throws() {
+        assertThrows<WolfMansionAuthException> {
+            newCoordinator(FakeRefreshTokenRepository()).login("nobody", "correct-horse")
+        }
+    }
+
+    @Test
+    fun refresh_rotates_old_token_and_issues_new() {
+        val repo = FakeRefreshTokenRepository()
+        val coordinator = newCoordinator(repo)
+        val first = coordinator.login("alice", "correct-horse")
+
+        val second = coordinator.refresh(first.refreshToken)
+
+        // 新しい refresh token が発行される
+        assertNotEquals(first.refreshToken, second.refreshToken)
+        // 旧トークンは使用済み (再利用不可)
+        val old = repo.findByHash(refreshFactory.hash(first.refreshToken))
+        assertTrue(old != null && old.isUsed)
+        // 新トークンは使用可能
+        val new = repo.findByHash(refreshFactory.hash(second.refreshToken))
+        assertTrue(new != null && new.isUsable(LocalDateTime.now()))
+    }
+
+    @Test
+    fun reusing_rotated_token_revokes_all_player_tokens() {
+        val repo = FakeRefreshTokenRepository()
+        val coordinator = newCoordinator(repo)
+        val first = coordinator.login("alice", "correct-horse")
+        val second = coordinator.refresh(first.refreshToken) // first は使用済みに
+
+        // 使用済みの first を再提示 → 漏洩疑いで例外 + 全失効
+        assertThrows<WolfMansionAuthException> { coordinator.refresh(first.refreshToken) }
+
+        // second (まだ有効だった) も失効している
+        val new = repo.findByHash(refreshFactory.hash(second.refreshToken))
+        assertTrue(new != null && new.isRevoked)
+    }
+
+    @Test
+    fun logout_revokes_presented_token() {
+        val repo = FakeRefreshTokenRepository()
+        val coordinator = newCoordinator(repo)
+        val tokens = coordinator.login("alice", "correct-horse")
+
+        coordinator.logout(tokens.refreshToken)
+
+        val stored = repo.findByHash(refreshFactory.hash(tokens.refreshToken))
+        assertTrue(stored != null && stored.isRevoked)
+    }
+
+    @Test
+    fun refresh_with_unknown_token_throws() {
+        assertThrows<WolfMansionAuthException> {
+            newCoordinator(FakeRefreshTokenRepository()).refresh("does-not-exist")
+        }
+    }
+
+    @Test
+    fun logout_with_null_token_is_noop() {
+        val repo = FakeRefreshTokenRepository()
+        newCoordinator(repo).logout(null)
+        assertNull(repo.findByHash("anything"))
+        assertFalse(repo.hasAny())
+    }
+}
+
+private class FakePlayerAuthRepository(
+    players: List<PlayerAuth>,
+) : PlayerAuthRepository {
+    private val byName = players.associateBy { it.name }
+    private val byId = players.associateBy { it.playerId }
+
+    override fun findByName(name: String): PlayerAuth? = byName[name]
+
+    override fun findById(playerId: Int): PlayerAuth? = byId[playerId]
+}
+
+private class FakeRefreshTokenRepository : RefreshTokenRepository {
+    private val tokens = mutableListOf<RefreshToken>()
+    private var sequence = 0
+
+    override fun insert(
+        playerId: Int,
+        tokenHash: String,
+        issuedDatetime: LocalDateTime,
+        expiresDatetime: LocalDateTime,
+    ): RefreshToken {
+        val token =
+            RefreshToken(
+                id = ++sequence,
+                playerId = playerId,
+                tokenHash = tokenHash,
+                issuedDatetime = issuedDatetime,
+                expiresDatetime = expiresDatetime,
+                usedDatetime = null,
+                revokedDatetime = null,
+            )
+        tokens.add(token)
+        return token
+    }
+
+    override fun findByHash(tokenHash: String): RefreshToken? = tokens.firstOrNull { it.tokenHash == tokenHash }
+
+    override fun markUsed(
+        id: Int,
+        usedDatetime: LocalDateTime,
+    ) = replace(id) { it.copy(usedDatetime = usedDatetime) }
+
+    override fun revoke(
+        id: Int,
+        revokedDatetime: LocalDateTime,
+    ) = replace(id) { it.copy(revokedDatetime = revokedDatetime) }
+
+    override fun revokeAllByPlayer(
+        playerId: Int,
+        revokedDatetime: LocalDateTime,
+    ) {
+        tokens.replaceAll {
+            if (it.playerId == playerId && it.revokedDatetime == null) it.copy(revokedDatetime = revokedDatetime) else it
+        }
+    }
+
+    fun hasAny(): Boolean = tokens.isNotEmpty()
+
+    private fun replace(
+        id: Int,
+        transform: (RefreshToken) -> RefreshToken,
+    ) {
+        val index = tokens.indexOfFirst { it.id == id }
+        if (index >= 0) tokens[index] = transform(tokens[index])
+    }
+}

--- a/backend/src/test/kotlin/com/ort/app/fw/security/jwt/JwtTokenProviderTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/fw/security/jwt/JwtTokenProviderTest.kt
@@ -1,0 +1,51 @@
+package com.ort.app.fw.security.jwt
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+internal class JwtTokenProviderTest {
+    // HS256 は 256bit(32 バイト)以上の鍵が必要
+    private val secret = "test-secret-key-for-jwt-hs256-aaaaaaaaaaaaaaaaaaaa"
+    private val provider = JwtTokenProvider(secret, accessTokenValidityMinutes = 15, refreshTokenValidityDays = 14)
+
+    @Test
+    fun issue_then_parse_roundtrip() {
+        val token = provider.issueAccessToken(42, "alice", listOf("ROLE_PLAYER"))
+        val principal = provider.parseAccessToken(token)
+        assertNotNull(principal)
+        assertEquals(42, principal!!.playerId)
+        assertEquals("alice", principal.name)
+        assertEquals(listOf("ROLE_PLAYER"), principal.authorities)
+    }
+
+    @Test
+    fun parse_returns_null_for_expired_token() {
+        // 30 分前に発行 → exp(発行+15分) は既に過去
+        val past = Instant.now().minus(30, ChronoUnit.MINUTES)
+        val token = provider.issueAccessToken(1, "bob", listOf("ROLE_PLAYER"), now = past)
+        assertNull(provider.parseAccessToken(token))
+    }
+
+    @Test
+    fun parse_returns_null_for_tampered_token() {
+        val token = provider.issueAccessToken(1, "bob", listOf("ROLE_PLAYER"))
+        val tampered = token.dropLast(3) + "xyz"
+        assertNull(provider.parseAccessToken(tampered))
+    }
+
+    @Test
+    fun parse_returns_null_for_token_signed_with_other_key() {
+        val other = JwtTokenProvider("another-secret-key-totally-different-bbbbbbbbbbbb", 15, 14)
+        val token = other.issueAccessToken(1, "bob", listOf("ROLE_PLAYER"))
+        assertNull(provider.parseAccessToken(token))
+    }
+
+    @Test
+    fun parse_returns_null_for_garbage() {
+        assertNull(provider.parseAccessToken("not-a-jwt"))
+    }
+}


### PR DESCRIPTION
closes .issues/step-3.1-jwt-auth-core.md

Step 3 (認証 REST 化) の 1/4。backend に JWT 認証基盤と最初の auth エンドポイント群を追加する。refresh token テーブルと DBFlute entity は step-3.0 (#51) で導入済み。

## 変更内容

- **SecurityConfig 2 チェーン化**: `/api/v1/**` は stateless JWT チェーン (@Order 1)、それ以外は既存 session + formLogin チェーン (@Order 2) を**そのまま温存**。旧 SSR 全画面と公開 `/api/login` (analyzer 依存) は無変更
- **JWT 基盤** (`fw/security/jwt/`):
  - `JwtTokenProvider`: access token を **HS256 明示**で発行・検証 (sub=playerId, name, authorities)
  - `JwtAuthenticationFilter`: access Cookie を検証して SecurityContext に詰める (無効でも弾かず認可に委譲)
  - `JwtAuthenticationEntryPoint`: 未認証は 401 を ProblemDetail で返す
  - `AuthCookieFactory`: access `Path=/` (15分) / refresh `Path=<contextPath>/api/v1/auth` (14日)。HttpOnly / SameSite=Lax / Secure は `jwt.cookie-secure` 連動
- **AuthController** (`/api/v1/auth`): `login` / `refresh` / `logout` / `me`
- **refresh 使い捨て rotation + 漏洩検知**: refresh のたびに旧トークンを使用済みにし新規発行。使用済みトークンの再提示は当該プレイヤーの全トークンを失効。refresh token は不透明乱数で、DB (`REFRESH_TOKEN`) には SHA-256 ハッシュのみ保存
- **ProblemDetail (RFC 7807)** を `@RestControllerAdvice(annotations=[RestController])` で統一 (SSR の `@Controller` には非干渉)
- **パスワードポリシー緩和準拠**: login は password 形式を検証しない (NotNull のみ)。資格情報誤りはユーザー存在を区別しない 401 文言
- JWT 鍵 / Cookie secure を yml に追加 (local は dev 既定値、prod/playground は env 必須 + Secure 有効)

## 動作確認

- [x] `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew build` → BUILD SUCCESSFUL (compile + ktlint(main/test) + 全テスト + assemble)
- [x] 単体テスト: `JwtTokenProviderTest` (発行/検証/期限切れ/改竄/別鍵, 5件) + `AuthCoordinatorTest` (login・rotation・漏洩検知・logout, 8件) すべて green
- [x] 手動 (bootRun :8089) curl:
  - login → 200 + Set-Cookie 2本 (JWT header alg=HS256 を確認) + body `{playerId,name,authorities}`
  - me (Cookie あり) → 200 / me (Cookie なし) → 401 `application/problem+json`
  - refresh → 200 + 新 Cookie (rotation) / 旧 refresh 再提示 → 401 (漏洩検知)
  - logout → 204 + 両 Cookie 消去
  - **回帰**: 旧 SSR `GET /` → 200 / 公開 `POST /api/login` → 200 PlayerView (chain 2 温存)
- e2e (認証フロー) は step-3.3 (frontend) で追加

## 備考

- frontend 認証フロー + e2e は step-3.3、signup/password REST 化 + ログインレート制限は step-3.2、OpenAPI→TS 型生成は step-3.4
- 権限名は現行 `CDef.Authority` = `ROLE_ADMIN` / `ROLE_PLAYER` を踏襲

🤖 Generated with [Claude Code](https://claude.com/claude-code)