### PR TITLE
feat: Step 3.4 OpenAPI→TS 型生成パイプライン (pnpm gen:api + CI drift) + 3.3暫定型/定数の正式共有 (step-3.4)

### DIFF
--- a/.github/workflows/api-drift.yml
+++ b/.github/workflows/api-drift.yml
@@ -70,7 +70,9 @@ jobs:
           fi
           # 生成物を作り直す
           (cd frontend && BACKEND_ORIGIN=http://localhost:8089 pnpm gen:api)
-          # commit 済みと差分があれば fail
+          # commit 済みと差分があれば fail。git diff は tracked のみ見るため、未追跡の
+          # 新規生成物も拾えるよう intent-to-add してから比較する
+          git add -N frontend/app/api
           if ! git diff --exit-code -- frontend/app/api; then
             echo "::error::OpenAPI 生成物が古いです。frontend で 'pnpm gen:api' を実行して commit してください。"
             exit 1

--- a/.github/workflows/api-drift.yml
+++ b/.github/workflows/api-drift.yml
@@ -1,0 +1,78 @@
+name: api-drift
+
+# OpenAPI (backend) → TS 型/定数 (frontend) の追随漏れを検知する。
+# backend を起動して /v3/api-docs を取得し直し、frontend の生成物 (app/api/*) を再生成 → 差分があれば fail。
+# 差分が出たら frontend で `pnpm gen:api` を実行して commit すれば解消する。
+on:
+  pull_request:
+    branches: [feature/monorepo]
+    paths:
+      - backend/**
+      - frontend/app/api/**
+      - frontend/package.json
+      - frontend/scripts/**
+      - .github/workflows/api-drift.yml
+
+jobs:
+  drift:
+    runs-on: ubuntu-24.04
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          # backend の application.yml 既定に合わせる (空 DB で OK — spec 生成にテーブルは不要)
+          MYSQL_DATABASE: werewolf_mansiondb
+          MYSQL_USER: wmansion
+          MYSQL_PASSWORD: wmans10n
+        ports:
+          - 4306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Enable pnpm (corepack)
+        run: corepack enable
+
+      - name: Install frontend deps
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Regenerate API artifacts & check drift
+        run: |
+          set -euo pipefail
+          # backend 起動 (空 DB に接続。spec 取得のみなのでテーブルは不要)
+          (cd backend && ./gradlew bootRun > /tmp/backend.log 2>&1 &)
+          echo "waiting for backend /v3/api-docs ..."
+          ready=
+          for i in $(seq 1 60); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8089/wolf-mansion/v3/api-docs || true)
+            if [ "$code" = "200" ]; then ready=1; echo "backend ready after $((i*5))s"; break; fi
+            sleep 5
+          done
+          if [ -z "$ready" ]; then
+            echo "::error::backend が起動しませんでした"; tail -n 100 /tmp/backend.log; exit 1
+          fi
+          # 生成物を作り直す
+          (cd frontend && BACKEND_ORIGIN=http://localhost:8089 pnpm gen:api)
+          # commit 済みと差分があれば fail
+          if ! git diff --exit-code -- frontend/app/api; then
+            echo "::error::OpenAPI 生成物が古いです。frontend で 'pnpm gen:api' を実行して commit してください。"
+            exit 1
+          fi
+          echo "no drift 🎉"

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -49,6 +49,8 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:0.12.6")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
+    // OpenAPI spec (/v3/api-docs)。frontend の TS 型生成 (pnpm gen:api) の元になる。swagger-ui は含めない
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.17")
 
     // test
     testImplementation("org.jetbrains.kotlin:kotlin-test")

--- a/backend/src/main/kotlin/com/ort/app/api/auth/request/PasswordChangeRequest.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/auth/request/PasswordChangeRequest.kt
@@ -3,19 +3,21 @@ package com.ort.app.api.auth.request
 import com.ort.app.fw.security.PasswordPolicy
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Pattern
-import org.hibernate.validator.constraints.Length
+import jakarta.validation.constraints.Size
 
 /**
  * パスワード変更リクエスト。緩和ポリシー ([PasswordPolicy])。
  * `password == confirmPassword` の相関チェックはコントローラ側で行う (不一致は 400)。
+ *
+ * 長さ制約は Jakarta 標準の [Size] を使う ([SignupRequest] と同じ理由 — SpringDoc が minLength/maxLength を出力する)。
  */
 data class PasswordChangeRequest(
     @field:NotNull
-    @field:Length(min = PasswordPolicy.MIN_LENGTH, max = PasswordPolicy.MAX_LENGTH)
+    @field:Size(min = PasswordPolicy.MIN_LENGTH, max = PasswordPolicy.MAX_LENGTH)
     @field:Pattern(regexp = PasswordPolicy.PATTERN)
     val password: String? = null,
     @field:NotNull
-    @field:Length(min = PasswordPolicy.MIN_LENGTH, max = PasswordPolicy.MAX_LENGTH)
+    @field:Size(min = PasswordPolicy.MIN_LENGTH, max = PasswordPolicy.MAX_LENGTH)
     @field:Pattern(regexp = PasswordPolicy.PATTERN)
     val confirmPassword: String? = null,
 )

--- a/backend/src/main/kotlin/com/ort/app/api/auth/request/SignupRequest.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/auth/request/SignupRequest.kt
@@ -3,19 +3,22 @@ package com.ort.app.api.auth.request
 import com.ort.app.fw.security.PasswordPolicy
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Pattern
-import org.hibernate.validator.constraints.Length
+import jakarta.validation.constraints.Size
 
 /**
  * 新規登録リクエスト。userId は現状維持 (3〜12文字 / 英数 + ハイフン・アンダーバー / 1文字目英字)、
  * password は緩和ポリシー ([PasswordPolicy])。
+ *
+ * 長さ制約は Jakarta 標準の [Size] を使う (Hibernate `@Length` は SpringDoc が minLength/maxLength として
+ * 出力しないため)。これにより `/v3/api-docs` がフロント定数 (pnpm gen:api → constants.ts) の単一ソースになる。
  */
 data class SignupRequest(
     @field:NotNull
-    @field:Length(min = 3, max = 12)
+    @field:Size(min = 3, max = 12)
     @field:Pattern(regexp = "[a-zA-Z][a-zA-Z0-9\\-_]*")
     val userId: String? = null,
     @field:NotNull
-    @field:Length(min = PasswordPolicy.MIN_LENGTH, max = PasswordPolicy.MAX_LENGTH)
+    @field:Size(min = PasswordPolicy.MIN_LENGTH, max = PasswordPolicy.MAX_LENGTH)
     @field:Pattern(regexp = PasswordPolicy.PATTERN)
     val password: String? = null,
 )

--- a/backend/src/main/resources/config/application-production.yml
+++ b/backend/src/main/resources/config/application-production.yml
@@ -71,3 +71,8 @@ login-rate-limit:
   window-minutes: 15
   max-per-account: 5
   max-per-ip: 30
+
+# OpenAPI spec は本番に公開しない (型生成は dev / CI でのみ実施)
+springdoc:
+  api-docs:
+    enabled: false

--- a/backend/src/main/resources/config/application.yml
+++ b/backend/src/main/resources/config/application.yml
@@ -67,3 +67,8 @@ login-rate-limit:
   max-per-account: 5
   # IP 単位の失敗上限。共有 NAT を許容しつつ bulk を抑止
   max-per-ip: 30
+
+# OpenAPI (SpringDoc)。frontend の TS 型生成 (pnpm gen:api) が /v3/api-docs を取得する
+springdoc:
+  # 新 REST 面 (/api/v1/**) のみを spec に含める。旧 SSR Controller / 公開 API (/api/login 等) は対象外
+  paths-to-match: /api/v1/**

--- a/frontend/app/api/constants.ts
+++ b/frontend/app/api/constants.ts
@@ -1,0 +1,14 @@
+/**
+ * このファイルは `pnpm gen:api` による生成物です。手動編集しないでください。
+ * 元: backend の OpenAPI spec (/v3/api-docs)。再生成すると上書きされます。
+ */
+
+/** パスワードポリシー (backend PasswordPolicy 由来)。 */
+export const PASSWORD_MIN_LENGTH = 3;
+export const PASSWORD_MAX_LENGTH = 60;
+export const PASSWORD_PATTERN = "[\\x21-\\x7E]+";
+
+/** signup userId 制約 (backend SignupRequest 由来)。 */
+export const SIGNUP_USER_ID_MIN_LENGTH = 3;
+export const SIGNUP_USER_ID_MAX_LENGTH = 12;
+export const SIGNUP_USER_ID_PATTERN = "[a-zA-Z][a-zA-Z0-9\\-_]*";

--- a/frontend/app/api/openapi.json
+++ b/frontend/app/api/openapi.json
@@ -4,12 +4,6 @@
     "title": "OpenAPI definition",
     "version": "v0"
   },
-  "servers": [
-    {
-      "url": "http://localhost:18089/wolf-mansion",
-      "description": "Generated server url"
-    }
-  ],
   "paths": {
     "/api/v1/auth/signup": {
       "post": {

--- a/frontend/app/api/openapi.json
+++ b/frontend/app/api/openapi.json
@@ -1,0 +1,240 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:18089/wolf-mansion",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/api/v1/auth/signup": {
+      "post": {
+        "tags": ["auth-controller"],
+        "operationId": "signup",
+        "parameters": [
+          {
+            "name": "id_register",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SignupRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/refresh": {
+      "post": {
+        "tags": ["auth-controller"],
+        "operationId": "refresh",
+        "parameters": [
+          {
+            "name": "refresh_token",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/password": {
+      "post": {
+        "tags": ["auth-controller"],
+        "operationId": "changePassword",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PasswordChangeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/auth/logout": {
+      "post": {
+        "tags": ["auth-controller"],
+        "operationId": "logout",
+        "parameters": [
+          {
+            "name": "refresh_token",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/auth/login": {
+      "post": {
+        "tags": ["auth-controller"],
+        "operationId": "login",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/me": {
+      "get": {
+        "tags": ["auth-controller"],
+        "operationId": "me",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "SignupRequest": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": ["string", "null"],
+            "maxLength": 12,
+            "minLength": 3,
+            "pattern": "[a-zA-Z][a-zA-Z0-9\\-_]*"
+          },
+          "password": {
+            "type": ["string", "null"],
+            "maxLength": 60,
+            "minLength": 3,
+            "pattern": "[\\x21-\\x7E]+"
+          }
+        },
+        "required": ["password", "userId"]
+      },
+      "MeResponse": {
+        "type": "object",
+        "properties": {
+          "playerId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string"
+          },
+          "authorities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["authorities", "name", "playerId"]
+      },
+      "PasswordChangeRequest": {
+        "type": "object",
+        "properties": {
+          "password": {
+            "type": ["string", "null"],
+            "maxLength": 60,
+            "minLength": 3,
+            "pattern": "[\\x21-\\x7E]+"
+          },
+          "confirmPassword": {
+            "type": ["string", "null"],
+            "maxLength": 60,
+            "minLength": 3,
+            "pattern": "[\\x21-\\x7E]+"
+          }
+        },
+        "required": ["confirmPassword", "password"]
+      },
+      "LoginRequest": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": ["string", "null"]
+          },
+          "password": {
+            "type": ["string", "null"]
+          }
+        },
+        "required": ["password", "userId"]
+      }
+    }
+  }
+}

--- a/frontend/app/api/types.ts
+++ b/frontend/app/api/types.ts
@@ -1,0 +1,267 @@
+/**
+ * このファイルは `pnpm gen:api` による生成物です。手動編集しないでください。
+ * 元: backend の OpenAPI spec (/v3/api-docs)。再生成すると上書きされます。
+ */
+export interface paths {
+  "/api/v1/auth/signup": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["signup"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/auth/refresh": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["refresh"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/auth/password": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["changePassword"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/auth/logout": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["logout"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/auth/login": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["login"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/auth/me": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["me"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+}
+export type webhooks = Record<string, never>;
+export interface components {
+  schemas: {
+    SignupRequest: {
+      userId: string | null;
+      password: string | null;
+    };
+    MeResponse: {
+      /** Format: int32 */
+      playerId: number;
+      name: string;
+      authorities: string[];
+    };
+    PasswordChangeRequest: {
+      password: string | null;
+      confirmPassword: string | null;
+    };
+    LoginRequest: {
+      userId: string | null;
+      password: string | null;
+    };
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
+}
+export type $defs = Record<string, never>;
+export interface operations {
+  signup: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: {
+        id_register?: boolean;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["SignupRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["MeResponse"];
+        };
+      };
+    };
+  };
+  refresh: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: {
+        refresh_token?: string;
+      };
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["MeResponse"];
+        };
+      };
+    };
+  };
+  changePassword: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PasswordChangeRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  logout: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: {
+        refresh_token?: string;
+      };
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  login: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["LoginRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["MeResponse"];
+        };
+      };
+    };
+  };
+  me: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["MeResponse"];
+        };
+      };
+    };
+  };
+}

--- a/frontend/app/features/auth/api.ts
+++ b/frontend/app/features/auth/api.ts
@@ -1,3 +1,4 @@
+import type { components } from "~/api/types";
 import { apiFetch } from "~/lib/api";
 
 /**
@@ -5,12 +6,8 @@ import { apiFetch } from "~/lib/api";
  * すべて CSR 専用。Cookie は backend が HttpOnly で発行/破棄する。
  */
 
-/** `/api/v1/auth/me` 等が返す最小プレイヤー情報。 */
-export type MeResponse = {
-  playerId: number;
-  name: string;
-  authorities: string[];
-};
+/** `/api/v1/auth/me` 等が返す最小プレイヤー情報 (OpenAPI 生成型・Step 3.4)。 */
+export type MeResponse = components["schemas"]["MeResponse"];
 
 const AUTH_BASE = "/api/v1/auth";
 

--- a/frontend/app/features/auth/schema.ts
+++ b/frontend/app/features/auth/schema.ts
@@ -1,26 +1,32 @@
 import { z } from "zod";
+import {
+  PASSWORD_MAX_LENGTH,
+  PASSWORD_MIN_LENGTH,
+  PASSWORD_PATTERN,
+  SIGNUP_USER_ID_MAX_LENGTH,
+  SIGNUP_USER_ID_MIN_LENGTH,
+  SIGNUP_USER_ID_PATTERN,
+} from "~/api/constants";
 
 /**
- * 認証フォームの入力スキーマ (Step 3.3)。
+ * 認証フォームの入力スキーマ (Step 3.3 / 3.4)。
  *
- * パスワードポリシー / userId 制約は backend と一致させる:
- * - PasswordPolicy (`backend/.../fw/security/PasswordPolicy.kt`): 3〜60 文字 / 印字可能 ASCII
- * - signup userId (`SignupRequest`): 3〜12 文字 / 1 文字目英字 + 英数 - _
- *
- * NOTE: これらの定数の **正式な共有は Step 3.4 (OpenAPI→TS)** で行う。ここでは暫定で手書きする。
+ * パスワードポリシー / userId 制約は backend の OpenAPI spec 由来の生成定数 (`~/api/constants`) を使う。
+ * 定数の単一ソースは backend (`PasswordPolicy` / `SignupRequest`) で、`pnpm gen:api` で同期される。
+ * spec の pattern は非アンカーなので、Bean Validation (matches) と揃えるためここで `^…$` を付与する。
  */
 
-export const PASSWORD_MIN_LENGTH = 3;
-export const PASSWORD_MAX_LENGTH = 60;
-/** 印字可能 ASCII (0x21–0x7E) のみ。backend PasswordPolicy.PATTERN と等価。 */
-const PASSWORD_PATTERN = /^[\x21-\x7E]+$/;
+const passwordRegex = new RegExp(`^${PASSWORD_PATTERN}$`);
+const userIdRegex = new RegExp(`^${SIGNUP_USER_ID_PATTERN}$`);
+
 const PASSWORD_MESSAGE = `パスワードは ${PASSWORD_MIN_LENGTH}〜${PASSWORD_MAX_LENGTH} 文字の半角英数記号で入力してください`;
+const USER_ID_LENGTH_MESSAGE = `IDは ${SIGNUP_USER_ID_MIN_LENGTH}〜${SIGNUP_USER_ID_MAX_LENGTH} 文字で入力してください`;
 
 const password = z
   .string()
   .min(PASSWORD_MIN_LENGTH, PASSWORD_MESSAGE)
   .max(PASSWORD_MAX_LENGTH, PASSWORD_MESSAGE)
-  .regex(PASSWORD_PATTERN, PASSWORD_MESSAGE);
+  .regex(passwordRegex, PASSWORD_MESSAGE);
 
 /** login は backend が password 形式を検証しない (緩和後ポリシー) ので、空でないことだけ見る。 */
 export const loginSchema = z.object({
@@ -31,12 +37,9 @@ export const loginSchema = z.object({
 export const signupSchema = z.object({
   userId: z
     .string()
-    .min(3, "IDは 3〜12 文字で入力してください")
-    .max(12, "IDは 3〜12 文字で入力してください")
-    .regex(
-      /^[a-zA-Z][a-zA-Z0-9\-_]*$/,
-      "IDは英字で始まり、英数字・ハイフン・アンダーバーのみ使えます",
-    ),
+    .min(SIGNUP_USER_ID_MIN_LENGTH, USER_ID_LENGTH_MESSAGE)
+    .max(SIGNUP_USER_ID_MAX_LENGTH, USER_ID_LENGTH_MESSAGE)
+    .regex(userIdRegex, "IDは英字で始まり、英数字・ハイフン・アンダーバーのみ使えます"),
   password,
 });
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "format": "oxfmt --write",
     "format:check": "oxfmt --check",
     "gen:api": "node scripts/gen-api.mjs && oxfmt --write app/api",
-    "check:api": "pnpm gen:api && git diff --exit-code -- app/api"
+    "check:api": "pnpm gen:api && git add -N app/api && git diff --exit-code -- app/api"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,9 @@
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
     "format": "oxfmt --write",
-    "format:check": "oxfmt --check"
+    "format:check": "oxfmt --check",
+    "gen:api": "node scripts/gen-api.mjs && oxfmt --write app/api",
+    "check:api": "pnpm gen:api && git diff --exit-code -- app/api"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/frontend/scripts/gen-api.mjs
+++ b/frontend/scripts/gen-api.mjs
@@ -1,0 +1,88 @@
+// @ts-check
+/**
+ * OpenAPI → TypeScript 型 / 定数 生成スクリプト (Step 3.4)。
+ *
+ * 稼働中 backend の `/v3/api-docs` を取得し、以下を `app/api/` に生成する:
+ *   - openapi.json … 取得した OpenAPI spec (drift 検知の基準)
+ *   - types.ts     … openapi-typescript による型定義
+ *   - constants.ts … request schema の制約 (minLength/maxLength/pattern) 由来の共有定数
+ *
+ * すべて生成物。手動編集しないこと (再生成で上書きされる)。
+ * 実行前に backend を起動しておく (既定 http://localhost:8089/wolf-mansion)。
+ *
+ * env:
+ *   BACKEND_ORIGIN … backend オリジン (既定 http://localhost:8089)。CI は別ポートを渡す
+ *   VITE_API_BASE  … context-path (既定 /wolf-mansion)
+ *   OPENAPI_URL    … spec URL を直接指定 (上記 2 つを上書き)
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import openapiTS, { astToString } from "openapi-typescript";
+
+const BACKEND_ORIGIN = process.env.BACKEND_ORIGIN ?? "http://localhost:8089";
+const API_BASE = process.env.VITE_API_BASE ?? "/wolf-mansion";
+const SPEC_URL = process.env.OPENAPI_URL ?? `${BACKEND_ORIGIN}${API_BASE}/v3/api-docs`;
+
+const apiDir = resolve(dirname(fileURLToPath(import.meta.url)), "../app/api");
+
+const GENERATED_HEADER = `/**
+ * このファイルは \`pnpm gen:api\` による生成物です。手動編集しないでください。
+ * 元: backend の OpenAPI spec (/v3/api-docs)。再生成すると上書きされます。
+ */
+`;
+
+/** spec を取得する。 */
+async function fetchSpec() {
+  const res = await fetch(SPEC_URL);
+  if (!res.ok) {
+    throw new Error(
+      `OpenAPI spec の取得に失敗: ${SPEC_URL} → HTTP ${res.status}. backend が起動しているか確認してください。`,
+    );
+  }
+  return res.json();
+}
+
+/** request schema のプロパティから制約定数を抽出する。 */
+function extractConstants(spec) {
+  const schemas = spec.components?.schemas ?? {};
+  const signup = schemas.SignupRequest?.properties ?? {};
+  const password = signup.password ?? {};
+  const userId = signup.userId ?? {};
+
+  /** @param {string} name @param {unknown} value */
+  const line = (name, value) => `export const ${name} = ${JSON.stringify(value)};`;
+
+  return [
+    GENERATED_HEADER,
+    "/** パスワードポリシー (backend PasswordPolicy 由来)。 */",
+    line("PASSWORD_MIN_LENGTH", password.minLength),
+    line("PASSWORD_MAX_LENGTH", password.maxLength),
+    line("PASSWORD_PATTERN", password.pattern),
+    "",
+    "/** signup userId 制約 (backend SignupRequest 由来)。 */",
+    line("SIGNUP_USER_ID_MIN_LENGTH", userId.minLength),
+    line("SIGNUP_USER_ID_MAX_LENGTH", userId.maxLength),
+    line("SIGNUP_USER_ID_PATTERN", userId.pattern),
+    "",
+  ].join("\n");
+}
+
+async function main() {
+  const spec = await fetchSpec();
+  await mkdir(apiDir, { recursive: true });
+
+  // 1. spec をそのまま保存 (drift 検知の基準)
+  await writeFile(resolve(apiDir, "openapi.json"), `${JSON.stringify(spec, null, 2)}\n`);
+
+  // 2. 型生成
+  const ast = await openapiTS(spec);
+  await writeFile(resolve(apiDir, "types.ts"), GENERATED_HEADER + astToString(ast));
+
+  // 3. 共有定数生成
+  await writeFile(resolve(apiDir, "constants.ts"), extractConstants(spec));
+
+  console.log(`generated app/api/{openapi.json,types.ts,constants.ts} from ${SPEC_URL}`);
+}
+
+await main();

--- a/frontend/scripts/gen-api.mjs
+++ b/frontend/scripts/gen-api.mjs
@@ -72,7 +72,12 @@ async function main() {
   const spec = await fetchSpec();
   await mkdir(apiDir, { recursive: true });
 
-  // 1. spec をそのまま保存 (drift 検知の基準)
+  // SpringDoc は server URL をリクエスト由来 (host:port + context-path) で動的に埋め込むため、
+  // 生成元のポート (8089 / e2e 18089 / CI) によって `servers` が揺れて drift の温床になる。
+  // frontend は相対 base (VITE_API_BASE) で叩くので server URL は不要 → 除去してポート非依存にする。
+  delete spec.servers;
+
+  // 1. spec を保存 (drift 検知の基準)
   await writeFile(resolve(apiDir, "openapi.json"), `${JSON.stringify(spec, null, 2)}\n`);
 
   // 2. 型生成

--- a/frontend/scripts/gen-api.mjs
+++ b/frontend/scripts/gen-api.mjs
@@ -50,6 +50,26 @@ function extractConstants(spec) {
   const password = signup.password ?? {};
   const userId = signup.userId ?? {};
 
+  // backend を制約の単一ソースにするのが目的なので、ソース欠落は黙って `undefined` 定数を吐かず loud に落とす
+  // (SpringDoc の回帰や @Size/@Pattern 取り違えで frontend バリデーションが無効化されるのを防ぐ)。
+  const required = {
+    "SignupRequest.password.minLength": password.minLength,
+    "SignupRequest.password.maxLength": password.maxLength,
+    "SignupRequest.password.pattern": password.pattern,
+    "SignupRequest.userId.minLength": userId.minLength,
+    "SignupRequest.userId.maxLength": userId.maxLength,
+    "SignupRequest.userId.pattern": userId.pattern,
+  };
+  const missing = Object.entries(required)
+    .filter(([, v]) => v === undefined)
+    .map(([k]) => k);
+  if (missing.length > 0) {
+    throw new Error(
+      `OpenAPI spec に必須の制約が見つかりません: ${missing.join(", ")}. ` +
+        "backend の @Size/@Pattern (PasswordPolicy / SignupRequest) を確認してください。",
+    );
+  }
+
   /** @param {string} name @param {unknown} value */
   const line = (name, value) => `export const ${name} = ${JSON.stringify(value)};`;
 


### PR DESCRIPTION
closes .issues/step-3.4-openapi-ts-typegen.md

## 概要

Step 3.4。backend の OpenAPI spec を単一ソースに、frontend の型/定数を生成パイプライン化する。
3.3 で手書き二重定義していた `MeResponse` 型と zod の password/userId ポリシー定数を spec 由来の生成物に置換し、`pnpm gen:api` + GitHub Actions の drift 検知で追随漏れを防ぐ。

正本: `doc/migration/06-infra-deploy.md`「型共有 (OpenAPI → TypeScript)」/ `08-step-plan.md` 横断タスク。

## 変更点

### backend (SpringDoc)
- `springdoc-openapi-starter-webmvc-api:2.8.17` 追加 (Spring Boot 3.5 系ビルド。swagger-ui は含めない)
- `application.yml`: `springdoc.paths-to-match=/api/v1/**` で **新 REST 面のみ**を spec 化 (旧 SSR Controller / 公開 API を混ぜない)
- `production`: `springdoc.api-docs.enabled=false` (本番に spec を公開しない)
- `SignupRequest` / `PasswordChangeRequest`: Hibernate `@Length` → Jakarta `@Size`
  - **理由**: SpringDoc は `@Length` を `minLength`/`maxLength` として出力しない。`@Size` にすることで spec がパスワード/userId 定数の単一ソースになる (`@Pattern` は元から出力される)

### frontend (生成パイプライン)
- `scripts/gen-api.mjs`: 稼働中 backend の `/v3/api-docs` → `app/api/{openapi.json,types.ts,constants.ts}` を生成
- `package.json`: `gen:api` (生成 + oxfmt) / `check:api` (生成 + `git diff --exit-code`)
- `features/auth/api.ts`: 手書き `MeResponse` → 生成型 `components["schemas"]["MeResponse"]`
- `features/auth/schema.ts`: password/userId の min/max/pattern を `~/api/constants` (生成定数) から取得。spec の pattern は非アンカーなので zod 用に `^…$` を付与

### CI
- `.github/workflows/api-drift.yml`: `feature/monorepo` への PR (paths: `backend/**` / `frontend/app/api/**` / `package.json` / `scripts/**`) で MySQL 起動 → backend 起動 → `pnpm gen:api` → `git diff --exit-code` で drift 検知

## spec 生成方式 / drift 検知の決定
- spec 生成 = **稼働中 backend から fetch** (06-infra-deploy.md の正本フロー)。生成物 (openapi.json/types.ts/constants.ts) を commit
- drift 検知 = **GitHub Actions を本 step で先行追加**。spec 取得にテーブルは不要なため CI の MySQL は**空 DB**でよい (検証済)

## 動作確認
- backend: `compileKotlin` / `test` (37件・context 起動) / `ktlintCheck` すべて green
- `/v3/api-docs` が `/api/v1/**` のみを含み、未認証で取得でき、`@Size` 化で `minLength`/`maxLength`/`pattern` が出力される
- **空 DB** に接続した backend でも `/v3/api-docs` が 200 (CI workflow の前提を実機検証)
- `pnpm gen:api` を2回実行して生成物が同一 (冪等)
- frontend: `typecheck` / `lint` / `format:check` / `build` すべて green
- e2e: `auth.spec` (signup→me→logout→login + 未認証リダイレクト) + smoke の **3件 green** (リフレッシュした型/定数で認証フローが不変)

## スコープ外 / メモ
- context-path rename (`/wolf-mansion-api`) は別サブ step (据置)
- `changePassword`/`logout` の spec 上の応答は 204 だが SpringDoc 既定で 200 と記載される (型生成に影響なし。必要なら別途 `@ApiResponse` 注釈)
- 旧 SSR フォーム (`NewVillageForm` 等) の `@Length` は spec 対象外なので変更していない

🤖 Generated with [Claude Code](https://claude.com/claude-code)