### PR TITLE
feat: 村作成フォームに発言制限設定を追加 (step-7.2)

### DIFF
--- a/.issues/README.md
+++ b/.issues/README.md
@@ -24,7 +24,7 @@ monorepo 移行作業中につき **階層番号方式** (`step-<N>(.M)-<slug>.m
 
 | # | タイトル | type | status |
 | --- | --- | --- | --- |
-| (現在 open な Issue なし) | | | |
+| step-7.2 | 発言制限設定 React 化 | feat | open |
 
 > **Step 0・1・2 完了** 🎉 — Step 1 は `.java-version` 21 化 / README 整備 (PR #46)。
 > **Step 2 (monorepo 化) は 4 サブ step すべて完了**: 2.1 backend/ 移動 (PR #47 ✅) / 2.2 ktlint+hook+per-dir .gitignore (PR #48 ✅) / 2.3 frontend 雛形 (PR #49 ✅) / 2.4 e2e 雛形 (PR #50 ✅)。次は **Step 3 (認証 REST 化)**。

--- a/e2e/tests/new-village.spec.ts
+++ b/e2e/tests/new-village.spec.ts
@@ -86,30 +86,30 @@ test("発言制限のチェックで入力の有効/無効が切り替わる", a
   await signupAndGotoNewVillage(page);
 
   // 3 テーブル (役職別 / 発言種別 / RP) が表示される
-  await expect(page.getByLabel("村人 発言文字数")).toBeVisible();
-  await expect(page.getByLabel("人狼の囁き 発言文字数")).toBeVisible();
-  await expect(page.getByLabel("アクション 発言文字数")).toBeVisible();
+  await expect(page.getByLabel("村人 発言文字数", { exact: true })).toBeVisible();
+  await expect(page.getByLabel("人狼の囁き 発言文字数", { exact: true })).toBeVisible();
+  await expect(page.getByLabel("アクション 発言文字数", { exact: true })).toBeVisible();
 
   // 既定はチェックなし + 入力無効 (400 * 20)
-  const lengthInput = page.getByLabel("村人 発言文字数");
-  const countInput = page.getByLabel("村人 発言回数");
+  const lengthInput = page.getByLabel("村人 発言文字数", { exact: true });
+  const countInput = page.getByLabel("村人 発言回数", { exact: true });
   await expect(lengthInput).toBeDisabled();
   await expect(lengthInput).toHaveValue("400");
   await expect(countInput).toHaveValue("20");
 
-  await page.getByLabel("村人 制限").check();
+  await page.getByLabel("村人 制限", { exact: true }).check();
   await expect(lengthInput).toBeEnabled();
   await expect(countInput).toBeEnabled();
 
-  await page.getByLabel("村人 制限").uncheck();
+  await page.getByLabel("村人 制限", { exact: true }).uncheck();
   await expect(lengthInput).toBeDisabled();
 });
 
 test("村人の設定を全てにコピーで役職別テーブルの全行に反映される", async ({ page }) => {
   await signupAndGotoNewVillage(page);
 
-  await page.getByLabel("村人 制限").check();
-  await page.getByLabel("村人 発言文字数").fill("200");
+  await page.getByLabel("村人 制限", { exact: true }).check();
+  await page.getByLabel("村人 発言文字数", { exact: true }).fill("200");
   await page.getByRole("button", { name: "村人の設定を全てにコピー" }).click();
 
   await expect(page.getByLabel("占い師 制限", { exact: true })).toBeChecked();
@@ -117,19 +117,19 @@ test("村人の設定を全てにコピーで役職別テーブルの全行に�
   await expect(page.getByLabel("占い師 発言文字数", { exact: true })).toHaveValue("200");
 
   // 発言種別 / RP のテーブルには波及しない
-  await expect(page.getByLabel("人狼の囁き 制限")).not.toBeChecked();
-  await expect(page.getByLabel("アクション 制限")).not.toBeChecked();
+  await expect(page.getByLabel("人狼の囁き 制限", { exact: true })).not.toBeChecked();
+  await expect(page.getByLabel("アクション 制限", { exact: true })).not.toBeChecked();
 });
 
 test("発言制限の範囲外入力でエラーが表示される", async ({ page }) => {
   await signupAndGotoNewVillage(page);
 
-  await page.getByLabel("村人 制限").check();
-  await page.getByLabel("村人 発言文字数").fill("500");
-  await page.getByLabel("村人 発言文字数").blur();
+  await page.getByLabel("村人 制限", { exact: true }).check();
+  await page.getByLabel("村人 発言文字数", { exact: true }).fill("500");
+  await page.getByLabel("村人 発言文字数", { exact: true }).blur();
   await expect(page.getByText("発言制限は0~400 * 0~100 で設定してください")).toBeVisible();
 
-  await page.getByLabel("村人 発言文字数").fill("400");
+  await page.getByLabel("村人 発言文字数", { exact: true }).fill("400");
   await expect(page.getByText("発言制限は0~400 * 0~100 で設定してください")).not.toBeVisible();
 });
 

--- a/e2e/tests/new-village.spec.ts
+++ b/e2e/tests/new-village.spec.ts
@@ -82,6 +82,57 @@ test("固定と闇鍋の編成切替で表示が切り替わる", async ({ page 
   await expect(page.getByLabel("固定の役職構成")).toBeVisible();
 });
 
+test("発言制限のチェックで入力の有効/無効が切り替わる", async ({ page }) => {
+  await signupAndGotoNewVillage(page);
+
+  // 3 テーブル (役職別 / 発言種別 / RP) が表示される
+  await expect(page.getByLabel("村人 発言文字数")).toBeVisible();
+  await expect(page.getByLabel("人狼の囁き 発言文字数")).toBeVisible();
+  await expect(page.getByLabel("アクション 発言文字数")).toBeVisible();
+
+  // 既定はチェックなし + 入力無効 (400 * 20)
+  const lengthInput = page.getByLabel("村人 発言文字数");
+  const countInput = page.getByLabel("村人 発言回数");
+  await expect(lengthInput).toBeDisabled();
+  await expect(lengthInput).toHaveValue("400");
+  await expect(countInput).toHaveValue("20");
+
+  await page.getByLabel("村人 制限").check();
+  await expect(lengthInput).toBeEnabled();
+  await expect(countInput).toBeEnabled();
+
+  await page.getByLabel("村人 制限").uncheck();
+  await expect(lengthInput).toBeDisabled();
+});
+
+test("村人の設定を全てにコピーで役職別テーブルの全行に反映される", async ({ page }) => {
+  await signupAndGotoNewVillage(page);
+
+  await page.getByLabel("村人 制限").check();
+  await page.getByLabel("村人 発言文字数").fill("200");
+  await page.getByRole("button", { name: "村人の設定を全てにコピー" }).click();
+
+  await expect(page.getByLabel("占い師 制限", { exact: true })).toBeChecked();
+  await expect(page.getByLabel("占い師 発言文字数", { exact: true })).toBeEnabled();
+  await expect(page.getByLabel("占い師 発言文字数", { exact: true })).toHaveValue("200");
+
+  // 発言種別 / RP のテーブルには波及しない
+  await expect(page.getByLabel("人狼の囁き 制限")).not.toBeChecked();
+  await expect(page.getByLabel("アクション 制限")).not.toBeChecked();
+});
+
+test("発言制限の範囲外入力でエラーが表示される", async ({ page }) => {
+  await signupAndGotoNewVillage(page);
+
+  await page.getByLabel("村人 制限").check();
+  await page.getByLabel("村人 発言文字数").fill("500");
+  await page.getByLabel("村人 発言文字数").blur();
+  await expect(page.getByText("発言制限は0~400 * 0~100 で設定してください")).toBeVisible();
+
+  await page.getByLabel("村人 発言文字数").fill("400");
+  await expect(page.getByText("発言制限は0~400 * 0~100 で設定してください")).not.toBeVisible();
+});
+
 test("クライアント検証エラーが表示される", async ({ page }) => {
   await signupAndGotoNewVillage(page);
 

--- a/frontend/app/components/ui/Button.tsx
+++ b/frontend/app/components/ui/Button.tsx
@@ -1,28 +1,37 @@
 import type { AnchorHTMLAttributes, ButtonHTMLAttributes } from "react";
 import { Link, type LinkProps } from "react-router";
 
-type ButtonVariant = "success" | "default" | "danger";
+type ButtonVariant = "success" | "default" | "danger" | "info";
+type ButtonSize = "sm" | "xs";
 
 const variantStyle: Record<ButtonVariant, string> = {
-  success:
-    "rounded-[3px] border-2 border-[#00bc8c] bg-[#00bc8c] px-[9px] py-[6px] text-white hover:opacity-90",
-  default:
-    "rounded-[3px] border-2 border-[#464545] bg-[#464545] px-[9px] py-[6px] text-white hover:opacity-90",
-  danger:
-    "rounded-[3px] border-2 border-[#e74c3c] bg-[#e74c3c] px-[9px] py-[6px] text-white hover:opacity-90",
+  success: "border-[#00bc8c] bg-[#00bc8c]",
+  default: "border-[#464545] bg-[#464545]",
+  danger: "border-[#e74c3c] bg-[#e74c3c]",
+  info: "border-[#3498db] bg-[#3498db]",
 };
 
-/** ボタン。主アクションは success (緑)、破壊的操作は danger (赤)。 */
+const sizeStyle: Record<ButtonSize, string> = {
+  sm: "px-[9px] py-[6px]",
+  xs: "px-[5px] py-[1px]",
+};
+
+function buttonClass(variant: ButtonVariant, size: ButtonSize): string {
+  return `rounded-[3px] border-2 text-[13px] text-white hover:opacity-90 ${variantStyle[variant]} ${sizeStyle[size]}`;
+}
+
+/** ボタン。主アクションは success (緑)、破壊的操作は danger (赤)、補助操作は info (青)。 */
 export function Button({
   variant = "success",
+  size = "sm",
   className = "",
   type = "button",
   ...props
-}: ButtonHTMLAttributes<HTMLButtonElement> & { variant?: ButtonVariant }) {
+}: ButtonHTMLAttributes<HTMLButtonElement> & { variant?: ButtonVariant; size?: ButtonSize }) {
   return (
     <button
       type={type}
-      className={`cursor-pointer text-[13px] ${variantStyle[variant]} disabled:opacity-50 ${className}`}
+      className={`cursor-pointer ${buttonClass(variant, size)} disabled:opacity-50 ${className}`}
       {...props}
     />
   );
@@ -31,12 +40,13 @@ export function Button({
 /** react-router Link をボタン風にする。 */
 export function LinkButton({
   variant = "success",
+  size = "sm",
   className = "",
   ...props
-}: LinkProps & { variant?: ButtonVariant }) {
+}: LinkProps & { variant?: ButtonVariant; size?: ButtonSize }) {
   return (
     <Link
-      className={`inline-block text-[13px] no-underline ${variantStyle[variant]} ${className}`}
+      className={`inline-block no-underline ${buttonClass(variant, size)} ${className}`}
       {...props}
     />
   );
@@ -45,12 +55,13 @@ export function LinkButton({
 /** 外部 <a> をボタン風にする。 */
 export function AnchorButton({
   variant = "success",
+  size = "sm",
   className = "",
   ...props
-}: AnchorHTMLAttributes<HTMLAnchorElement> & { variant?: ButtonVariant }) {
+}: AnchorHTMLAttributes<HTMLAnchorElement> & { variant?: ButtonVariant; size?: ButtonSize }) {
   return (
     <a
-      className={`inline-block text-[13px] no-underline ${variantStyle[variant]} ${className}`}
+      className={`inline-block no-underline ${buttonClass(variant, size)} ${className}`}
       {...props}
     />
   );

--- a/frontend/app/routes/new-village/OtherSections.tsx
+++ b/frontend/app/routes/new-village/OtherSections.tsx
@@ -2,8 +2,28 @@ import { useFormContext } from "react-hook-form";
 
 import { fieldErrorClass, FormRow } from "~/components/ui/Form";
 import { inputClass, selectClass } from "~/components/ui/Input";
+import type { SimpleSkillView } from "~/features/skills/api";
 import { RadioRow, RequiredAfterCreationMark, SettingSection } from "./fields";
+import {
+  CopySayRestrictButton,
+  SayRestrictionTable,
+  type SayRestrictRowLabel,
+} from "./SayRestrictionTable";
 import type { NewVillageFormInput } from "./schema";
+import { RP_SAY_MESSAGE_TYPES, SKILL_SAY_MESSAGE_TYPES } from "./schema";
+
+const sayRestrictNote = (
+  <div className="[&>p]:mb-[10.5px]">
+    <p>1回の文字数は0~400、1日の回数は0~100で設定してください。</p>
+    <p>チェックなしにすると無制限になります。</p>
+  </div>
+);
+
+function toMessageTypeRows(
+  messageTypes: readonly { messageTypeCode: string; messageTypeName: string }[],
+): SayRestrictRowLabel[] {
+  return messageTypes.map((t) => ({ key: t.messageTypeCode, label: t.messageTypeName }));
+}
 
 /** 見学、閲覧設定。 */
 export function SpectateSection() {
@@ -99,10 +119,27 @@ export function RelativesSection() {
   );
 }
 
-/** 特殊ルール向け (発言制限は未実装のため投票のみ)。 */
-export function SpecialRuleSection() {
+/** 特殊ルール向け。 */
+export function SpecialRuleSection({ skills }: { skills: SimpleSkillView[] }) {
   return (
     <SettingSection title="特殊ルール向け">
+      <FormRow label="発言制限（通常発言）" labelWidth="wide">
+        <CopySayRestrictButton />
+        <SayRestrictionTable
+          name="sayRestrictList"
+          targetHeader="役職"
+          rows={skills.map((s) => ({ key: s.code, label: s.name }))}
+        />
+        {sayRestrictNote}
+      </FormRow>
+      <FormRow label="発言制限（役職発言）" labelWidth="wide">
+        <SayRestrictionTable
+          name="skillSayRestrictList"
+          targetHeader="発言種別"
+          rows={toMessageTypeRows(SKILL_SAY_MESSAGE_TYPES)}
+        />
+        {sayRestrictNote}
+      </FormRow>
       <RadioRow
         name="openVote"
         label="投票"
@@ -116,7 +153,7 @@ export function SpecialRuleSection() {
   );
 }
 
-/** RP村向け (発言制限 (RP発言) は未実装のため年齢制限とアクションのみ)。 */
+/** RP村向け。 */
 export function RpSection() {
   return (
     <SettingSection title="RP村向け">
@@ -142,6 +179,14 @@ export function RpSection() {
           { value: false, label: "不可" },
         ]}
       />
+      <FormRow label="発言制限（RP発言）" labelWidth="wide">
+        <SayRestrictionTable
+          name="rpSayRestrictList"
+          targetHeader="発言種別"
+          rows={toMessageTypeRows(RP_SAY_MESSAGE_TYPES)}
+        />
+        {sayRestrictNote}
+      </FormRow>
     </SettingSection>
   );
 }

--- a/frontend/app/routes/new-village/SayRestrictionTable.tsx
+++ b/frontend/app/routes/new-village/SayRestrictionTable.tsx
@@ -1,0 +1,124 @@
+import { useFormContext, useWatch } from "react-hook-form";
+
+import { Button } from "~/components/ui/Button";
+import { fieldErrorClass } from "~/components/ui/Form";
+import type { NewVillageFormInput } from "./schema";
+
+type SayRestrictListName = "sayRestrictList" | "skillSayRestrictList" | "rpSayRestrictList";
+
+export type SayRestrictRowLabel = { key: string; label: string };
+
+const tableClass =
+  "border-collapse text-[10.32px] " +
+  "[&_th]:border [&_th]:border-[#464545] [&_th]:p-[5px] [&_th]:text-left [&_th]:align-middle " +
+  "[&_td]:border [&_td]:border-[#464545] [&_td]:p-[5px] [&_td]:align-middle";
+
+const numberInputClass =
+  "h-[30px] w-[135px] bg-white px-[10px] py-[5px] text-[#464545] disabled:bg-[#aaaaaa]";
+
+function toNullableNumber(value: unknown): number | null {
+  return value === "" || value == null ? null : Number(value);
+}
+
+/**
+ * 発言制限テーブル (制限チェック + 1回あたりの文字数 * 1日あたりの回数)。
+ * 行ラベルは静的 prop、値はフォーム state で持つ。チェックなしの行は無制限扱いのため
+ * 入力を無効化する。
+ */
+export function SayRestrictionTable({
+  name,
+  targetHeader,
+  rows,
+}: {
+  name: SayRestrictListName;
+  targetHeader: string;
+  rows: SayRestrictRowLabel[];
+}) {
+  return (
+    <table className={tableClass}>
+      <thead>
+        <tr>
+          <th>{targetHeader}</th>
+          <th>制限</th>
+          <th>1回あたりの発言文字数 * 1日あたりの発言回数</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, index) => (
+          <SayRestrictRow key={row.key} name={name} index={index} label={row.label} />
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function SayRestrictRow({
+  name,
+  index,
+  label,
+}: {
+  name: SayRestrictListName;
+  index: number;
+  label: string;
+}) {
+  const { register, getFieldState, formState } = useFormContext<NewVillageFormInput>();
+  const restrict = useWatch<NewVillageFormInput>({ name: `${name}.${index}.restrict` }) as boolean;
+  const lengthError = getFieldState(`${name}.${index}.length`, formState).error;
+  const countError = getFieldState(`${name}.${index}.count`, formState).error;
+  const error = lengthError ?? countError;
+  return (
+    <tr>
+      <td>{label}</td>
+      <td>
+        <input
+          type="checkbox"
+          className="block h-[20px] w-[20px]"
+          aria-label={`${label} 制限`}
+          {...register(`${name}.${index}.restrict`)}
+        />
+      </td>
+      <td>
+        <div className="flex items-stretch">
+          <input
+            type="number"
+            className={`${numberInputClass} rounded-l-[4px]`}
+            placeholder="400"
+            disabled={!restrict}
+            aria-label={`${label} 発言文字数`}
+            {...register(`${name}.${index}.length`, { setValueAs: toNullableNumber })}
+          />
+          <span className="flex items-center bg-[#464545] p-[5px] text-[12px]">{" * "}</span>
+          <input
+            type="number"
+            className={`${numberInputClass} rounded-r-[4px]`}
+            placeholder="20"
+            disabled={!restrict}
+            aria-label={`${label} 発言回数`}
+            {...register(`${name}.${index}.count`, { setValueAs: toNullableNumber })}
+          />
+        </div>
+        {error && <p className={fieldErrorClass}>{error.message}</p>}
+      </td>
+    </tr>
+  );
+}
+
+/** 役職別の発言制限テーブルの先頭行 (村人) の設定を全行へ反映するボタン。 */
+export function CopySayRestrictButton() {
+  const { getValues, setValue } = useFormContext<NewVillageFormInput>();
+  const copyFirstRowToAll = () => {
+    const list = getValues("sayRestrictList");
+    const first = list[0];
+    if (!first) return;
+    list.forEach((_, index) => {
+      setValue(`sayRestrictList.${index}.restrict`, first.restrict);
+      setValue(`sayRestrictList.${index}.length`, first.length);
+      setValue(`sayRestrictList.${index}.count`, first.count);
+    });
+  };
+  return (
+    <Button variant="info" size="xs" onClick={copyFirstRowToAll}>
+      村人の設定を全てにコピー
+    </Button>
+  );
+}

--- a/frontend/app/routes/new-village/SayRestrictionTable.tsx
+++ b/frontend/app/routes/new-village/SayRestrictionTable.tsx
@@ -105,16 +105,18 @@ function SayRestrictRow({
 
 /** 役職別の発言制限テーブルの先頭行 (村人) の設定を全行へ反映するボタン。 */
 export function CopySayRestrictButton() {
-  const { getValues, setValue } = useFormContext<NewVillageFormInput>();
+  const { getValues, setValue, trigger } = useFormContext<NewVillageFormInput>();
   const copyFirstRowToAll = () => {
     const list = getValues("sayRestrictList");
     const first = list[0];
     if (!first) return;
     list.forEach((_, index) => {
-      setValue(`sayRestrictList.${index}.restrict`, first.restrict);
-      setValue(`sayRestrictList.${index}.length`, first.length);
-      setValue(`sayRestrictList.${index}.count`, first.count);
+      setValue(`sayRestrictList.${index}.restrict`, first.restrict, { shouldDirty: true });
+      setValue(`sayRestrictList.${index}.length`, first.length, { shouldDirty: true });
+      setValue(`sayRestrictList.${index}.count`, first.count, { shouldDirty: true });
     });
+    // コピー元が範囲外の値でもコピー先にエラーが出るよう、まとめて再検証する
+    void trigger("sayRestrictList");
   };
   return (
     <Button variant="info" size="xs" onClick={copyFirstRowToAll}>

--- a/frontend/app/routes/new-village/route.tsx
+++ b/frontend/app/routes/new-village/route.tsx
@@ -72,7 +72,7 @@ function NewVillageForm({ skills }: { skills: SimpleSkillView[] }) {
             <DetailRuleSection skills={skills} defaultCamps={defaultCamps} />
             <SpectateSection />
             <RelativesSection />
-            <SpecialRuleSection />
+            <SpecialRuleSection skills={skills} />
             <RpSection />
             <Divider />
             <FormActions>

--- a/frontend/app/routes/new-village/schema.ts
+++ b/frontend/app/routes/new-village/schema.ts
@@ -33,6 +33,11 @@ const START_DATETIME_MESSAGE = "開始日時は現在から14日以内の存在�
 const JOIN_PASSWORD_MESSAGE = `入村パスワードは${JOIN_PASSWORD_MIN_LENGTH}文字以上${JOIN_PASSWORD_MAX_LENGTH}文字以内にしてください`;
 const ALLOCATION_MESSAGE = "0~100で入力してください";
 const WOLF_ALLOCATION_MESSAGE = "1~100で入力してください";
+const SAY_RESTRICT_MESSAGE = "発言制限は0~400 * 0~100 で設定してください";
+
+/** 発言制限の上限 (1回あたりの文字数 / 1日あたりの回数)。 */
+export const SAY_RESTRICT_LENGTH_MAX = 400;
+export const SAY_RESTRICT_COUNT_MAX = 100;
 
 const allocationNum = z
   .number(ALLOCATION_MESSAGE)
@@ -54,6 +59,50 @@ const skillAllocationSchema = z.object({
   allocation: allocationNum,
   reincarnationAllocation: allocationNum,
 });
+
+/** 制限ありの行のみ length/count を検証する (制限なしの行は無制限扱いで値は送らない)。 */
+function refineSayRestrict(
+  values: { restrict: boolean; length: number | null; count: number | null },
+  ctx: z.RefinementCtx,
+) {
+  if (!values.restrict) return;
+  if (
+    values.length == null ||
+    !Number.isInteger(values.length) ||
+    values.length < 0 ||
+    values.length > SAY_RESTRICT_LENGTH_MAX
+  ) {
+    ctx.addIssue({ code: "custom", path: ["length"], message: SAY_RESTRICT_MESSAGE });
+  }
+  if (
+    values.count == null ||
+    !Number.isInteger(values.count) ||
+    values.count < 0 ||
+    values.count > SAY_RESTRICT_COUNT_MAX
+  ) {
+    ctx.addIssue({ code: "custom", path: ["count"], message: SAY_RESTRICT_MESSAGE });
+  }
+}
+
+const skillSayRestrictSchema = z
+  .object({
+    skillCode: z.string(),
+    skillName: z.string(),
+    restrict: z.boolean(),
+    length: z.number().nullable(),
+    count: z.number().nullable(),
+  })
+  .superRefine(refineSayRestrict);
+
+const messageTypeSayRestrictSchema = z
+  .object({
+    messageTypeCode: z.string(),
+    messageTypeName: z.string(),
+    restrict: z.boolean(),
+    length: z.number().nullable(),
+    count: z.number().nullable(),
+  })
+  .superRefine(refineSayRestrict);
 
 const campAllocationSchema = z.object({
   campCode: z.string(),
@@ -108,6 +157,9 @@ export const newVillageSchema = z
       minNum: wolfAllocationNum,
       maxNum: wolfAllocationNum.nullable(),
     }),
+    sayRestrictList: z.array(skillSayRestrictSchema),
+    skillSayRestrictList: z.array(messageTypeSayRestrictSchema),
+    rpSayRestrictList: z.array(messageTypeSayRestrictSchema),
     allowedSecretSayCode: z.enum(["NOTHING", "ONLY_CREATOR", "EVERYTHING"]),
     joinPassword: z
       .string()
@@ -160,6 +212,40 @@ export const newVillageSchema = z
 
 export type NewVillageFormInput = z.infer<typeof newVillageSchema>;
 export type CampAllocationInput = NewVillageFormInput["campAllocationList"][number];
+
+/** 発言制限の対象 (発言種別)。正本は backend `NewVillageForm.initialize` の対象種別。 */
+export const SKILL_SAY_MESSAGE_TYPES = [
+  { messageTypeCode: "WEREWOLF_SAY", messageTypeName: "人狼の囁き" },
+  { messageTypeCode: "MASON_SAY", messageTypeName: "共鳴発言" },
+  { messageTypeCode: "LOVERS_SAY", messageTypeName: "恋人発言" },
+  { messageTypeCode: "TELEPATHY", messageTypeName: "念話" },
+] as const;
+
+export const RP_SAY_MESSAGE_TYPES = [
+  { messageTypeCode: "ACTION", messageTypeName: "アクション" },
+] as const;
+
+type MessageTypeRef = { messageTypeCode: string; messageTypeName: string };
+
+/** 役職別 (通常発言) の発言制限の初期行。行順は役職一覧 API の並びに合わせる。 */
+export function createDefaultSayRestricts(
+  skills: SimpleSkillView[],
+): NewVillageFormInput["sayRestrictList"] {
+  return skills.map((s) => ({
+    skillCode: s.code,
+    skillName: s.name,
+    restrict: false,
+    length: 400,
+    count: 20,
+  }));
+}
+
+/** 発言種別 (役職発言 / RP発言) の発言制限の初期行。 */
+export function createDefaultMessageTypeSayRestricts(
+  messageTypes: readonly MessageTypeRef[],
+): NewVillageFormInput["skillSayRestrictList"] {
+  return messageTypes.map((t) => ({ ...t, restrict: false, length: 400, count: 20 }));
+}
 
 /** 闇鍋配分テーブルの陣営の並び順 (正本は backend `NewVillageForm` の陣営順)。 */
 const CAMP_CODE_ORDER = ["VILLAGER", "WEREWOLF", "FOX", "LOVERS", "CRIMINAL"];
@@ -222,6 +308,9 @@ export function createDefaultValues(skills: SimpleSkillView[], now: Date): NewVi
     organization: addPersonCountPrefix(DEFAULT_FIXED_ORGANIZATION),
     campAllocationList: createDefaultCampAllocations(skills),
     wolfAllocation: { minNum: 1, maxNum: null },
+    sayRestrictList: createDefaultSayRestricts(skills),
+    skillSayRestrictList: createDefaultMessageTypeSayRestricts(SKILL_SAY_MESSAGE_TYPES),
+    rpSayRestrictList: createDefaultMessageTypeSayRestricts(RP_SAY_MESSAGE_TYPES),
     allowedSecretSayCode: "NOTHING",
     joinPassword: "",
     ageLimit: "",

--- a/frontend/app/routes/new-village/schema.ts
+++ b/frontend/app/routes/new-village/schema.ts
@@ -60,7 +60,7 @@ const skillAllocationSchema = z.object({
   reincarnationAllocation: allocationNum,
 });
 
-/** 制限ありの行のみ length/count を検証する (制限なしの行は無制限扱いで値は送らない)。 */
+/** 制限ありの行のみ length/count を検証する (制限なしの行は無制限扱いで値を使わない)。 */
 function refineSayRestrict(
   values: { restrict: boolean; length: number | null; count: number | null },
   ctx: z.RefinementCtx,


### PR DESCRIPTION
closes .issues/step-7.2-say-restriction.md

## 概要

村作成フォーム (`/new-village`) に発言制限の 3 セクションを追加する (step-7.2)。

- **役職別 (通常発言)** `sayRestrictList`: 全役職分 (役職一覧 API の並び・123 行)。「村人の設定を全てにコピー」ボタン付き (先頭行の 制限/文字数/回数 を役職別テーブル全行へ反映。他テーブルへは波及しない)
- **発言種別 (役職発言)** `skillSayRestrictList`: 人狼の囁き / 共鳴発言 / 恋人発言 / 念話
- **RP (RP発言)** `rpSayRestrictList`: アクション

## 実装

- 各行: 制限チェックボックス + 1回あたりの発言文字数 (placeholder 400) * 1日あたりの発言回数 (placeholder 20)。チェックなしの行は無制限扱いで入力を disabled (背景 #aaaaaa) にする
- zod: 制限ありの行のみ length 0〜400 / count 0〜100 を検証 (エラー文言はサーバーの `NewVillageForm.validator.sayRestrictList` と同一)。正本はサーバー検証
- 既定値は backend `NewVillageForm.initialize()` (`SkillSayRestrictForm` / `MessageTypeSayRestrictForm`) と同一 (restrict=false / 400 * 20)
- `components/ui/Button` に **info variant + xs サイズ** を追加 (variant=色 / size=padding に分離。既存 LinkButton / AnchorButton も同構成に)
- backend 変更なし (役職リストは既存 `GET /api/v1/skills` を流用)
- 「確認画面へ」ボタンは引き続き disabled (7.4 で作成 API 接続時に有効化)

## 動作確認

- `:8091` 実測突合: 行数 (123/4/1)・行ラベル・表示順 (通常発言 → 役職発言 → 投票 / 年齢制限 → アクション → RP発言)・テーブル外観 (10.32px / th 左寄せ太字 / セル padding 5px / 枠 #464545)・入力 (135px 幅 / 白地 / disabled #aaaaaa / アドオン `*` #464545 地)・コピーボタン (#3498db / padding 1px 5px / 13px) すべて一致
- チェック切替・コピー・範囲外エラー表示を実機確認
- frontend: typecheck / lint / format:check / build green
- e2e: 3 件追加、全 **41 件 green**

🤖 Generated with [Claude Code](https://claude.com/claude-code)