### PR TITLE
feat: 設定流用 (divert) を REST + React 化 (step-7.5)

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/village/VillageRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/VillageRestController.kt
@@ -5,6 +5,7 @@ import com.ort.app.api.village.request.VillageCreateRequest
 import com.ort.app.api.village.request.VillageSearchRequest
 import com.ort.app.api.village.response.VillageCreateResponse
 import com.ort.app.api.village.response.VillageListResponse
+import com.ort.app.api.village.response.VillageSettingView
 import com.ort.app.application.coordinator.VillageCoordinator
 import com.ort.app.application.service.CharaService
 import com.ort.app.application.service.PlayerService
@@ -15,16 +16,19 @@ import com.ort.app.fw.exception.WolfMansionValidationException.FieldErrorItem
 import com.ort.app.fw.security.jwt.JwtPrincipal
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.context.MessageSource
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.validation.BeanPropertyBindingResult
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
+import org.springframework.web.server.ResponseStatusException
 import java.util.Locale
 
 /**
@@ -46,6 +50,14 @@ class VillageRestController(
     fun list(
         @ParameterObject request: VillageSearchRequest,
     ): VillageListResponse = VillageListResponse(villageService.findVillages(request.toQuery()))
+
+    /** 村設定。村画面で公開されている情報のため認証不要 (入村パスワードのみマスク)。 */
+    @GetMapping("/{id}/setting")
+    fun setting(
+        @PathVariable id: Int,
+    ): VillageSettingView =
+        villageService.findVillage(id)?.let { VillageSettingView(it.setting) }
+            ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "village not found")
 
     /**
      * 村作成。multipart/form-data で JSON part (`request`) + オリジナルダミーキャラ画像

--- a/backend/src/main/kotlin/com/ort/app/api/village/request/VillageCreateRequest.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/request/VillageCreateRequest.kt
@@ -8,6 +8,7 @@ import com.ort.app.api.request.setting.RandomOrganizationWolfForm
 import com.ort.app.api.request.setting.SkillSayRestrictForm
 import com.ort.app.fw.exception.WolfMansionValidationException.FieldErrorItem
 import com.ort.dbflute.allcommon.CDef
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
@@ -131,6 +132,9 @@ data class VillageCreateRequest(
     @field:Pattern(regexp = "R15|R18")
     val ageLimit: String? = null,
 ) {
+    // ドメインの VillageRandomOrganize.CampAllocation 等と単純名が衝突すると
+    // SpringDoc が片方のスキーマ定義で上書きしてしまうため、spec 上の名前を明示する
+    @Schema(name = "VillageCreateRequestCampAllocation")
     data class CampAllocation(
         @field:NotNull
         val campCode: String? = null,
@@ -154,6 +158,7 @@ data class VillageCreateRequest(
         val skillAllocation: List<SkillAllocation>? = null,
     )
 
+    @Schema(name = "VillageCreateRequestSkillAllocation")
     data class SkillAllocation(
         @field:NotNull
         val skillCode: String? = null,
@@ -174,6 +179,7 @@ data class VillageCreateRequest(
         val reincarnationAllocation: Int? = null,
     )
 
+    @Schema(name = "VillageCreateRequestWolfAllocation")
     data class WolfAllocation(
         @field:NotNull
         @field:Min(1)

--- a/backend/src/main/kotlin/com/ort/app/api/village/response/VillageSettingView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/response/VillageSettingView.kt
@@ -1,0 +1,38 @@
+package com.ort.app.api.village.response
+
+import com.ort.app.domain.model.village.VillageSetting
+import com.ort.app.domain.model.village.setting.SayRestriction
+import com.ort.app.domain.model.village.setting.VillageCharaSetting
+import com.ort.app.domain.model.village.setting.VillageOrganize
+import com.ort.app.domain.model.village.setting.VillageRule
+import com.ort.app.domain.model.village.setting.VillageTags
+import java.time.LocalDateTime
+
+/**
+ * 村設定。ドメインの [VillageSetting] から非公開の入村パスワードのみ除外して返す
+ * (REST API 設計方針: マスクが要る場合のみ Response DTO)。ネストした設定は
+ * ドメインモデルをそのまま返す。
+ */
+data class VillageSettingView(
+    val chara: VillageCharaSetting,
+    val personMin: Int,
+    val personMax: Int,
+    val startDatetime: LocalDateTime,
+    val dayChangeIntervalSeconds: Int,
+    val rule: VillageRule,
+    val organize: VillageOrganize,
+    val sayRestriction: SayRestriction,
+    val tags: VillageTags,
+) {
+    constructor(setting: VillageSetting) : this(
+        chara = setting.chara,
+        personMin = setting.personMin,
+        personMax = setting.personMax,
+        startDatetime = setting.startDatetime,
+        dayChangeIntervalSeconds = setting.dayChangeIntervalSeconds,
+        rule = setting.rule,
+        organize = setting.organize,
+        sayRestriction = setting.sayRestriction,
+        tags = setting.tags,
+    )
+}

--- a/backend/src/main/kotlin/com/ort/app/fw/config/WolfMansionOpenApiConfig.kt
+++ b/backend/src/main/kotlin/com/ort/app/fw/config/WolfMansionOpenApiConfig.kt
@@ -1,0 +1,28 @@
+package com.ort.app.fw.config
+
+import org.springdoc.core.customizers.OpenApiCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class WolfMansionOpenApiConfig {
+    /**
+     * `Skill.histories` (とその先の SkillHistories/SkillHistory) を spec から除外する。
+     * Skill ⇄ SkillHistories ⇄ SkillHistory の自己参照サイクルを SpringDoc が `$ref` で
+     * 表現できず、内容が解決順に依存する退化ノードを出力してしまい、spec の再生成差分
+     * (api-drift) を不安定にするため。histories はゲーム内部の役職変化履歴で、
+     * REST レスポンスでは常に空であり frontend からは参照しない。
+     * シリアライズ自体には手を入れない (実レスポンスには引き続き含まれる)。
+     */
+    @Bean
+    fun skillHistoriesSchemaCustomizer(): OpenApiCustomizer =
+        OpenApiCustomizer { openApi ->
+            val schemas = openApi.components?.schemas ?: return@OpenApiCustomizer
+            schemas["Skill"]?.let { skill ->
+                skill.properties?.remove("histories")
+                skill.required = skill.required?.filterNot { it == "histories" }
+            }
+            schemas.remove("SkillHistories")
+            schemas.remove("SkillHistory")
+        }
+}

--- a/backend/src/main/kotlin/com/ort/app/fw/config/WolfMansionOpenApiConfig.kt
+++ b/backend/src/main/kotlin/com/ort/app/fw/config/WolfMansionOpenApiConfig.kt
@@ -10,8 +10,8 @@ class WolfMansionOpenApiConfig {
      * `Skill.histories` (とその先の SkillHistories/SkillHistory) を spec から除外する。
      * Skill ⇄ SkillHistories ⇄ SkillHistory の自己参照サイクルを SpringDoc が `$ref` で
      * 表現できず、内容が解決順に依存する退化ノードを出力してしまい、spec の再生成差分
-     * (api-drift) を不安定にするため。histories はゲーム内部の役職変化履歴で、
-     * REST レスポンスでは常に空であり frontend からは参照しない。
+     * (api-drift) を不安定にするため。histories はゲーム内部の役職変化履歴で
+     * frontend からは参照しないため、spec から落としても支障がない。
      * シリアライズ自体には手を入れない (実レスポンスには引き続き含まれる)。
      */
     @Bean

--- a/backend/src/main/kotlin/com/ort/app/fw/security/WolfMansionWebSecurityConfig.kt
+++ b/backend/src/main/kotlin/com/ort/app/fw/security/WolfMansionWebSecurityConfig.kt
@@ -47,6 +47,7 @@ class WolfMansionWebSecurityConfig {
                     .requestMatchers(
                         org.springframework.http.HttpMethod.GET,
                         "/api/v1/villages",
+                        "/api/v1/villages/{id}/setting",
                         "/api/v1/charachips",
                         "/api/v1/charachips/{id}",
                         "/api/v1/rooms",

--- a/backend/src/main/resources/config/application.yml
+++ b/backend/src/main/resources/config/application.yml
@@ -72,3 +72,6 @@ login-rate-limit:
 springdoc:
   # 新 REST 面 (/api/v1/**) のみを spec に含める。旧 SSR Controller / 公開 API (/api/login 等) は対象外
   paths-to-match: /api/v1/**
+  # spec のキーをアルファベット順で出力する。Kotlin の isXxx() 由来プロパティはリフレクションの
+  # 列挙順 (JVM 実行ごとに不定) で並ぶため、ソートしないと再生成のたびに差分が出て drift 検知が壊れる
+  writer-with-order-by-keys: true

--- a/backend/src/test/kotlin/com/ort/app/api/village/response/VillageSettingViewTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/api/village/response/VillageSettingViewTest.kt
@@ -1,0 +1,42 @@
+package com.ort.app.api.village.response
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.ort.app.domain.model.village.createVillageSetting
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+
+internal class VillageSettingViewTest {
+    @Test
+    fun `ドメインの設定値をそのまま写す`() {
+        val setting = createVillageSetting()
+
+        val view = VillageSettingView(setting)
+
+        assertEquals(setting.chara, view.chara)
+        assertEquals(setting.personMin, view.personMin)
+        assertEquals(setting.personMax, view.personMax)
+        assertEquals(setting.startDatetime, view.startDatetime)
+        assertEquals(setting.dayChangeIntervalSeconds, view.dayChangeIntervalSeconds)
+        assertEquals(setting.rule, view.rule)
+        assertEquals(setting.organize, view.organize)
+        assertEquals(setting.sayRestriction, view.sayRestriction)
+        assertEquals(setting.tags, view.tags)
+    }
+
+    @Test
+    fun `入村パスワードをシリアライズ結果に含まない`() {
+        val setting = createVillageSetting().copy(joinPassword = "secret-password")
+
+        val json =
+            ObjectMapper()
+                .registerKotlinModule()
+                .registerModule(JavaTimeModule())
+                .writeValueAsString(VillageSettingView(setting))
+
+        assertFalse(json.contains("joinPassword"))
+        assertFalse(json.contains("secret-password"))
+    }
+}

--- a/e2e/tests/new-village.spec.ts
+++ b/e2e/tests/new-village.spec.ts
@@ -196,6 +196,42 @@ test("クライアント検証エラーが表示される", async ({ page }) => 
   await expect(page.getByText("入村パスワードは3文字以上12文字以内にしてください")).toBeVisible();
 });
 
+test("設定流用セクションが表示され、流用で選択した村の設定がフォームへ流し込まれる", async ({ page }) => {
+  await signupAndGotoNewVillage(page);
+
+  await expect(page.getByRole("heading", { name: "設定流用" })).toBeVisible();
+  const select = page.getByLabel("他の村から流用する");
+  await expect(select).toBeVisible();
+  await expect(page.getByRole("button", { name: "流用する" })).toBeVisible();
+
+  // 流用候補 (エピローグ/終了/廃村の村) は API から非同期に入る。候補が無い DB ではスキップ
+  await page.waitForLoadState("networkidle");
+  const optionCount = await select.locator("option").count();
+  test.skip(optionCount === 0, "流用候補 (終了村) が無い DB のためスキップ");
+
+  const villageId = await select.inputValue();
+  const res = await page.request.get(`/wolf-mansion-api/api/v1/villages/${villageId}/setting`);
+  expect(res.ok()).toBe(true);
+  const setting = await res.json();
+
+  // 編集状態は保持されない (村名は流用対象外のため既定値 = 空に戻る)
+  await page.fill("#villageName", "流用前の編集");
+  await page.getByRole("button", { name: "流用する" }).click();
+
+  await expect(page.locator("#villageName")).toHaveValue("");
+  await expect(page.locator("#startPersonMinNum")).toHaveValue(String(setting.personMin));
+  await expect(page.locator("#personMaxNum")).toHaveValue(String(setting.personMax));
+  await expect(page.getByLabel("更新間隔 (時間)")).toHaveValue(
+    String(Math.floor(setting.dayChangeIntervalSeconds / 3600)),
+  );
+
+  // 編成 (固定/闇鍋) も流用元に合わせて切り替わる
+  const orgRadioGroup = page.getByRole("radiogroup", { name: "役職構成" });
+  await expect(
+    orgRadioGroup.getByRole("radio", { name: setting.rule.isRandomOrganization ? "闇鍋" : "固定" }),
+  ).toHaveAttribute("aria-checked", "true");
+});
+
 test("確認画面へ→確認モーダル→作成で村作成 API を叩く", async ({ page }) => {
   await signupAndGotoNewVillage(page);
 

--- a/e2e/tests/new-village.spec.ts
+++ b/e2e/tests/new-village.spec.ts
@@ -205,11 +205,16 @@ test("設定流用セクションが表示され、流用で選択した村の�
   await expect(page.getByRole("button", { name: "流用する" })).toBeVisible();
 
   // 流用候補 (エピローグ/終了/廃村の村) は API から非同期に入る。候補が無い DB ではスキップ
-  await page.waitForLoadState("networkidle");
-  const optionCount = await select.locator("option").count();
-  test.skip(optionCount === 0, "流用候補 (終了村) が無い DB のためスキップ");
+  const listRes = await page.request.get(
+    "/wolf-mansion-api/api/v1/villages?status=EPILOGUE&status=COMPLETED&status=CANCEL&order=asc",
+  );
+  expect(listRes.ok()).toBe(true);
+  const candidates = (await listRes.json()).villages as { id: number }[];
+  test.skip(candidates.length === 0, "流用候補 (終了村) が無い DB のためスキップ");
 
-  const villageId = await select.inputValue();
+  // 先頭候補が select に入るまで待つ (既定で選択される)
+  await expect(select).toHaveValue(String(candidates[0].id));
+  const villageId = candidates[0].id;
   const res = await page.request.get(`/wolf-mansion-api/api/v1/villages/${villageId}/setting`);
   expect(res.ok()).toBe(true);
   const setting = await res.json();

--- a/frontend/app/api/openapi.json
+++ b/frontend/app/api/openapi.json
@@ -1260,9 +1260,6 @@
           "code": {
             "type": "string"
           },
-          "histories": {
-            "$ref": "#/components/schemas/SkillHistories"
-          },
           "isCounterDeadByDivine": {
             "type": "boolean"
           },
@@ -1365,7 +1362,6 @@
         },
         "required": [
           "code",
-          "histories",
           "isCounterDeadByDivine",
           "isCounterDeadByInvestigate",
           "isDeadByDivine",
@@ -1425,31 +1421,6 @@
           }
         },
         "required": ["initAllocation", "min", "reincarnationAllocation", "skill"]
-      },
-      "SkillHistories": {
-        "type": "object",
-        "properties": {
-          "list": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/SkillHistory"
-            }
-          }
-        },
-        "required": ["list"]
-      },
-      "SkillHistory": {
-        "type": "object",
-        "properties": {
-          "day": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "skill": {
-            "required": ["code"]
-          }
-        },
-        "required": ["day", "skill"]
       },
       "SkillListResponse": {
         "type": "object",

--- a/frontend/app/api/openapi.json
+++ b/frontend/app/api/openapi.json
@@ -386,6 +386,35 @@
         }
       }
     },
+    "/api/v1/villages/{id}/setting": {
+      "get": {
+        "tags": ["village-rest-controller"],
+        "operationId": "setting",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/VillageSettingView"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/skills": {
       "get": {
         "tags": ["skill-rest-controller"],
@@ -610,51 +639,6 @@
         },
         "required": ["contents", "id", "keyword"]
       },
-      "CampAllocation": {
-        "type": "object",
-        "properties": {
-          "campCode": {
-            "type": ["string", "null"]
-          },
-          "minNum": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 100,
-            "minimum": 0
-          },
-          "maxNum": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 100,
-            "minimum": 0
-          },
-          "allocation": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 100,
-            "minimum": 0
-          },
-          "reincarnationAllocation": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 100,
-            "minimum": 0
-          },
-          "skillAllocation": {
-            "type": ["array", "null"],
-            "items": {
-              "$ref": "#/components/schemas/SkillAllocation"
-            }
-          }
-        },
-        "required": [
-          "allocation",
-          "campCode",
-          "minNum",
-          "reincarnationAllocation",
-          "skillAllocation"
-        ]
-      },
       "MessageTypeSayRestrict": {
         "type": "object",
         "properties": {
@@ -674,39 +658,6 @@
           }
         },
         "required": ["messageTypeCode", "restrict"]
-      },
-      "SkillAllocation": {
-        "type": "object",
-        "properties": {
-          "skillCode": {
-            "type": ["string", "null"]
-          },
-          "minNum": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 100,
-            "minimum": 0
-          },
-          "maxNum": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 100,
-            "minimum": 0
-          },
-          "allocation": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 100,
-            "minimum": 0
-          },
-          "reincarnationAllocation": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 100,
-            "minimum": 0
-          }
-        },
-        "required": ["allocation", "minNum", "reincarnationAllocation", "skillCode"]
       },
       "SkillSayRestrict": {
         "type": "object",
@@ -879,13 +830,13 @@
           "campAllocationList": {
             "type": ["array", "null"],
             "items": {
-              "$ref": "#/components/schemas/CampAllocation"
+              "$ref": "#/components/schemas/VillageCreateRequestCampAllocation"
             }
           },
           "wolfAllocation": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/WolfAllocation"
+                "$ref": "#/components/schemas/VillageCreateRequestWolfAllocation"
               },
               {
                 "type": "null"
@@ -955,7 +906,85 @@
           "visibleGraveSpectateMessage"
         ]
       },
-      "WolfAllocation": {
+      "VillageCreateRequestCampAllocation": {
+        "type": "object",
+        "properties": {
+          "campCode": {
+            "type": ["string", "null"]
+          },
+          "minNum": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 100,
+            "minimum": 0
+          },
+          "maxNum": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 100,
+            "minimum": 0
+          },
+          "allocation": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 100,
+            "minimum": 0
+          },
+          "reincarnationAllocation": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 100,
+            "minimum": 0
+          },
+          "skillAllocation": {
+            "type": ["array", "null"],
+            "items": {
+              "$ref": "#/components/schemas/VillageCreateRequestSkillAllocation"
+            }
+          }
+        },
+        "required": [
+          "allocation",
+          "campCode",
+          "minNum",
+          "reincarnationAllocation",
+          "skillAllocation"
+        ]
+      },
+      "VillageCreateRequestSkillAllocation": {
+        "type": "object",
+        "properties": {
+          "skillCode": {
+            "type": ["string", "null"]
+          },
+          "minNum": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 100,
+            "minimum": 0
+          },
+          "maxNum": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 100,
+            "minimum": 0
+          },
+          "allocation": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 100,
+            "minimum": 0
+          },
+          "reincarnationAllocation": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 100,
+            "minimum": 0
+          }
+        },
+        "required": ["allocation", "minNum", "reincarnationAllocation", "skillCode"]
+      },
+      "VillageCreateRequestWolfAllocation": {
         "type": "object",
         "properties": {
           "minNum": {
@@ -1191,6 +1220,557 @@
           }
         },
         "required": ["code", "name"]
+      },
+      "AbilityType": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "setMessageType": {
+            "$ref": "#/components/schemas/MessageType"
+          }
+        },
+        "required": ["code", "name", "setMessageType"]
+      },
+      "Camp": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "isFoxs": {
+            "type": "boolean"
+          },
+          "isLovers": {
+            "type": "boolean"
+          },
+          "isVillagers": {
+            "type": "boolean"
+          },
+          "isWolfs": {
+            "type": "boolean"
+          },
+          "isCriminals": {
+            "type": "boolean"
+          }
+        },
+        "required": ["code", "isCriminals", "isFoxs", "isLovers", "isVillagers", "isWolfs", "name"]
+      },
+      "CampAllocation": {
+        "type": "object",
+        "properties": {
+          "camp": {
+            "$ref": "#/components/schemas/Camp"
+          },
+          "min": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "max": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          },
+          "initAllocation": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "reincarnationAllocation": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": ["camp", "initAllocation", "min", "reincarnationAllocation"]
+      },
+      "MessageType": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "isOwlViewableType": {
+            "type": "boolean"
+          },
+          "isSayType": {
+            "type": "boolean"
+          }
+        },
+        "required": ["code", "isOwlViewableType", "isSayType", "name"]
+      },
+      "NormalSayRestriction": {
+        "type": "object",
+        "properties": {
+          "skill": {
+            "$ref": "#/components/schemas/Skill"
+          },
+          "messageType": {
+            "$ref": "#/components/schemas/MessageType"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "length": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": ["count", "length", "messageType", "skill"]
+      },
+      "SayRestriction": {
+        "type": "object",
+        "properties": {
+          "normalSayRestriction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NormalSayRestriction"
+            }
+          },
+          "skillSayRestriction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SkillSayRestriction"
+            }
+          }
+        },
+        "required": ["normalSayRestriction", "skillSayRestriction"]
+      },
+      "SecretSayRange": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["code", "name"]
+      },
+      "Skill": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "shortName": {
+            "type": "string"
+          },
+          "histories": {
+            "$ref": "#/components/schemas/SkillHistories"
+          },
+          "isRequestable": {
+            "type": "boolean"
+          },
+          "isWolfCount": {
+            "type": "boolean"
+          },
+          "ability": {
+            "$ref": "#/components/schemas/AbilityType"
+          },
+          "isNoSound": {
+            "type": "boolean"
+          },
+          "isNoDeadByAttack": {
+            "type": "boolean"
+          },
+          "isShogiWolf": {
+            "type": "boolean"
+          },
+          "isViewableWolfCharaName": {
+            "type": "boolean"
+          },
+          "isSayableWerewolfSay": {
+            "type": "boolean"
+          },
+          "isFoxCount": {
+            "type": "boolean"
+          },
+          "isViewableSympathizeSay": {
+            "type": "boolean"
+          },
+          "isDivineResultWolf": {
+            "type": "boolean"
+          },
+          "isDeadByDivine": {
+            "type": "boolean"
+          },
+          "isCounterDeadByInvestigate": {
+            "type": "boolean"
+          },
+          "isOpenSkill": {
+            "type": "boolean"
+          },
+          "isViewableTelepathy": {
+            "type": "boolean"
+          },
+          "isSayableTelepathy": {
+            "type": "boolean"
+          },
+          "isViewableWerewolfSay": {
+            "type": "boolean"
+          },
+          "isViewableAttackMessage": {
+            "type": "boolean"
+          },
+          "isViewableCoronerMessage": {
+            "type": "boolean"
+          },
+          "isViewableLoversSay": {
+            "type": "boolean"
+          },
+          "isSayableSympathizeSay": {
+            "type": "boolean"
+          },
+          "isViewableFoxMessage": {
+            "type": "boolean"
+          },
+          "isViewableGuruMessage": {
+            "type": "boolean"
+          },
+          "isViewableInvestigateMessage": {
+            "type": "boolean"
+          },
+          "isViewableLoversMessage": {
+            "type": "boolean"
+          },
+          "isViewableDivineMessage": {
+            "type": "boolean"
+          },
+          "isViewablePsychicMessage": {
+            "type": "boolean"
+          },
+          "isViewableWiseMessage": {
+            "type": "boolean"
+          },
+          "isNoCount": {
+            "type": "boolean"
+          },
+          "isPsychicResultWolf": {
+            "type": "boolean"
+          },
+          "isRevivable": {
+            "type": "boolean"
+          },
+          "isCounterDeadByDivine": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "code",
+          "histories",
+          "isCounterDeadByDivine",
+          "isCounterDeadByInvestigate",
+          "isDeadByDivine",
+          "isDivineResultWolf",
+          "isFoxCount",
+          "isNoCount",
+          "isNoDeadByAttack",
+          "isNoSound",
+          "isOpenSkill",
+          "isPsychicResultWolf",
+          "isRequestable",
+          "isRevivable",
+          "isSayableSympathizeSay",
+          "isSayableTelepathy",
+          "isSayableWerewolfSay",
+          "isShogiWolf",
+          "isViewableAttackMessage",
+          "isViewableCoronerMessage",
+          "isViewableDivineMessage",
+          "isViewableFoxMessage",
+          "isViewableGuruMessage",
+          "isViewableInvestigateMessage",
+          "isViewableLoversMessage",
+          "isViewableLoversSay",
+          "isViewablePsychicMessage",
+          "isViewableSympathizeSay",
+          "isViewableTelepathy",
+          "isViewableWerewolfSay",
+          "isViewableWiseMessage",
+          "isViewableWolfCharaName",
+          "isWolfCount",
+          "name",
+          "shortName"
+        ]
+      },
+      "SkillAllocation": {
+        "type": "object",
+        "properties": {
+          "skill": {
+            "$ref": "#/components/schemas/Skill"
+          },
+          "min": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "max": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          },
+          "initAllocation": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "reincarnationAllocation": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": ["initAllocation", "min", "reincarnationAllocation", "skill"]
+      },
+      "SkillHistories": {
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SkillHistory"
+            }
+          }
+        },
+        "required": ["list"]
+      },
+      "SkillHistory": {
+        "type": "object",
+        "properties": {
+          "skill": {
+            "required": ["code", "name", "shortName"]
+          },
+          "day": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": ["day", "skill"]
+      },
+      "SkillSayRestriction": {
+        "type": "object",
+        "properties": {
+          "messageType": {
+            "$ref": "#/components/schemas/MessageType"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "length": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": ["count", "length", "messageType"]
+      },
+      "VillageCharaSetting": {
+        "type": "object",
+        "properties": {
+          "isOriginalCharachip": {
+            "type": "boolean"
+          },
+          "dummyCharaId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "dummyDay1Message": {
+            "type": ["string", "null"]
+          },
+          "charachipIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        },
+        "required": ["charachipIds", "dummyCharaId", "isOriginalCharachip"]
+      },
+      "VillageOrganize": {
+        "type": "object",
+        "properties": {
+          "fixedOrganization": {
+            "type": "string"
+          },
+          "randomOrganization": {
+            "$ref": "#/components/schemas/VillageRandomOrganize"
+          }
+        },
+        "required": ["fixedOrganization", "randomOrganization"]
+      },
+      "VillageRandomOrganize": {
+        "type": "object",
+        "properties": {
+          "skillAllocation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SkillAllocation"
+            }
+          },
+          "campAllocation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CampAllocation"
+            }
+          },
+          "wolfAllocation": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/WolfAllocation"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": ["campAllocation", "skillAllocation"]
+      },
+      "VillageRule": {
+        "type": "object",
+        "properties": {
+          "isOpenVote": {
+            "type": "boolean"
+          },
+          "isPossibleSkillRequest": {
+            "type": "boolean"
+          },
+          "isAvailableSpectate": {
+            "type": "boolean"
+          },
+          "isCreatorIsProducer": {
+            "type": "boolean"
+          },
+          "isAvailableSameWolfAttack": {
+            "type": "boolean"
+          },
+          "isOpenSkillInGrave": {
+            "type": "boolean"
+          },
+          "isVisibleGraveSpectateMessage": {
+            "type": "boolean"
+          },
+          "isAvailableSuddenlyDeath": {
+            "type": "boolean"
+          },
+          "isAvailableCommit": {
+            "type": "boolean"
+          },
+          "isAvailableGuardSameTarget": {
+            "type": "boolean"
+          },
+          "isAvailableAction": {
+            "type": "boolean"
+          },
+          "isRandomOrganization": {
+            "type": "boolean"
+          },
+          "isReincarnationSkillAll": {
+            "type": "boolean"
+          },
+          "secretSayRange": {
+            "$ref": "#/components/schemas/SecretSayRange"
+          }
+        },
+        "required": [
+          "isAvailableAction",
+          "isAvailableCommit",
+          "isAvailableGuardSameTarget",
+          "isAvailableSameWolfAttack",
+          "isAvailableSpectate",
+          "isAvailableSuddenlyDeath",
+          "isCreatorIsProducer",
+          "isOpenSkillInGrave",
+          "isOpenVote",
+          "isPossibleSkillRequest",
+          "isRandomOrganization",
+          "isReincarnationSkillAll",
+          "isVisibleGraveSpectateMessage",
+          "secretSayRange"
+        ]
+      },
+      "VillageSettingView": {
+        "type": "object",
+        "properties": {
+          "chara": {
+            "$ref": "#/components/schemas/VillageCharaSetting"
+          },
+          "personMin": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "personMax": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "startDatetime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "dayChangeIntervalSeconds": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "rule": {
+            "$ref": "#/components/schemas/VillageRule"
+          },
+          "organize": {
+            "$ref": "#/components/schemas/VillageOrganize"
+          },
+          "sayRestriction": {
+            "$ref": "#/components/schemas/SayRestriction"
+          },
+          "tags": {
+            "$ref": "#/components/schemas/VillageTags"
+          }
+        },
+        "required": [
+          "chara",
+          "dayChangeIntervalSeconds",
+          "organize",
+          "personMax",
+          "personMin",
+          "rule",
+          "sayRestriction",
+          "startDatetime",
+          "tags"
+        ]
+      },
+      "VillageTags": {
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VillageTag"
+            }
+          }
+        },
+        "required": ["list"]
+      },
+      "WolfAllocation": {
+        "type": "object",
+        "properties": {
+          "min": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "max": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          }
+        },
+        "required": ["min"]
       },
       "SimpleSkillView": {
         "type": "object",

--- a/frontend/app/api/openapi.json
+++ b/frontend/app/api/openapi.json
@@ -5,14 +5,185 @@
     "version": "v0"
   },
   "paths": {
-    "/api/v1/random-keywords/{id}": {
-      "get": {
-        "tags": ["random-keyword-rest-controller"],
-        "operationId": "detail",
+    "/api/v1/auth/login": {
+      "post": {
+        "operationId": "login",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": ["auth-controller"]
+      }
+    },
+    "/api/v1/auth/logout": {
+      "post": {
+        "operationId": "logout",
         "parameters": [
           {
-            "name": "id",
+            "in": "cookie",
+            "name": "refresh_token",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "tags": ["auth-controller"]
+      }
+    },
+    "/api/v1/auth/me": {
+      "get": {
+        "operationId": "me",
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": ["auth-controller"]
+      }
+    },
+    "/api/v1/auth/password": {
+      "post": {
+        "operationId": "changePassword",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PasswordChangeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "tags": ["auth-controller"]
+      }
+    },
+    "/api/v1/auth/refresh": {
+      "post": {
+        "operationId": "refresh",
+        "parameters": [
+          {
+            "in": "cookie",
+            "name": "refresh_token",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": ["auth-controller"]
+      }
+    },
+    "/api/v1/auth/signup": {
+      "post": {
+        "operationId": "signup",
+        "parameters": [
+          {
+            "in": "cookie",
+            "name": "id_register",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SignupRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": ["auth-controller"]
+      }
+    },
+    "/api/v1/charachips": {
+      "get": {
+        "operationId": "list_3",
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/CharachipListResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": ["charachip-rest-controller"]
+      }
+    },
+    "/api/v1/charachips/{id}": {
+      "get": {
+        "operationId": "detail_1",
+        "parameters": [
+          {
             "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "integer",
@@ -22,24 +193,127 @@
         ],
         "responses": {
           "200": {
-            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Charachip"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": ["charachip-rest-controller"]
+      }
+    },
+    "/api/v1/random-keywords": {
+      "get": {
+        "operationId": "list_1",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RandomKeywords"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": ["random-keyword-rest-controller"]
+      },
+      "post": {
+        "operationId": "register",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RandomKeywordRegisterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
             "content": {
               "*/*": {
                 "schema": {
                   "$ref": "#/components/schemas/RandomKeyword"
                 }
               }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": ["random-keyword-rest-controller"]
+      }
+    },
+    "/api/v1/random-keywords/{id}": {
+      "delete": {
+        "operationId": "delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
             }
           }
-        }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": ["random-keyword-rest-controller"]
+      },
+      "get": {
+        "operationId": "detail",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RandomKeyword"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": ["random-keyword-rest-controller"]
       },
       "put": {
-        "tags": ["random-keyword-rest-controller"],
         "operationId": "update",
         "parameters": [
           {
-            "name": "id",
             "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "integer",
@@ -59,24 +333,26 @@
         },
         "responses": {
           "200": {
-            "description": "OK",
             "content": {
               "*/*": {
                 "schema": {
                   "$ref": "#/components/schemas/RandomKeyword"
                 }
               }
-            }
+            },
+            "description": "OK"
           }
-        }
-      },
-      "delete": {
-        "tags": ["random-keyword-rest-controller"],
-        "operationId": "delete",
+        },
+        "tags": ["random-keyword-rest-controller"]
+      }
+    },
+    "/api/v1/rooms": {
+      "get": {
+        "operationId": "roomAssignment",
         "parameters": [
           {
-            "name": "id",
-            "in": "path",
+            "in": "query",
+            "name": "personNum",
             "required": true,
             "schema": {
               "type": "integer",
@@ -85,20 +361,63 @@
           }
         ],
         "responses": {
-          "204": {
-            "description": "No Content"
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoomAssignmentResponse"
+                }
+              }
+            },
+            "description": "OK"
           }
-        }
+        },
+        "tags": ["room-rest-controller"]
       }
     },
-    "/api/v1/villages": {
+    "/api/v1/rule/judges": {
       "get": {
-        "tags": ["village-rest-controller"],
-        "operationId": "list",
+        "operationId": "judges",
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/JudgeListResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": ["rule-rest-controller"]
+      }
+    },
+    "/api/v1/skills": {
+      "get": {
+        "operationId": "list_2",
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillListResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": ["skill-rest-controller"]
+      }
+    },
+    "/api/v1/skills/search": {
+      "get": {
+        "operationId": "search",
         "parameters": [
           {
-            "name": "status",
             "in": "query",
+            "name": "tags",
             "required": false,
             "schema": {
               "type": "array",
@@ -108,8 +427,56 @@
             }
           },
           {
-            "name": "charachip",
             "in": "query",
+            "name": "name",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "villageId",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillSearchResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": ["skill-rest-controller"]
+      }
+    },
+    "/api/v1/villages": {
+      "get": {
+        "operationId": "list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "in": "query",
+            "name": "charachip",
             "required": false,
             "schema": {
               "type": "array",
@@ -120,8 +487,8 @@
             }
           },
           {
-            "name": "skill",
             "in": "query",
+            "name": "skill",
             "required": false,
             "schema": {
               "type": "array",
@@ -131,16 +498,16 @@
             }
           },
           {
-            "name": "random",
             "in": "query",
+            "name": "random",
             "required": false,
             "schema": {
               "type": "boolean"
             }
           },
           {
-            "name": "order",
             "in": "query",
+            "name": "order",
             "required": false,
             "schema": {
               "type": "string"
@@ -149,19 +516,19 @@
         ],
         "responses": {
           "200": {
-            "description": "OK",
             "content": {
               "*/*": {
                 "schema": {
                   "$ref": "#/components/schemas/VillageListResponse"
                 }
               }
-            }
+            },
+            "description": "OK"
           }
-        }
+        },
+        "tags": ["village-rest-controller"]
       },
       "post": {
-        "tags": ["village-rest-controller"],
         "operationId": "create",
         "requestBody": {
           "content": {
@@ -169,12 +536,12 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "request": {
-                    "$ref": "#/components/schemas/VillageCreateRequest"
-                  },
                   "dummyCharaImage": {
                     "type": "string",
                     "format": "binary"
+                  },
+                  "request": {
+                    "$ref": "#/components/schemas/VillageCreateRequest"
                   }
                 },
                 "required": ["request"]
@@ -184,216 +551,26 @@
         },
         "responses": {
           "200": {
-            "description": "OK",
             "content": {
               "*/*": {
                 "schema": {
                   "$ref": "#/components/schemas/VillageCreateResponse"
                 }
               }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/random-keywords": {
-      "get": {
-        "tags": ["random-keyword-rest-controller"],
-        "operationId": "list_1",
-        "parameters": [
-          {
-            "name": "q",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/RandomKeywords"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": ["random-keyword-rest-controller"],
-        "operationId": "register",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RandomKeywordRegisterRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/RandomKeyword"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/auth/signup": {
-      "post": {
-        "tags": ["auth-controller"],
-        "operationId": "signup",
-        "parameters": [
-          {
-            "name": "id_register",
-            "in": "cookie",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SignupRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/MeResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/auth/refresh": {
-      "post": {
-        "tags": ["auth-controller"],
-        "operationId": "refresh",
-        "parameters": [
-          {
-            "name": "refresh_token",
-            "in": "cookie",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/MeResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/auth/password": {
-      "post": {
-        "tags": ["auth-controller"],
-        "operationId": "changePassword",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PasswordChangeRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
+            },
             "description": "OK"
           }
-        }
-      }
-    },
-    "/api/v1/auth/logout": {
-      "post": {
-        "tags": ["auth-controller"],
-        "operationId": "logout",
-        "parameters": [
-          {
-            "name": "refresh_token",
-            "in": "cookie",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
-    },
-    "/api/v1/auth/login": {
-      "post": {
-        "tags": ["auth-controller"],
-        "operationId": "login",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/LoginRequest"
-              }
-            }
-          },
-          "required": true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/MeResponse"
-                }
-              }
-            }
-          }
-        }
+        "tags": ["village-rest-controller"]
       }
     },
     "/api/v1/villages/{id}/setting": {
       "get": {
-        "tags": ["village-rest-controller"],
         "operationId": "setting",
         "parameters": [
           {
-            "name": "id",
             "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "integer",
@@ -403,213 +580,403 @@
         ],
         "responses": {
           "200": {
-            "description": "OK",
             "content": {
               "*/*": {
                 "schema": {
                   "$ref": "#/components/schemas/VillageSettingView"
                 }
               }
-            }
+            },
+            "description": "OK"
           }
-        }
-      }
-    },
-    "/api/v1/skills": {
-      "get": {
-        "tags": ["skill-rest-controller"],
-        "operationId": "list_2",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/SkillListResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/skills/search": {
-      "get": {
-        "tags": ["skill-rest-controller"],
-        "operationId": "search",
-        "parameters": [
-          {
-            "name": "tags",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "name": "name",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "villageId",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/SkillSearchResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/rule/judges": {
-      "get": {
-        "tags": ["rule-rest-controller"],
-        "operationId": "judges",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/JudgeListResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/rooms": {
-      "get": {
-        "tags": ["room-rest-controller"],
-        "operationId": "roomAssignment",
-        "parameters": [
-          {
-            "name": "personNum",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/RoomAssignmentResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/charachips": {
-      "get": {
-        "tags": ["charachip-rest-controller"],
-        "operationId": "list_3",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/CharachipListResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/charachips/{id}": {
-      "get": {
-        "tags": ["charachip-rest-controller"],
-        "operationId": "detail_1",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/Charachip"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/auth/me": {
-      "get": {
-        "tags": ["auth-controller"],
-        "operationId": "me",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/MeResponse"
-                }
-              }
-            }
-          }
-        }
+        },
+        "tags": ["village-rest-controller"]
       }
     }
   },
   "components": {
     "schemas": {
-      "RandomKeywordUpdateRequest": {
+      "AbilityType": {
         "type": "object",
         "properties": {
-          "messages": {
-            "type": ["array", "null"],
-            "items": {
-              "type": "string",
-              "maxLength": 20,
-              "minLength": 1
-            },
-            "minItems": 1
+          "code": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "setMessageType": {
+            "$ref": "#/components/schemas/MessageType"
           }
         },
-        "required": ["messages"]
+        "required": ["code", "name", "setMessageType"]
+      },
+      "Camp": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "isCriminals": {
+            "type": "boolean"
+          },
+          "isFoxs": {
+            "type": "boolean"
+          },
+          "isLovers": {
+            "type": "boolean"
+          },
+          "isVillagers": {
+            "type": "boolean"
+          },
+          "isWolfs": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["code", "isCriminals", "isFoxs", "isLovers", "isVillagers", "isWolfs", "name"]
+      },
+      "CampAllocation": {
+        "type": "object",
+        "properties": {
+          "camp": {
+            "$ref": "#/components/schemas/Camp"
+          },
+          "initAllocation": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "max": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          },
+          "min": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "reincarnationAllocation": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": ["camp", "initAllocation", "min", "reincarnationAllocation"]
+      },
+      "Chara": {
+        "type": "object",
+        "properties": {
+          "defaultFirstdayMessage": {
+            "type": ["string", "null"]
+          },
+          "defaultJoinMessage": {
+            "type": ["string", "null"]
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "images": {
+            "$ref": "#/components/schemas/CharaImages"
+          },
+          "name": {
+            "type": "string"
+          },
+          "shortName": {
+            "type": "string"
+          },
+          "size": {
+            "$ref": "#/components/schemas/CharaSize"
+          }
+        },
+        "required": ["id", "images", "name", "shortName", "size"]
+      },
+      "CharaImage": {
+        "type": "object",
+        "properties": {
+          "faceType": {
+            "$ref": "#/components/schemas/FaceType"
+          },
+          "isDisplay": {
+            "type": "boolean"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": ["faceType", "isDisplay", "url"]
+      },
+      "CharaImages": {
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CharaImage"
+            }
+          }
+        },
+        "required": ["list"]
+      },
+      "CharaSize": {
+        "type": "object",
+        "properties": {
+          "height": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "width": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": ["height", "width"]
+      },
+      "Charachip": {
+        "type": "object",
+        "properties": {
+          "charas": {
+            "$ref": "#/components/schemas/Charas"
+          },
+          "descriptionUrl": {
+            "type": ["string", "null"]
+          },
+          "designer": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Designer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "isAvailableChangeName": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["charas", "id", "isAvailableChangeName", "name"]
+      },
+      "CharachipListResponse": {
+        "type": "object",
+        "properties": {
+          "charachips": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SimpleCharachipView"
+            }
+          }
+        },
+        "required": ["charachips"]
+      },
+      "Charas": {
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Chara"
+            }
+          }
+        },
+        "required": ["list"]
+      },
+      "Designer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["id", "name"]
+      },
+      "FaceType": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["code", "name"]
+      },
+      "JudgeListResponse": {
+        "type": "object",
+        "properties": {
+          "judges": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/JudgeView"
+            }
+          }
+        },
+        "required": ["judges"]
+      },
+      "JudgeSkillView": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["code", "name"]
+      },
+      "JudgeView": {
+        "type": "object",
+        "properties": {
+          "countType": {
+            "type": "string",
+            "enum": ["HUMAN", "WOLF", "NO_COUNT"]
+          },
+          "divineResultWolf": {
+            "type": "boolean"
+          },
+          "noDeadByAttack": {
+            "type": "boolean"
+          },
+          "psychicResultWolf": {
+            "type": "boolean"
+          },
+          "skills": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/JudgeSkillView"
+            }
+          }
+        },
+        "required": [
+          "countType",
+          "divineResultWolf",
+          "noDeadByAttack",
+          "psychicResultWolf",
+          "skills"
+        ]
+      },
+      "LoginRequest": {
+        "type": "object",
+        "properties": {
+          "password": {
+            "type": ["string", "null"]
+          },
+          "userId": {
+            "type": ["string", "null"]
+          }
+        },
+        "required": ["password", "userId"]
+      },
+      "MeResponse": {
+        "type": "object",
+        "properties": {
+          "authorities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "canCreateVillage": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "playerId": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": ["authorities", "canCreateVillage", "name", "playerId"]
+      },
+      "MessageType": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "isOwlViewableType": {
+            "type": "boolean"
+          },
+          "isSayType": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["code", "isOwlViewableType", "isSayType", "name"]
+      },
+      "MessageTypeSayRestrict": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          },
+          "length": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          },
+          "messageTypeCode": {
+            "type": ["string", "null"]
+          },
+          "restrict": {
+            "type": ["boolean", "null"]
+          }
+        },
+        "required": ["messageTypeCode", "restrict"]
+      },
+      "NormalSayRestriction": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "length": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "messageType": {
+            "$ref": "#/components/schemas/MessageType"
+          },
+          "skill": {
+            "$ref": "#/components/schemas/Skill"
+          }
+        },
+        "required": ["count", "length", "messageType", "skill"]
+      },
+      "PasswordChangeRequest": {
+        "type": "object",
+        "properties": {
+          "confirmPassword": {
+            "type": ["string", "null"],
+            "maxLength": 60,
+            "minLength": 3,
+            "pattern": "[\\x21-\\x7E]+"
+          },
+          "password": {
+            "type": ["string", "null"],
+            "maxLength": 60,
+            "minLength": 3,
+            "pattern": "[\\x21-\\x7E]+"
+          }
+        },
+        "required": ["confirmPassword", "password"]
       },
       "RandomContent": {
         "type": "object",
@@ -623,394 +990,21 @@
       "RandomKeyword": {
         "type": "object",
         "properties": {
+          "contents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RandomContent"
+            }
+          },
           "id": {
             "type": "integer",
             "format": "int32"
           },
           "keyword": {
             "type": "string"
-          },
-          "contents": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/RandomContent"
-            }
           }
         },
         "required": ["contents", "id", "keyword"]
-      },
-      "MessageTypeSayRestrict": {
-        "type": "object",
-        "properties": {
-          "messageTypeCode": {
-            "type": ["string", "null"]
-          },
-          "restrict": {
-            "type": ["boolean", "null"]
-          },
-          "length": {
-            "type": ["integer", "null"],
-            "format": "int32"
-          },
-          "count": {
-            "type": ["integer", "null"],
-            "format": "int32"
-          }
-        },
-        "required": ["messageTypeCode", "restrict"]
-      },
-      "SkillSayRestrict": {
-        "type": "object",
-        "properties": {
-          "skillCode": {
-            "type": ["string", "null"]
-          },
-          "restrict": {
-            "type": ["boolean", "null"]
-          },
-          "length": {
-            "type": ["integer", "null"],
-            "format": "int32"
-          },
-          "count": {
-            "type": ["integer", "null"],
-            "format": "int32"
-          }
-        },
-        "required": ["restrict", "skillCode"]
-      },
-      "VillageCreateRequest": {
-        "type": "object",
-        "properties": {
-          "villageName": {
-            "type": ["string", "null"],
-            "maxLength": 40,
-            "minLength": 5
-          },
-          "welcomeRange": {
-            "type": ["string", "null"],
-            "pattern": "ANYONE_WELCOME|RELATIVES_ONLY"
-          },
-          "startPersonMinNum": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "minimum": 8
-          },
-          "personMaxNum": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 999
-          },
-          "dayChangeIntervalHours": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 72,
-            "minimum": 0
-          },
-          "dayChangeIntervalMinutes": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 59,
-            "minimum": 0
-          },
-          "dayChangeIntervalSeconds": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 59,
-            "minimum": 0
-          },
-          "startYear": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "minimum": 0
-          },
-          "startMonth": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 12,
-            "minimum": 1
-          },
-          "startDay": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 31,
-            "minimum": 1
-          },
-          "startHour": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 23,
-            "minimum": 0
-          },
-          "startMinute": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 59,
-            "minimum": 0
-          },
-          "shouldOriginalImage": {
-            "type": ["boolean", "null"]
-          },
-          "characterSetId": {
-            "type": ["array", "null"],
-            "items": {
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          "dummyCharaId": {
-            "type": ["integer", "null"],
-            "format": "int32"
-          },
-          "dummyCharaName": {
-            "type": ["string", "null"],
-            "maxLength": 40,
-            "minLength": 1
-          },
-          "dummyCharaShortName": {
-            "type": ["string", "null"],
-            "maxLength": 1,
-            "minLength": 1
-          },
-          "dummyJoinMessage": {
-            "type": ["string", "null"],
-            "maxLength": 400,
-            "minLength": 1
-          },
-          "dummyDay1Message": {
-            "type": ["string", "null"],
-            "maxLength": 400,
-            "minLength": 0
-          },
-          "joinPassword": {
-            "type": ["string", "null"]
-          },
-          "openVote": {
-            "type": ["boolean", "null"]
-          },
-          "possibleSkillRequest": {
-            "type": ["boolean", "null"]
-          },
-          "availableSameWolfAttack": {
-            "type": ["boolean", "null"]
-          },
-          "availableGuardSameTarget": {
-            "type": ["boolean", "null"]
-          },
-          "reincarnationSkillAll": {
-            "type": ["boolean", "null"]
-          },
-          "availableSuddonlyDeath": {
-            "type": ["boolean", "null"]
-          },
-          "availableCommit": {
-            "type": ["boolean", "null"]
-          },
-          "availableSpectate": {
-            "type": ["boolean", "null"]
-          },
-          "creatorIsProducer": {
-            "type": ["boolean", "null"]
-          },
-          "openSkillInGrave": {
-            "type": ["boolean", "null"]
-          },
-          "visibleGraveSpectateMessage": {
-            "type": ["boolean", "null"]
-          },
-          "availableAction": {
-            "type": ["boolean", "null"]
-          },
-          "randomOrganization": {
-            "type": ["boolean", "null"]
-          },
-          "organization": {
-            "type": ["string", "null"]
-          },
-          "campAllocationList": {
-            "type": ["array", "null"],
-            "items": {
-              "$ref": "#/components/schemas/VillageCreateRequestCampAllocation"
-            }
-          },
-          "wolfAllocation": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/VillageCreateRequestWolfAllocation"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "allowedSecretSayCode": {
-            "type": ["string", "null"],
-            "pattern": "NOTHING|ONLY_CREATOR|EVERYTHING"
-          },
-          "sayRestrictList": {
-            "type": ["array", "null"],
-            "items": {
-              "$ref": "#/components/schemas/SkillSayRestrict"
-            }
-          },
-          "skillSayRestrictList": {
-            "type": ["array", "null"],
-            "items": {
-              "$ref": "#/components/schemas/MessageTypeSayRestrict"
-            }
-          },
-          "rpSayRestrictList": {
-            "type": ["array", "null"],
-            "items": {
-              "$ref": "#/components/schemas/MessageTypeSayRestrict"
-            }
-          },
-          "ageLimit": {
-            "type": ["string", "null"],
-            "pattern": "R15|R18"
-          }
-        },
-        "required": [
-          "allowedSecretSayCode",
-          "availableAction",
-          "availableCommit",
-          "availableGuardSameTarget",
-          "availableSameWolfAttack",
-          "availableSpectate",
-          "availableSuddonlyDeath",
-          "characterSetId",
-          "creatorIsProducer",
-          "dayChangeIntervalHours",
-          "dayChangeIntervalMinutes",
-          "dayChangeIntervalSeconds",
-          "dummyCharaName",
-          "dummyCharaShortName",
-          "dummyJoinMessage",
-          "openSkillInGrave",
-          "openVote",
-          "personMaxNum",
-          "possibleSkillRequest",
-          "randomOrganization",
-          "reincarnationSkillAll",
-          "rpSayRestrictList",
-          "sayRestrictList",
-          "shouldOriginalImage",
-          "skillSayRestrictList",
-          "startDay",
-          "startHour",
-          "startMinute",
-          "startMonth",
-          "startPersonMinNum",
-          "startYear",
-          "villageName",
-          "visibleGraveSpectateMessage"
-        ]
-      },
-      "VillageCreateRequestCampAllocation": {
-        "type": "object",
-        "properties": {
-          "campCode": {
-            "type": ["string", "null"]
-          },
-          "minNum": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 100,
-            "minimum": 0
-          },
-          "maxNum": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 100,
-            "minimum": 0
-          },
-          "allocation": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 100,
-            "minimum": 0
-          },
-          "reincarnationAllocation": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 100,
-            "minimum": 0
-          },
-          "skillAllocation": {
-            "type": ["array", "null"],
-            "items": {
-              "$ref": "#/components/schemas/VillageCreateRequestSkillAllocation"
-            }
-          }
-        },
-        "required": [
-          "allocation",
-          "campCode",
-          "minNum",
-          "reincarnationAllocation",
-          "skillAllocation"
-        ]
-      },
-      "VillageCreateRequestSkillAllocation": {
-        "type": "object",
-        "properties": {
-          "skillCode": {
-            "type": ["string", "null"]
-          },
-          "minNum": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 100,
-            "minimum": 0
-          },
-          "maxNum": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 100,
-            "minimum": 0
-          },
-          "allocation": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 100,
-            "minimum": 0
-          },
-          "reincarnationAllocation": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 100,
-            "minimum": 0
-          }
-        },
-        "required": ["allocation", "minNum", "reincarnationAllocation", "skillCode"]
-      },
-      "VillageCreateRequestWolfAllocation": {
-        "type": "object",
-        "properties": {
-          "minNum": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 100,
-            "minimum": 1
-          },
-          "maxNum": {
-            "type": ["integer", "null"],
-            "format": "int32",
-            "maximum": 100,
-            "minimum": 1
-          }
-        },
-        "required": ["minNum"]
-      },
-      "VillageCreateResponse": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int32"
-          }
-        },
-        "required": ["id"]
       },
       "RandomKeywordRegisterRequest": {
         "type": "object",
@@ -1033,298 +1027,53 @@
         },
         "required": ["keyword", "messages"]
       },
-      "SignupRequest": {
+      "RandomKeywordUpdateRequest": {
         "type": "object",
         "properties": {
-          "userId": {
-            "type": ["string", "null"],
-            "maxLength": 12,
-            "minLength": 3,
-            "pattern": "[a-zA-Z][a-zA-Z0-9\\-_]*"
-          },
-          "password": {
-            "type": ["string", "null"],
-            "maxLength": 60,
-            "minLength": 3,
-            "pattern": "[\\x21-\\x7E]+"
+          "messages": {
+            "type": ["array", "null"],
+            "items": {
+              "type": "string",
+              "maxLength": 20,
+              "minLength": 1
+            },
+            "minItems": 1
           }
         },
-        "required": ["password", "userId"]
+        "required": ["messages"]
       },
-      "MeResponse": {
+      "RandomKeywords": {
         "type": "object",
         "properties": {
-          "playerId": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "name": {
-            "type": "string"
-          },
-          "authorities": {
+          "list": {
             "type": "array",
             "items": {
-              "type": "string"
-            }
-          },
-          "canCreateVillage": {
-            "type": "boolean"
-          }
-        },
-        "required": ["authorities", "canCreateVillage", "name", "playerId"]
-      },
-      "PasswordChangeRequest": {
-        "type": "object",
-        "properties": {
-          "password": {
-            "type": ["string", "null"],
-            "maxLength": 60,
-            "minLength": 3,
-            "pattern": "[\\x21-\\x7E]+"
-          },
-          "confirmPassword": {
-            "type": ["string", "null"],
-            "maxLength": 60,
-            "minLength": 3,
-            "pattern": "[\\x21-\\x7E]+"
-          }
-        },
-        "required": ["confirmPassword", "password"]
-      },
-      "LoginRequest": {
-        "type": "object",
-        "properties": {
-          "userId": {
-            "type": ["string", "null"]
-          },
-          "password": {
-            "type": ["string", "null"]
-          }
-        },
-        "required": ["password", "userId"]
-      },
-      "Setting": {
-        "type": "object",
-        "properties": {
-          "personMin": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "personMax": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "tags": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/VillageTag"
+              "$ref": "#/components/schemas/RandomKeyword"
             }
           }
         },
-        "required": ["personMax", "personMin", "tags"]
+        "required": ["list"]
       },
-      "SimpleVillageView": {
+      "RoomAssignmentResponse": {
         "type": "object",
         "properties": {
-          "id": {
+          "height": {
             "type": "integer",
             "format": "int32"
           },
-          "name": {
-            "type": "string"
-          },
-          "status": {
-            "$ref": "#/components/schemas/VillageStatus"
-          },
-          "participantCount": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "spectatorCount": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "setting": {
-            "$ref": "#/components/schemas/Setting"
-          }
-        },
-        "required": ["id", "name", "participantCount", "setting", "spectatorCount", "status"]
-      },
-      "VillageListResponse": {
-        "type": "object",
-        "properties": {
-          "villages": {
+          "roomNumbers": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/SimpleVillageView"
+              "type": "integer",
+              "format": "int32"
             }
-          }
-        },
-        "required": ["villages"]
-      },
-      "VillageStatus": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
           },
-          "name": {
-            "type": "string"
-          },
-          "isPrologue": {
-            "type": "boolean"
-          },
-          "isCanceled": {
-            "type": "boolean"
-          },
-          "isSettled": {
-            "type": "boolean"
-          },
-          "isProgress": {
-            "type": "boolean"
-          },
-          "isEpilogue": {
-            "type": "boolean"
-          },
-          "isNotFinished": {
-            "type": "boolean"
-          },
-          "isSettleOrCanceled": {
-            "type": "boolean"
-          },
-          "isFinished": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "code",
-          "isCanceled",
-          "isEpilogue",
-          "isFinished",
-          "isNotFinished",
-          "isProgress",
-          "isPrologue",
-          "isSettleOrCanceled",
-          "isSettled",
-          "name"
-        ]
-      },
-      "VillageTag": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          }
-        },
-        "required": ["code", "name"]
-      },
-      "AbilityType": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "setMessageType": {
-            "$ref": "#/components/schemas/MessageType"
-          }
-        },
-        "required": ["code", "name", "setMessageType"]
-      },
-      "Camp": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "isFoxs": {
-            "type": "boolean"
-          },
-          "isLovers": {
-            "type": "boolean"
-          },
-          "isVillagers": {
-            "type": "boolean"
-          },
-          "isWolfs": {
-            "type": "boolean"
-          },
-          "isCriminals": {
-            "type": "boolean"
-          }
-        },
-        "required": ["code", "isCriminals", "isFoxs", "isLovers", "isVillagers", "isWolfs", "name"]
-      },
-      "CampAllocation": {
-        "type": "object",
-        "properties": {
-          "camp": {
-            "$ref": "#/components/schemas/Camp"
-          },
-          "min": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "max": {
-            "type": ["integer", "null"],
-            "format": "int32"
-          },
-          "initAllocation": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "reincarnationAllocation": {
+          "width": {
             "type": "integer",
             "format": "int32"
           }
         },
-        "required": ["camp", "initAllocation", "min", "reincarnationAllocation"]
-      },
-      "MessageType": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "isOwlViewableType": {
-            "type": "boolean"
-          },
-          "isSayType": {
-            "type": "boolean"
-          }
-        },
-        "required": ["code", "isOwlViewableType", "isSayType", "name"]
-      },
-      "NormalSayRestriction": {
-        "type": "object",
-        "properties": {
-          "skill": {
-            "$ref": "#/components/schemas/Skill"
-          },
-          "messageType": {
-            "$ref": "#/components/schemas/MessageType"
-          },
-          "count": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "length": {
-            "type": "integer",
-            "format": "int32"
-          }
-        },
-        "required": ["count", "length", "messageType", "skill"]
+        "required": ["height", "roomNumbers", "width"]
       },
       "SayRestriction": {
         "type": "object",
@@ -1356,70 +1105,210 @@
         },
         "required": ["code", "name"]
       },
-      "Skill": {
+      "Setting": {
         "type": "object",
         "properties": {
+          "personMax": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "personMin": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VillageTag"
+            }
+          }
+        },
+        "required": ["personMax", "personMin", "tags"]
+      },
+      "SignupRequest": {
+        "type": "object",
+        "properties": {
+          "password": {
+            "type": ["string", "null"],
+            "maxLength": 60,
+            "minLength": 3,
+            "pattern": "[\\x21-\\x7E]+"
+          },
+          "userId": {
+            "type": ["string", "null"],
+            "maxLength": 12,
+            "minLength": 3,
+            "pattern": "[a-zA-Z][a-zA-Z0-9\\-_]*"
+          }
+        },
+        "required": ["password", "userId"]
+      },
+      "SimpleCharachipView": {
+        "type": "object",
+        "properties": {
+          "charaNum": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "designerName": {
+            "type": "string"
+          },
+          "dummyImgHeight": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "dummyImgUrl": {
+            "type": "string"
+          },
+          "dummyImgWidth": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "charaNum",
+          "designerName",
+          "dummyImgHeight",
+          "dummyImgUrl",
+          "dummyImgWidth",
+          "id",
+          "name"
+        ]
+      },
+      "SimpleSkillView": {
+        "type": "object",
+        "properties": {
+          "campCode": {
+            "type": "string"
+          },
+          "campName": {
+            "type": "string"
+          },
           "code": {
             "type": "string"
           },
           "name": {
             "type": "string"
           },
+          "requestable": {
+            "type": "boolean"
+          },
+          "revivable": {
+            "type": "boolean"
+          },
           "shortName": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "campCode",
+          "campName",
+          "code",
+          "name",
+          "requestable",
+          "revivable",
+          "shortName",
+          "tags"
+        ]
+      },
+      "SimpleVillageView": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string"
+          },
+          "participantCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "setting": {
+            "$ref": "#/components/schemas/Setting"
+          },
+          "spectatorCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "status": {
+            "$ref": "#/components/schemas/VillageStatus"
+          }
+        },
+        "required": ["id", "name", "participantCount", "setting", "spectatorCount", "status"]
+      },
+      "Skill": {
+        "type": "object",
+        "properties": {
+          "ability": {
+            "$ref": "#/components/schemas/AbilityType"
+          },
+          "code": {
             "type": "string"
           },
           "histories": {
             "$ref": "#/components/schemas/SkillHistories"
           },
-          "isRequestable": {
-            "type": "boolean"
-          },
-          "isWolfCount": {
-            "type": "boolean"
-          },
-          "ability": {
-            "$ref": "#/components/schemas/AbilityType"
-          },
-          "isNoSound": {
-            "type": "boolean"
-          },
-          "isNoDeadByAttack": {
-            "type": "boolean"
-          },
-          "isShogiWolf": {
-            "type": "boolean"
-          },
-          "isViewableWolfCharaName": {
-            "type": "boolean"
-          },
-          "isSayableWerewolfSay": {
-            "type": "boolean"
-          },
-          "isFoxCount": {
-            "type": "boolean"
-          },
-          "isViewableSympathizeSay": {
-            "type": "boolean"
-          },
-          "isDivineResultWolf": {
-            "type": "boolean"
-          },
-          "isDeadByDivine": {
+          "isCounterDeadByDivine": {
             "type": "boolean"
           },
           "isCounterDeadByInvestigate": {
             "type": "boolean"
           },
+          "isDeadByDivine": {
+            "type": "boolean"
+          },
+          "isDivineResultWolf": {
+            "type": "boolean"
+          },
+          "isFoxCount": {
+            "type": "boolean"
+          },
+          "isNoCount": {
+            "type": "boolean"
+          },
+          "isNoDeadByAttack": {
+            "type": "boolean"
+          },
+          "isNoSound": {
+            "type": "boolean"
+          },
           "isOpenSkill": {
             "type": "boolean"
           },
-          "isViewableTelepathy": {
+          "isPsychicResultWolf": {
+            "type": "boolean"
+          },
+          "isRequestable": {
+            "type": "boolean"
+          },
+          "isRevivable": {
+            "type": "boolean"
+          },
+          "isSayableSympathizeSay": {
             "type": "boolean"
           },
           "isSayableTelepathy": {
             "type": "boolean"
           },
-          "isViewableWerewolfSay": {
+          "isSayableWerewolfSay": {
+            "type": "boolean"
+          },
+          "isShogiWolf": {
             "type": "boolean"
           },
           "isViewableAttackMessage": {
@@ -1428,10 +1317,7 @@
           "isViewableCoronerMessage": {
             "type": "boolean"
           },
-          "isViewableLoversSay": {
-            "type": "boolean"
-          },
-          "isSayableSympathizeSay": {
+          "isViewableDivineMessage": {
             "type": "boolean"
           },
           "isViewableFoxMessage": {
@@ -1446,26 +1332,35 @@
           "isViewableLoversMessage": {
             "type": "boolean"
           },
-          "isViewableDivineMessage": {
+          "isViewableLoversSay": {
             "type": "boolean"
           },
           "isViewablePsychicMessage": {
             "type": "boolean"
           },
+          "isViewableSympathizeSay": {
+            "type": "boolean"
+          },
+          "isViewableTelepathy": {
+            "type": "boolean"
+          },
+          "isViewableWerewolfSay": {
+            "type": "boolean"
+          },
           "isViewableWiseMessage": {
             "type": "boolean"
           },
-          "isNoCount": {
+          "isViewableWolfCharaName": {
             "type": "boolean"
           },
-          "isPsychicResultWolf": {
+          "isWolfCount": {
             "type": "boolean"
           },
-          "isRevivable": {
-            "type": "boolean"
+          "name": {
+            "type": "string"
           },
-          "isCounterDeadByDivine": {
-            "type": "boolean"
+          "shortName": {
+            "type": "string"
           }
         },
         "required": [
@@ -1509,10 +1404,7 @@
       "SkillAllocation": {
         "type": "object",
         "properties": {
-          "skill": {
-            "$ref": "#/components/schemas/Skill"
-          },
-          "min": {
+          "initAllocation": {
             "type": "integer",
             "format": "int32"
           },
@@ -1520,13 +1412,16 @@
             "type": ["integer", "null"],
             "format": "int32"
           },
-          "initAllocation": {
+          "min": {
             "type": "integer",
             "format": "int32"
           },
           "reincarnationAllocation": {
             "type": "integer",
             "format": "int32"
+          },
+          "skill": {
+            "$ref": "#/components/schemas/Skill"
           }
         },
         "required": ["initAllocation", "min", "reincarnationAllocation", "skill"]
@@ -1546,22 +1441,57 @@
       "SkillHistory": {
         "type": "object",
         "properties": {
-          "skill": {
-            "required": ["code", "name", "shortName"]
-          },
           "day": {
             "type": "integer",
             "format": "int32"
+          },
+          "skill": {
+            "required": ["code"]
           }
         },
         "required": ["day", "skill"]
       },
+      "SkillListResponse": {
+        "type": "object",
+        "properties": {
+          "skills": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SimpleSkillView"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["skills", "tags"]
+      },
+      "SkillSayRestrict": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          },
+          "length": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          },
+          "restrict": {
+            "type": ["boolean", "null"]
+          },
+          "skillCode": {
+            "type": ["string", "null"]
+          }
+        },
+        "required": ["restrict", "skillCode"]
+      },
       "SkillSayRestriction": {
         "type": "object",
         "properties": {
-          "messageType": {
-            "$ref": "#/components/schemas/MessageType"
-          },
           "count": {
             "type": "integer",
             "format": "int32"
@@ -1569,15 +1499,34 @@
           "length": {
             "type": "integer",
             "format": "int32"
+          },
+          "messageType": {
+            "$ref": "#/components/schemas/MessageType"
           }
         },
         "required": ["count", "length", "messageType"]
       },
+      "SkillSearchResponse": {
+        "type": "object",
+        "properties": {
+          "skillCodes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["skillCodes"]
+      },
       "VillageCharaSetting": {
         "type": "object",
         "properties": {
-          "isOriginalCharachip": {
-            "type": "boolean"
+          "charachipIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           "dummyCharaId": {
             "type": "integer",
@@ -1586,15 +1535,356 @@
           "dummyDay1Message": {
             "type": ["string", "null"]
           },
-          "charachipIds": {
-            "type": "array",
+          "isOriginalCharachip": {
+            "type": "boolean"
+          }
+        },
+        "required": ["charachipIds", "dummyCharaId", "isOriginalCharachip"]
+      },
+      "VillageCreateRequest": {
+        "type": "object",
+        "properties": {
+          "ageLimit": {
+            "type": ["string", "null"],
+            "pattern": "R15|R18"
+          },
+          "allowedSecretSayCode": {
+            "type": ["string", "null"],
+            "pattern": "NOTHING|ONLY_CREATOR|EVERYTHING"
+          },
+          "availableAction": {
+            "type": ["boolean", "null"]
+          },
+          "availableCommit": {
+            "type": ["boolean", "null"]
+          },
+          "availableGuardSameTarget": {
+            "type": ["boolean", "null"]
+          },
+          "availableSameWolfAttack": {
+            "type": ["boolean", "null"]
+          },
+          "availableSpectate": {
+            "type": ["boolean", "null"]
+          },
+          "availableSuddonlyDeath": {
+            "type": ["boolean", "null"]
+          },
+          "campAllocationList": {
+            "type": ["array", "null"],
+            "items": {
+              "$ref": "#/components/schemas/VillageCreateRequestCampAllocation"
+            }
+          },
+          "characterSetId": {
+            "type": ["array", "null"],
             "items": {
               "type": "integer",
               "format": "int32"
             }
+          },
+          "creatorIsProducer": {
+            "type": ["boolean", "null"]
+          },
+          "dayChangeIntervalHours": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 72,
+            "minimum": 0
+          },
+          "dayChangeIntervalMinutes": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 59,
+            "minimum": 0
+          },
+          "dayChangeIntervalSeconds": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 59,
+            "minimum": 0
+          },
+          "dummyCharaId": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          },
+          "dummyCharaName": {
+            "type": ["string", "null"],
+            "maxLength": 40,
+            "minLength": 1
+          },
+          "dummyCharaShortName": {
+            "type": ["string", "null"],
+            "maxLength": 1,
+            "minLength": 1
+          },
+          "dummyDay1Message": {
+            "type": ["string", "null"],
+            "maxLength": 400,
+            "minLength": 0
+          },
+          "dummyJoinMessage": {
+            "type": ["string", "null"],
+            "maxLength": 400,
+            "minLength": 1
+          },
+          "joinPassword": {
+            "type": ["string", "null"]
+          },
+          "openSkillInGrave": {
+            "type": ["boolean", "null"]
+          },
+          "openVote": {
+            "type": ["boolean", "null"]
+          },
+          "organization": {
+            "type": ["string", "null"]
+          },
+          "personMaxNum": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 999
+          },
+          "possibleSkillRequest": {
+            "type": ["boolean", "null"]
+          },
+          "randomOrganization": {
+            "type": ["boolean", "null"]
+          },
+          "reincarnationSkillAll": {
+            "type": ["boolean", "null"]
+          },
+          "rpSayRestrictList": {
+            "type": ["array", "null"],
+            "items": {
+              "$ref": "#/components/schemas/MessageTypeSayRestrict"
+            }
+          },
+          "sayRestrictList": {
+            "type": ["array", "null"],
+            "items": {
+              "$ref": "#/components/schemas/SkillSayRestrict"
+            }
+          },
+          "shouldOriginalImage": {
+            "type": ["boolean", "null"]
+          },
+          "skillSayRestrictList": {
+            "type": ["array", "null"],
+            "items": {
+              "$ref": "#/components/schemas/MessageTypeSayRestrict"
+            }
+          },
+          "startDay": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 31,
+            "minimum": 1
+          },
+          "startHour": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 23,
+            "minimum": 0
+          },
+          "startMinute": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 59,
+            "minimum": 0
+          },
+          "startMonth": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 12,
+            "minimum": 1
+          },
+          "startPersonMinNum": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "minimum": 8
+          },
+          "startYear": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "minimum": 0
+          },
+          "villageName": {
+            "type": ["string", "null"],
+            "maxLength": 40,
+            "minLength": 5
+          },
+          "visibleGraveSpectateMessage": {
+            "type": ["boolean", "null"]
+          },
+          "welcomeRange": {
+            "type": ["string", "null"],
+            "pattern": "ANYONE_WELCOME|RELATIVES_ONLY"
+          },
+          "wolfAllocation": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/VillageCreateRequestWolfAllocation"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
-        "required": ["charachipIds", "dummyCharaId", "isOriginalCharachip"]
+        "required": [
+          "allowedSecretSayCode",
+          "availableAction",
+          "availableCommit",
+          "availableGuardSameTarget",
+          "availableSameWolfAttack",
+          "availableSpectate",
+          "availableSuddonlyDeath",
+          "characterSetId",
+          "creatorIsProducer",
+          "dayChangeIntervalHours",
+          "dayChangeIntervalMinutes",
+          "dayChangeIntervalSeconds",
+          "dummyCharaName",
+          "dummyCharaShortName",
+          "dummyJoinMessage",
+          "openSkillInGrave",
+          "openVote",
+          "personMaxNum",
+          "possibleSkillRequest",
+          "randomOrganization",
+          "reincarnationSkillAll",
+          "rpSayRestrictList",
+          "sayRestrictList",
+          "shouldOriginalImage",
+          "skillSayRestrictList",
+          "startDay",
+          "startHour",
+          "startMinute",
+          "startMonth",
+          "startPersonMinNum",
+          "startYear",
+          "villageName",
+          "visibleGraveSpectateMessage"
+        ]
+      },
+      "VillageCreateRequestCampAllocation": {
+        "type": "object",
+        "properties": {
+          "allocation": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 100,
+            "minimum": 0
+          },
+          "campCode": {
+            "type": ["string", "null"]
+          },
+          "maxNum": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 100,
+            "minimum": 0
+          },
+          "minNum": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 100,
+            "minimum": 0
+          },
+          "reincarnationAllocation": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 100,
+            "minimum": 0
+          },
+          "skillAllocation": {
+            "type": ["array", "null"],
+            "items": {
+              "$ref": "#/components/schemas/VillageCreateRequestSkillAllocation"
+            }
+          }
+        },
+        "required": [
+          "allocation",
+          "campCode",
+          "minNum",
+          "reincarnationAllocation",
+          "skillAllocation"
+        ]
+      },
+      "VillageCreateRequestSkillAllocation": {
+        "type": "object",
+        "properties": {
+          "allocation": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 100,
+            "minimum": 0
+          },
+          "maxNum": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 100,
+            "minimum": 0
+          },
+          "minNum": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 100,
+            "minimum": 0
+          },
+          "reincarnationAllocation": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 100,
+            "minimum": 0
+          },
+          "skillCode": {
+            "type": ["string", "null"]
+          }
+        },
+        "required": ["allocation", "minNum", "reincarnationAllocation", "skillCode"]
+      },
+      "VillageCreateRequestWolfAllocation": {
+        "type": "object",
+        "properties": {
+          "maxNum": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 100,
+            "minimum": 1
+          },
+          "minNum": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "maximum": 100,
+            "minimum": 1
+          }
+        },
+        "required": ["minNum"]
+      },
+      "VillageCreateResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": ["id"]
+      },
+      "VillageListResponse": {
+        "type": "object",
+        "properties": {
+          "villages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SimpleVillageView"
+            }
+          }
+        },
+        "required": ["villages"]
       },
       "VillageOrganize": {
         "type": "object",
@@ -1611,16 +1901,16 @@
       "VillageRandomOrganize": {
         "type": "object",
         "properties": {
-          "skillAllocation": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/SkillAllocation"
-            }
-          },
           "campAllocation": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/CampAllocation"
+            }
+          },
+          "skillAllocation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SkillAllocation"
             }
           },
           "wolfAllocation": {
@@ -1639,28 +1929,7 @@
       "VillageRule": {
         "type": "object",
         "properties": {
-          "isOpenVote": {
-            "type": "boolean"
-          },
-          "isPossibleSkillRequest": {
-            "type": "boolean"
-          },
-          "isAvailableSpectate": {
-            "type": "boolean"
-          },
-          "isCreatorIsProducer": {
-            "type": "boolean"
-          },
-          "isAvailableSameWolfAttack": {
-            "type": "boolean"
-          },
-          "isOpenSkillInGrave": {
-            "type": "boolean"
-          },
-          "isVisibleGraveSpectateMessage": {
-            "type": "boolean"
-          },
-          "isAvailableSuddenlyDeath": {
+          "isAvailableAction": {
             "type": "boolean"
           },
           "isAvailableCommit": {
@@ -1669,13 +1938,34 @@
           "isAvailableGuardSameTarget": {
             "type": "boolean"
           },
-          "isAvailableAction": {
+          "isAvailableSameWolfAttack": {
+            "type": "boolean"
+          },
+          "isAvailableSpectate": {
+            "type": "boolean"
+          },
+          "isAvailableSuddenlyDeath": {
+            "type": "boolean"
+          },
+          "isCreatorIsProducer": {
+            "type": "boolean"
+          },
+          "isOpenSkillInGrave": {
+            "type": "boolean"
+          },
+          "isOpenVote": {
+            "type": "boolean"
+          },
+          "isPossibleSkillRequest": {
             "type": "boolean"
           },
           "isRandomOrganization": {
             "type": "boolean"
           },
           "isReincarnationSkillAll": {
+            "type": "boolean"
+          },
+          "isVisibleGraveSpectateMessage": {
             "type": "boolean"
           },
           "secretSayRange": {
@@ -1705,30 +1995,30 @@
           "chara": {
             "$ref": "#/components/schemas/VillageCharaSetting"
           },
-          "personMin": {
+          "dayChangeIntervalSeconds": {
             "type": "integer",
             "format": "int32"
+          },
+          "organize": {
+            "$ref": "#/components/schemas/VillageOrganize"
           },
           "personMax": {
             "type": "integer",
             "format": "int32"
           },
-          "startDatetime": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "dayChangeIntervalSeconds": {
+          "personMin": {
             "type": "integer",
             "format": "int32"
           },
           "rule": {
             "$ref": "#/components/schemas/VillageRule"
           },
-          "organize": {
-            "$ref": "#/components/schemas/VillageOrganize"
-          },
           "sayRestriction": {
             "$ref": "#/components/schemas/SayRestriction"
+          },
+          "startDatetime": {
+            "type": "string",
+            "format": "date-time"
           },
           "tags": {
             "$ref": "#/components/schemas/VillageTags"
@@ -1746,6 +2036,65 @@
           "tags"
         ]
       },
+      "VillageStatus": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "isCanceled": {
+            "type": "boolean"
+          },
+          "isEpilogue": {
+            "type": "boolean"
+          },
+          "isFinished": {
+            "type": "boolean"
+          },
+          "isNotFinished": {
+            "type": "boolean"
+          },
+          "isProgress": {
+            "type": "boolean"
+          },
+          "isPrologue": {
+            "type": "boolean"
+          },
+          "isSettleOrCanceled": {
+            "type": "boolean"
+          },
+          "isSettled": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "isCanceled",
+          "isEpilogue",
+          "isFinished",
+          "isNotFinished",
+          "isProgress",
+          "isPrologue",
+          "isSettleOrCanceled",
+          "isSettled",
+          "name"
+        ]
+      },
+      "VillageTag": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["code", "name"]
+      },
       "VillageTags": {
         "type": "object",
         "properties": {
@@ -1761,365 +2110,16 @@
       "WolfAllocation": {
         "type": "object",
         "properties": {
-          "min": {
-            "type": "integer",
-            "format": "int32"
-          },
           "max": {
             "type": ["integer", "null"],
+            "format": "int32"
+          },
+          "min": {
+            "type": "integer",
             "format": "int32"
           }
         },
         "required": ["min"]
-      },
-      "SimpleSkillView": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "shortName": {
-            "type": "string"
-          },
-          "campCode": {
-            "type": "string"
-          },
-          "campName": {
-            "type": "string"
-          },
-          "tags": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "requestable": {
-            "type": "boolean"
-          },
-          "revivable": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "campCode",
-          "campName",
-          "code",
-          "name",
-          "requestable",
-          "revivable",
-          "shortName",
-          "tags"
-        ]
-      },
-      "SkillListResponse": {
-        "type": "object",
-        "properties": {
-          "skills": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/SimpleSkillView"
-            }
-          },
-          "tags": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "required": ["skills", "tags"]
-      },
-      "SkillSearchResponse": {
-        "type": "object",
-        "properties": {
-          "skillCodes": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "required": ["skillCodes"]
-      },
-      "JudgeListResponse": {
-        "type": "object",
-        "properties": {
-          "judges": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/JudgeView"
-            }
-          }
-        },
-        "required": ["judges"]
-      },
-      "JudgeSkillView": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          }
-        },
-        "required": ["code", "name"]
-      },
-      "JudgeView": {
-        "type": "object",
-        "properties": {
-          "skills": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/JudgeSkillView"
-            }
-          },
-          "divineResultWolf": {
-            "type": "boolean"
-          },
-          "psychicResultWolf": {
-            "type": "boolean"
-          },
-          "noDeadByAttack": {
-            "type": "boolean"
-          },
-          "countType": {
-            "type": "string",
-            "enum": ["HUMAN", "WOLF", "NO_COUNT"]
-          }
-        },
-        "required": [
-          "countType",
-          "divineResultWolf",
-          "noDeadByAttack",
-          "psychicResultWolf",
-          "skills"
-        ]
-      },
-      "RoomAssignmentResponse": {
-        "type": "object",
-        "properties": {
-          "width": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "height": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "roomNumbers": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "int32"
-            }
-          }
-        },
-        "required": ["height", "roomNumbers", "width"]
-      },
-      "RandomKeywords": {
-        "type": "object",
-        "properties": {
-          "list": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/RandomKeyword"
-            }
-          }
-        },
-        "required": ["list"]
-      },
-      "CharachipListResponse": {
-        "type": "object",
-        "properties": {
-          "charachips": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/SimpleCharachipView"
-            }
-          }
-        },
-        "required": ["charachips"]
-      },
-      "SimpleCharachipView": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "name": {
-            "type": "string"
-          },
-          "designerName": {
-            "type": "string"
-          },
-          "charaNum": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "dummyImgUrl": {
-            "type": "string"
-          },
-          "dummyImgWidth": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "dummyImgHeight": {
-            "type": "integer",
-            "format": "int32"
-          }
-        },
-        "required": [
-          "charaNum",
-          "designerName",
-          "dummyImgHeight",
-          "dummyImgUrl",
-          "dummyImgWidth",
-          "id",
-          "name"
-        ]
-      },
-      "Chara": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "name": {
-            "type": "string"
-          },
-          "shortName": {
-            "type": "string"
-          },
-          "defaultJoinMessage": {
-            "type": ["string", "null"]
-          },
-          "defaultFirstdayMessage": {
-            "type": ["string", "null"]
-          },
-          "size": {
-            "$ref": "#/components/schemas/CharaSize"
-          },
-          "images": {
-            "$ref": "#/components/schemas/CharaImages"
-          }
-        },
-        "required": ["id", "images", "name", "shortName", "size"]
-      },
-      "CharaImage": {
-        "type": "object",
-        "properties": {
-          "faceType": {
-            "$ref": "#/components/schemas/FaceType"
-          },
-          "url": {
-            "type": "string"
-          },
-          "isDisplay": {
-            "type": "boolean"
-          }
-        },
-        "required": ["faceType", "isDisplay", "url"]
-      },
-      "CharaImages": {
-        "type": "object",
-        "properties": {
-          "list": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CharaImage"
-            }
-          }
-        },
-        "required": ["list"]
-      },
-      "CharaSize": {
-        "type": "object",
-        "properties": {
-          "width": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "height": {
-            "type": "integer",
-            "format": "int32"
-          }
-        },
-        "required": ["height", "width"]
-      },
-      "Charachip": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "name": {
-            "type": "string"
-          },
-          "designer": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/Designer"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "descriptionUrl": {
-            "type": ["string", "null"]
-          },
-          "isAvailableChangeName": {
-            "type": "boolean"
-          },
-          "charas": {
-            "$ref": "#/components/schemas/Charas"
-          }
-        },
-        "required": ["charas", "id", "isAvailableChangeName", "name"]
-      },
-      "Charas": {
-        "type": "object",
-        "properties": {
-          "list": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Chara"
-            }
-          }
-        },
-        "required": ["list"]
-      },
-      "Designer": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "name": {
-            "type": "string"
-          }
-        },
-        "required": ["id", "name"]
-      },
-      "FaceType": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          }
-        },
-        "required": ["code", "name"]
       }
     }
   }

--- a/frontend/app/api/types.ts
+++ b/frontend/app/api/types.ts
@@ -470,7 +470,6 @@ export interface components {
     Skill: {
       ability?: components["schemas"]["AbilityType"];
       code: string;
-      histories: components["schemas"]["SkillHistories"];
       isCounterDeadByDivine: boolean;
       isCounterDeadByInvestigate: boolean;
       isDeadByDivine: boolean;
@@ -515,14 +514,6 @@ export interface components {
       /** Format: int32 */
       reincarnationAllocation: number;
       skill: components["schemas"]["Skill"];
-    };
-    SkillHistories: {
-      list: components["schemas"]["SkillHistory"][];
-    };
-    SkillHistory: {
-      /** Format: int32 */
-      day: number;
-      skill: unknown;
     };
     SkillListResponse: {
       skills: components["schemas"]["SimpleSkillView"][];

--- a/frontend/app/api/types.ts
+++ b/frontend/app/api/types.ts
@@ -3,55 +3,7 @@
  * 元: backend の OpenAPI spec (/v3/api-docs)。再生成すると上書きされます。
  */
 export interface paths {
-  "/api/v1/random-keywords/{id}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: operations["detail"];
-    put: operations["update"];
-    post?: never;
-    delete: operations["delete"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/villages": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: operations["list"];
-    put?: never;
-    post: operations["create"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/random-keywords": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: operations["list_1"];
-    put?: never;
-    post: operations["register"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/auth/signup": {
+  "/api/v1/auth/login": {
     parameters: {
       query?: never;
       header?: never;
@@ -60,39 +12,7 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    post: operations["signup"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/auth/refresh": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: operations["refresh"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/auth/password": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: operations["changePassword"];
+    post: operations["login"];
     delete?: never;
     options?: never;
     head?: never;
@@ -115,7 +35,23 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  "/api/v1/auth/login": {
+  "/api/v1/auth/me": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["me"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/auth/password": {
     parameters: {
       query?: never;
       header?: never;
@@ -124,21 +60,133 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    post: operations["login"];
+    post: operations["changePassword"];
     delete?: never;
     options?: never;
     head?: never;
     patch?: never;
     trace?: never;
   };
-  "/api/v1/villages/{id}/setting": {
+  "/api/v1/auth/refresh": {
     parameters: {
       query?: never;
       header?: never;
       path?: never;
       cookie?: never;
     };
-    get: operations["setting"];
+    get?: never;
+    put?: never;
+    post: operations["refresh"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/auth/signup": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["signup"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/charachips": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["list_3"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/charachips/{id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["detail_1"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/random-keywords": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["list_1"];
+    put?: never;
+    post: operations["register"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/random-keywords/{id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["detail"];
+    put: operations["update"];
+    post?: never;
+    delete: operations["delete"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/rooms": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["roomAssignment"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/rule/judges": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["judges"];
     put?: never;
     post?: never;
     delete?: never;
@@ -179,78 +227,30 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  "/api/v1/rule/judges": {
+  "/api/v1/villages": {
     parameters: {
       query?: never;
       header?: never;
       path?: never;
       cookie?: never;
     };
-    get: operations["judges"];
+    get: operations["list"];
     put?: never;
-    post?: never;
+    post: operations["create"];
     delete?: never;
     options?: never;
     head?: never;
     patch?: never;
     trace?: never;
   };
-  "/api/v1/rooms": {
+  "/api/v1/villages/{id}/setting": {
     parameters: {
       query?: never;
       header?: never;
       path?: never;
       cookie?: never;
     };
-    get: operations["roomAssignment"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/charachips": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: operations["list_3"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/charachips/{id}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: operations["detail_1"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/v1/auth/me": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: operations["me"];
+    get: operations["setting"];
     put?: never;
     post?: never;
     delete?: never;
@@ -263,181 +263,6 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
   schemas: {
-    RandomKeywordUpdateRequest: {
-      messages: string[] | null;
-    };
-    RandomContent: {
-      message: string;
-    };
-    RandomKeyword: {
-      /** Format: int32 */
-      id: number;
-      keyword: string;
-      contents: components["schemas"]["RandomContent"][];
-    };
-    MessageTypeSayRestrict: {
-      messageTypeCode: string | null;
-      restrict: boolean | null;
-      /** Format: int32 */
-      length?: number | null;
-      /** Format: int32 */
-      count?: number | null;
-    };
-    SkillSayRestrict: {
-      skillCode: string | null;
-      restrict: boolean | null;
-      /** Format: int32 */
-      length?: number | null;
-      /** Format: int32 */
-      count?: number | null;
-    };
-    VillageCreateRequest: {
-      villageName: string | null;
-      welcomeRange?: string | null;
-      /** Format: int32 */
-      startPersonMinNum: number | null;
-      /** Format: int32 */
-      personMaxNum: number | null;
-      /** Format: int32 */
-      dayChangeIntervalHours: number | null;
-      /** Format: int32 */
-      dayChangeIntervalMinutes: number | null;
-      /** Format: int32 */
-      dayChangeIntervalSeconds: number | null;
-      /** Format: int32 */
-      startYear: number | null;
-      /** Format: int32 */
-      startMonth: number | null;
-      /** Format: int32 */
-      startDay: number | null;
-      /** Format: int32 */
-      startHour: number | null;
-      /** Format: int32 */
-      startMinute: number | null;
-      shouldOriginalImage: boolean | null;
-      characterSetId: number[] | null;
-      /** Format: int32 */
-      dummyCharaId?: number | null;
-      dummyCharaName: string | null;
-      dummyCharaShortName: string | null;
-      dummyJoinMessage: string | null;
-      dummyDay1Message?: string | null;
-      joinPassword?: string | null;
-      openVote: boolean | null;
-      possibleSkillRequest: boolean | null;
-      availableSameWolfAttack: boolean | null;
-      availableGuardSameTarget: boolean | null;
-      reincarnationSkillAll: boolean | null;
-      availableSuddonlyDeath: boolean | null;
-      availableCommit: boolean | null;
-      availableSpectate: boolean | null;
-      creatorIsProducer: boolean | null;
-      openSkillInGrave: boolean | null;
-      visibleGraveSpectateMessage: boolean | null;
-      availableAction: boolean | null;
-      randomOrganization: boolean | null;
-      organization?: string | null;
-      campAllocationList?: components["schemas"]["VillageCreateRequestCampAllocation"][] | null;
-      wolfAllocation?: components["schemas"]["VillageCreateRequestWolfAllocation"] | null;
-      allowedSecretSayCode: string | null;
-      sayRestrictList: components["schemas"]["SkillSayRestrict"][] | null;
-      skillSayRestrictList: components["schemas"]["MessageTypeSayRestrict"][] | null;
-      rpSayRestrictList: components["schemas"]["MessageTypeSayRestrict"][] | null;
-      ageLimit?: string | null;
-    };
-    VillageCreateRequestCampAllocation: {
-      campCode: string | null;
-      /** Format: int32 */
-      minNum: number | null;
-      /** Format: int32 */
-      maxNum?: number | null;
-      /** Format: int32 */
-      allocation: number | null;
-      /** Format: int32 */
-      reincarnationAllocation: number | null;
-      skillAllocation: components["schemas"]["VillageCreateRequestSkillAllocation"][] | null;
-    };
-    VillageCreateRequestSkillAllocation: {
-      skillCode: string | null;
-      /** Format: int32 */
-      minNum: number | null;
-      /** Format: int32 */
-      maxNum?: number | null;
-      /** Format: int32 */
-      allocation: number | null;
-      /** Format: int32 */
-      reincarnationAllocation: number | null;
-    };
-    VillageCreateRequestWolfAllocation: {
-      /** Format: int32 */
-      minNum: number | null;
-      /** Format: int32 */
-      maxNum?: number | null;
-    };
-    VillageCreateResponse: {
-      /** Format: int32 */
-      id: number;
-    };
-    RandomKeywordRegisterRequest: {
-      keyword: string | null;
-      messages: string[] | null;
-    };
-    SignupRequest: {
-      userId: string | null;
-      password: string | null;
-    };
-    MeResponse: {
-      /** Format: int32 */
-      playerId: number;
-      name: string;
-      authorities: string[];
-      canCreateVillage: boolean;
-    };
-    PasswordChangeRequest: {
-      password: string | null;
-      confirmPassword: string | null;
-    };
-    LoginRequest: {
-      userId: string | null;
-      password: string | null;
-    };
-    Setting: {
-      /** Format: int32 */
-      personMin: number;
-      /** Format: int32 */
-      personMax: number;
-      tags: components["schemas"]["VillageTag"][];
-    };
-    SimpleVillageView: {
-      /** Format: int32 */
-      id: number;
-      name: string;
-      status: components["schemas"]["VillageStatus"];
-      /** Format: int32 */
-      participantCount: number;
-      /** Format: int32 */
-      spectatorCount: number;
-      setting: components["schemas"]["Setting"];
-    };
-    VillageListResponse: {
-      villages: components["schemas"]["SimpleVillageView"][];
-    };
-    VillageStatus: {
-      code: string;
-      name: string;
-      isPrologue: boolean;
-      isCanceled: boolean;
-      isSettled: boolean;
-      isProgress: boolean;
-      isEpilogue: boolean;
-      isNotFinished: boolean;
-      isSettleOrCanceled: boolean;
-      isFinished: boolean;
-    };
-    VillageTag: {
-      code: string;
-      name: string;
-    };
     AbilityType: {
       code: string;
       name: string;
@@ -445,256 +270,59 @@ export interface components {
     };
     Camp: {
       code: string;
-      name: string;
+      isCriminals: boolean;
       isFoxs: boolean;
       isLovers: boolean;
       isVillagers: boolean;
       isWolfs: boolean;
-      isCriminals: boolean;
+      name: string;
     };
     CampAllocation: {
       camp: components["schemas"]["Camp"];
       /** Format: int32 */
-      min: number;
-      /** Format: int32 */
-      max?: number | null;
-      /** Format: int32 */
       initAllocation: number;
       /** Format: int32 */
-      reincarnationAllocation: number;
-    };
-    MessageType: {
-      code: string;
-      name: string;
-      isOwlViewableType: boolean;
-      isSayType: boolean;
-    };
-    NormalSayRestriction: {
-      skill: components["schemas"]["Skill"];
-      messageType: components["schemas"]["MessageType"];
-      /** Format: int32 */
-      count: number;
-      /** Format: int32 */
-      length: number;
-    };
-    SayRestriction: {
-      normalSayRestriction: components["schemas"]["NormalSayRestriction"][];
-      skillSayRestriction: components["schemas"]["SkillSayRestriction"][];
-    };
-    SecretSayRange: {
-      code: string;
-      name: string;
-    };
-    Skill: {
-      code: string;
-      name: string;
-      shortName: string;
-      histories: components["schemas"]["SkillHistories"];
-      isRequestable: boolean;
-      isWolfCount: boolean;
-      ability?: components["schemas"]["AbilityType"];
-      isNoSound: boolean;
-      isNoDeadByAttack: boolean;
-      isShogiWolf: boolean;
-      isViewableWolfCharaName: boolean;
-      isSayableWerewolfSay: boolean;
-      isFoxCount: boolean;
-      isViewableSympathizeSay: boolean;
-      isDivineResultWolf: boolean;
-      isDeadByDivine: boolean;
-      isCounterDeadByInvestigate: boolean;
-      isOpenSkill: boolean;
-      isViewableTelepathy: boolean;
-      isSayableTelepathy: boolean;
-      isViewableWerewolfSay: boolean;
-      isViewableAttackMessage: boolean;
-      isViewableCoronerMessage: boolean;
-      isViewableLoversSay: boolean;
-      isSayableSympathizeSay: boolean;
-      isViewableFoxMessage: boolean;
-      isViewableGuruMessage: boolean;
-      isViewableInvestigateMessage: boolean;
-      isViewableLoversMessage: boolean;
-      isViewableDivineMessage: boolean;
-      isViewablePsychicMessage: boolean;
-      isViewableWiseMessage: boolean;
-      isNoCount: boolean;
-      isPsychicResultWolf: boolean;
-      isRevivable: boolean;
-      isCounterDeadByDivine: boolean;
-    };
-    SkillAllocation: {
-      skill: components["schemas"]["Skill"];
+      max?: number | null;
       /** Format: int32 */
       min: number;
       /** Format: int32 */
-      max?: number | null;
-      /** Format: int32 */
-      initAllocation: number;
-      /** Format: int32 */
       reincarnationAllocation: number;
-    };
-    SkillHistories: {
-      list: components["schemas"]["SkillHistory"][];
-    };
-    SkillHistory: {
-      skill: unknown;
-      /** Format: int32 */
-      day: number;
-    };
-    SkillSayRestriction: {
-      messageType: components["schemas"]["MessageType"];
-      /** Format: int32 */
-      count: number;
-      /** Format: int32 */
-      length: number;
-    };
-    VillageCharaSetting: {
-      isOriginalCharachip: boolean;
-      /** Format: int32 */
-      dummyCharaId: number;
-      dummyDay1Message?: string | null;
-      charachipIds: number[];
-    };
-    VillageOrganize: {
-      fixedOrganization: string;
-      randomOrganization: components["schemas"]["VillageRandomOrganize"];
-    };
-    VillageRandomOrganize: {
-      skillAllocation: components["schemas"]["SkillAllocation"][];
-      campAllocation: components["schemas"]["CampAllocation"][];
-      wolfAllocation?: components["schemas"]["WolfAllocation"] | null;
-    };
-    VillageRule: {
-      isOpenVote: boolean;
-      isPossibleSkillRequest: boolean;
-      isAvailableSpectate: boolean;
-      isCreatorIsProducer: boolean;
-      isAvailableSameWolfAttack: boolean;
-      isOpenSkillInGrave: boolean;
-      isVisibleGraveSpectateMessage: boolean;
-      isAvailableSuddenlyDeath: boolean;
-      isAvailableCommit: boolean;
-      isAvailableGuardSameTarget: boolean;
-      isAvailableAction: boolean;
-      isRandomOrganization: boolean;
-      isReincarnationSkillAll: boolean;
-      secretSayRange: components["schemas"]["SecretSayRange"];
-    };
-    VillageSettingView: {
-      chara: components["schemas"]["VillageCharaSetting"];
-      /** Format: int32 */
-      personMin: number;
-      /** Format: int32 */
-      personMax: number;
-      /** Format: date-time */
-      startDatetime: string;
-      /** Format: int32 */
-      dayChangeIntervalSeconds: number;
-      rule: components["schemas"]["VillageRule"];
-      organize: components["schemas"]["VillageOrganize"];
-      sayRestriction: components["schemas"]["SayRestriction"];
-      tags: components["schemas"]["VillageTags"];
-    };
-    VillageTags: {
-      list: components["schemas"]["VillageTag"][];
-    };
-    WolfAllocation: {
-      /** Format: int32 */
-      min: number;
-      /** Format: int32 */
-      max?: number | null;
-    };
-    SimpleSkillView: {
-      code: string;
-      name: string;
-      shortName: string;
-      campCode: string;
-      campName: string;
-      tags: string[];
-      requestable: boolean;
-      revivable: boolean;
-    };
-    SkillListResponse: {
-      skills: components["schemas"]["SimpleSkillView"][];
-      tags: string[];
-    };
-    SkillSearchResponse: {
-      skillCodes: string[];
-    };
-    JudgeListResponse: {
-      judges: components["schemas"]["JudgeView"][];
-    };
-    JudgeSkillView: {
-      code: string;
-      name: string;
-    };
-    JudgeView: {
-      skills: components["schemas"]["JudgeSkillView"][];
-      divineResultWolf: boolean;
-      psychicResultWolf: boolean;
-      noDeadByAttack: boolean;
-      /** @enum {string} */
-      countType: "HUMAN" | "WOLF" | "NO_COUNT";
-    };
-    RoomAssignmentResponse: {
-      /** Format: int32 */
-      width: number;
-      /** Format: int32 */
-      height: number;
-      roomNumbers: number[];
-    };
-    RandomKeywords: {
-      list: components["schemas"]["RandomKeyword"][];
-    };
-    CharachipListResponse: {
-      charachips: components["schemas"]["SimpleCharachipView"][];
-    };
-    SimpleCharachipView: {
-      /** Format: int32 */
-      id: number;
-      name: string;
-      designerName: string;
-      /** Format: int32 */
-      charaNum: number;
-      dummyImgUrl: string;
-      /** Format: int32 */
-      dummyImgWidth: number;
-      /** Format: int32 */
-      dummyImgHeight: number;
     };
     Chara: {
+      defaultFirstdayMessage?: string | null;
+      defaultJoinMessage?: string | null;
       /** Format: int32 */
       id: number;
+      images: components["schemas"]["CharaImages"];
       name: string;
       shortName: string;
-      defaultJoinMessage?: string | null;
-      defaultFirstdayMessage?: string | null;
       size: components["schemas"]["CharaSize"];
-      images: components["schemas"]["CharaImages"];
     };
     CharaImage: {
       faceType: components["schemas"]["FaceType"];
-      url: string;
       isDisplay: boolean;
+      url: string;
     };
     CharaImages: {
       list: components["schemas"]["CharaImage"][];
     };
     CharaSize: {
       /** Format: int32 */
-      width: number;
-      /** Format: int32 */
       height: number;
+      /** Format: int32 */
+      width: number;
     };
     Charachip: {
+      charas: components["schemas"]["Charas"];
+      descriptionUrl?: string | null;
+      designer?: components["schemas"]["Designer"] | null;
       /** Format: int32 */
       id: number;
-      name: string;
-      designer?: components["schemas"]["Designer"] | null;
-      descriptionUrl?: string | null;
       isAvailableChangeName: boolean;
-      charas: components["schemas"]["Charas"];
+      name: string;
+    };
+    CharachipListResponse: {
+      charachips: components["schemas"]["SimpleCharachipView"][];
     };
     Charas: {
       list: components["schemas"]["Chara"][];
@@ -708,6 +336,378 @@ export interface components {
       code: string;
       name: string;
     };
+    JudgeListResponse: {
+      judges: components["schemas"]["JudgeView"][];
+    };
+    JudgeSkillView: {
+      code: string;
+      name: string;
+    };
+    JudgeView: {
+      /** @enum {string} */
+      countType: "HUMAN" | "WOLF" | "NO_COUNT";
+      divineResultWolf: boolean;
+      noDeadByAttack: boolean;
+      psychicResultWolf: boolean;
+      skills: components["schemas"]["JudgeSkillView"][];
+    };
+    LoginRequest: {
+      password: string | null;
+      userId: string | null;
+    };
+    MeResponse: {
+      authorities: string[];
+      canCreateVillage: boolean;
+      name: string;
+      /** Format: int32 */
+      playerId: number;
+    };
+    MessageType: {
+      code: string;
+      isOwlViewableType: boolean;
+      isSayType: boolean;
+      name: string;
+    };
+    MessageTypeSayRestrict: {
+      /** Format: int32 */
+      count?: number | null;
+      /** Format: int32 */
+      length?: number | null;
+      messageTypeCode: string | null;
+      restrict: boolean | null;
+    };
+    NormalSayRestriction: {
+      /** Format: int32 */
+      count: number;
+      /** Format: int32 */
+      length: number;
+      messageType: components["schemas"]["MessageType"];
+      skill: components["schemas"]["Skill"];
+    };
+    PasswordChangeRequest: {
+      confirmPassword: string | null;
+      password: string | null;
+    };
+    RandomContent: {
+      message: string;
+    };
+    RandomKeyword: {
+      contents: components["schemas"]["RandomContent"][];
+      /** Format: int32 */
+      id: number;
+      keyword: string;
+    };
+    RandomKeywordRegisterRequest: {
+      keyword: string | null;
+      messages: string[] | null;
+    };
+    RandomKeywordUpdateRequest: {
+      messages: string[] | null;
+    };
+    RandomKeywords: {
+      list: components["schemas"]["RandomKeyword"][];
+    };
+    RoomAssignmentResponse: {
+      /** Format: int32 */
+      height: number;
+      roomNumbers: number[];
+      /** Format: int32 */
+      width: number;
+    };
+    SayRestriction: {
+      normalSayRestriction: components["schemas"]["NormalSayRestriction"][];
+      skillSayRestriction: components["schemas"]["SkillSayRestriction"][];
+    };
+    SecretSayRange: {
+      code: string;
+      name: string;
+    };
+    Setting: {
+      /** Format: int32 */
+      personMax: number;
+      /** Format: int32 */
+      personMin: number;
+      tags: components["schemas"]["VillageTag"][];
+    };
+    SignupRequest: {
+      password: string | null;
+      userId: string | null;
+    };
+    SimpleCharachipView: {
+      /** Format: int32 */
+      charaNum: number;
+      designerName: string;
+      /** Format: int32 */
+      dummyImgHeight: number;
+      dummyImgUrl: string;
+      /** Format: int32 */
+      dummyImgWidth: number;
+      /** Format: int32 */
+      id: number;
+      name: string;
+    };
+    SimpleSkillView: {
+      campCode: string;
+      campName: string;
+      code: string;
+      name: string;
+      requestable: boolean;
+      revivable: boolean;
+      shortName: string;
+      tags: string[];
+    };
+    SimpleVillageView: {
+      /** Format: int32 */
+      id: number;
+      name: string;
+      /** Format: int32 */
+      participantCount: number;
+      setting: components["schemas"]["Setting"];
+      /** Format: int32 */
+      spectatorCount: number;
+      status: components["schemas"]["VillageStatus"];
+    };
+    Skill: {
+      ability?: components["schemas"]["AbilityType"];
+      code: string;
+      histories: components["schemas"]["SkillHistories"];
+      isCounterDeadByDivine: boolean;
+      isCounterDeadByInvestigate: boolean;
+      isDeadByDivine: boolean;
+      isDivineResultWolf: boolean;
+      isFoxCount: boolean;
+      isNoCount: boolean;
+      isNoDeadByAttack: boolean;
+      isNoSound: boolean;
+      isOpenSkill: boolean;
+      isPsychicResultWolf: boolean;
+      isRequestable: boolean;
+      isRevivable: boolean;
+      isSayableSympathizeSay: boolean;
+      isSayableTelepathy: boolean;
+      isSayableWerewolfSay: boolean;
+      isShogiWolf: boolean;
+      isViewableAttackMessage: boolean;
+      isViewableCoronerMessage: boolean;
+      isViewableDivineMessage: boolean;
+      isViewableFoxMessage: boolean;
+      isViewableGuruMessage: boolean;
+      isViewableInvestigateMessage: boolean;
+      isViewableLoversMessage: boolean;
+      isViewableLoversSay: boolean;
+      isViewablePsychicMessage: boolean;
+      isViewableSympathizeSay: boolean;
+      isViewableTelepathy: boolean;
+      isViewableWerewolfSay: boolean;
+      isViewableWiseMessage: boolean;
+      isViewableWolfCharaName: boolean;
+      isWolfCount: boolean;
+      name: string;
+      shortName: string;
+    };
+    SkillAllocation: {
+      /** Format: int32 */
+      initAllocation: number;
+      /** Format: int32 */
+      max?: number | null;
+      /** Format: int32 */
+      min: number;
+      /** Format: int32 */
+      reincarnationAllocation: number;
+      skill: components["schemas"]["Skill"];
+    };
+    SkillHistories: {
+      list: components["schemas"]["SkillHistory"][];
+    };
+    SkillHistory: {
+      /** Format: int32 */
+      day: number;
+      skill: unknown;
+    };
+    SkillListResponse: {
+      skills: components["schemas"]["SimpleSkillView"][];
+      tags: string[];
+    };
+    SkillSayRestrict: {
+      /** Format: int32 */
+      count?: number | null;
+      /** Format: int32 */
+      length?: number | null;
+      restrict: boolean | null;
+      skillCode: string | null;
+    };
+    SkillSayRestriction: {
+      /** Format: int32 */
+      count: number;
+      /** Format: int32 */
+      length: number;
+      messageType: components["schemas"]["MessageType"];
+    };
+    SkillSearchResponse: {
+      skillCodes: string[];
+    };
+    VillageCharaSetting: {
+      charachipIds: number[];
+      /** Format: int32 */
+      dummyCharaId: number;
+      dummyDay1Message?: string | null;
+      isOriginalCharachip: boolean;
+    };
+    VillageCreateRequest: {
+      ageLimit?: string | null;
+      allowedSecretSayCode: string | null;
+      availableAction: boolean | null;
+      availableCommit: boolean | null;
+      availableGuardSameTarget: boolean | null;
+      availableSameWolfAttack: boolean | null;
+      availableSpectate: boolean | null;
+      availableSuddonlyDeath: boolean | null;
+      campAllocationList?: components["schemas"]["VillageCreateRequestCampAllocation"][] | null;
+      characterSetId: number[] | null;
+      creatorIsProducer: boolean | null;
+      /** Format: int32 */
+      dayChangeIntervalHours: number | null;
+      /** Format: int32 */
+      dayChangeIntervalMinutes: number | null;
+      /** Format: int32 */
+      dayChangeIntervalSeconds: number | null;
+      /** Format: int32 */
+      dummyCharaId?: number | null;
+      dummyCharaName: string | null;
+      dummyCharaShortName: string | null;
+      dummyDay1Message?: string | null;
+      dummyJoinMessage: string | null;
+      joinPassword?: string | null;
+      openSkillInGrave: boolean | null;
+      openVote: boolean | null;
+      organization?: string | null;
+      /** Format: int32 */
+      personMaxNum: number | null;
+      possibleSkillRequest: boolean | null;
+      randomOrganization: boolean | null;
+      reincarnationSkillAll: boolean | null;
+      rpSayRestrictList: components["schemas"]["MessageTypeSayRestrict"][] | null;
+      sayRestrictList: components["schemas"]["SkillSayRestrict"][] | null;
+      shouldOriginalImage: boolean | null;
+      skillSayRestrictList: components["schemas"]["MessageTypeSayRestrict"][] | null;
+      /** Format: int32 */
+      startDay: number | null;
+      /** Format: int32 */
+      startHour: number | null;
+      /** Format: int32 */
+      startMinute: number | null;
+      /** Format: int32 */
+      startMonth: number | null;
+      /** Format: int32 */
+      startPersonMinNum: number | null;
+      /** Format: int32 */
+      startYear: number | null;
+      villageName: string | null;
+      visibleGraveSpectateMessage: boolean | null;
+      welcomeRange?: string | null;
+      wolfAllocation?: components["schemas"]["VillageCreateRequestWolfAllocation"] | null;
+    };
+    VillageCreateRequestCampAllocation: {
+      /** Format: int32 */
+      allocation: number | null;
+      campCode: string | null;
+      /** Format: int32 */
+      maxNum?: number | null;
+      /** Format: int32 */
+      minNum: number | null;
+      /** Format: int32 */
+      reincarnationAllocation: number | null;
+      skillAllocation: components["schemas"]["VillageCreateRequestSkillAllocation"][] | null;
+    };
+    VillageCreateRequestSkillAllocation: {
+      /** Format: int32 */
+      allocation: number | null;
+      /** Format: int32 */
+      maxNum?: number | null;
+      /** Format: int32 */
+      minNum: number | null;
+      /** Format: int32 */
+      reincarnationAllocation: number | null;
+      skillCode: string | null;
+    };
+    VillageCreateRequestWolfAllocation: {
+      /** Format: int32 */
+      maxNum?: number | null;
+      /** Format: int32 */
+      minNum: number | null;
+    };
+    VillageCreateResponse: {
+      /** Format: int32 */
+      id: number;
+    };
+    VillageListResponse: {
+      villages: components["schemas"]["SimpleVillageView"][];
+    };
+    VillageOrganize: {
+      fixedOrganization: string;
+      randomOrganization: components["schemas"]["VillageRandomOrganize"];
+    };
+    VillageRandomOrganize: {
+      campAllocation: components["schemas"]["CampAllocation"][];
+      skillAllocation: components["schemas"]["SkillAllocation"][];
+      wolfAllocation?: components["schemas"]["WolfAllocation"] | null;
+    };
+    VillageRule: {
+      isAvailableAction: boolean;
+      isAvailableCommit: boolean;
+      isAvailableGuardSameTarget: boolean;
+      isAvailableSameWolfAttack: boolean;
+      isAvailableSpectate: boolean;
+      isAvailableSuddenlyDeath: boolean;
+      isCreatorIsProducer: boolean;
+      isOpenSkillInGrave: boolean;
+      isOpenVote: boolean;
+      isPossibleSkillRequest: boolean;
+      isRandomOrganization: boolean;
+      isReincarnationSkillAll: boolean;
+      isVisibleGraveSpectateMessage: boolean;
+      secretSayRange: components["schemas"]["SecretSayRange"];
+    };
+    VillageSettingView: {
+      chara: components["schemas"]["VillageCharaSetting"];
+      /** Format: int32 */
+      dayChangeIntervalSeconds: number;
+      organize: components["schemas"]["VillageOrganize"];
+      /** Format: int32 */
+      personMax: number;
+      /** Format: int32 */
+      personMin: number;
+      rule: components["schemas"]["VillageRule"];
+      sayRestriction: components["schemas"]["SayRestriction"];
+      /** Format: date-time */
+      startDatetime: string;
+      tags: components["schemas"]["VillageTags"];
+    };
+    VillageStatus: {
+      code: string;
+      isCanceled: boolean;
+      isEpilogue: boolean;
+      isFinished: boolean;
+      isNotFinished: boolean;
+      isProgress: boolean;
+      isPrologue: boolean;
+      isSettleOrCanceled: boolean;
+      isSettled: boolean;
+      name: string;
+    };
+    VillageTag: {
+      code: string;
+      name: string;
+    };
+    VillageTags: {
+      list: components["schemas"]["VillageTag"][];
+    };
+    WolfAllocation: {
+      /** Format: int32 */
+      max?: number | null;
+      /** Format: int32 */
+      min: number;
+    };
   };
   responses: never;
   parameters: never;
@@ -717,6 +717,228 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+  login: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["LoginRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["MeResponse"];
+        };
+      };
+    };
+  };
+  logout: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: {
+        refresh_token?: string;
+      };
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  me: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["MeResponse"];
+        };
+      };
+    };
+  };
+  changePassword: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PasswordChangeRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  refresh: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: {
+        refresh_token?: string;
+      };
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["MeResponse"];
+        };
+      };
+    };
+  };
+  signup: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: {
+        id_register?: boolean;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["SignupRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["MeResponse"];
+        };
+      };
+    };
+  };
+  list_3: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["CharachipListResponse"];
+        };
+      };
+    };
+  };
+  detail_1: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["Charachip"];
+        };
+      };
+    };
+  };
+  list_1: {
+    parameters: {
+      query?: {
+        q?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["RandomKeywords"];
+        };
+      };
+    };
+  };
+  register: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["RandomKeywordRegisterRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["RandomKeyword"];
+        };
+      };
+    };
+  };
   detail: {
     parameters: {
       query?: never;
@@ -785,14 +1007,10 @@ export interface operations {
       };
     };
   };
-  list: {
+  roomAssignment: {
     parameters: {
-      query?: {
-        status?: string[];
-        charachip?: number[];
-        skill?: string[];
-        random?: boolean;
-        order?: string;
+      query: {
+        personNum: number;
       };
       header?: never;
       path?: never;
@@ -806,44 +1024,14 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          "*/*": components["schemas"]["VillageListResponse"];
+          "*/*": components["schemas"]["RoomAssignmentResponse"];
         };
       };
     };
   };
-  create: {
+  judges: {
     parameters: {
       query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: {
-      content: {
-        "multipart/form-data": {
-          request: components["schemas"]["VillageCreateRequest"];
-          /** Format: binary */
-          dummyCharaImage?: string;
-        };
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["VillageCreateResponse"];
-        };
-      };
-    };
-  };
-  list_1: {
-    parameters: {
-      query?: {
-        q?: string;
-      };
       header?: never;
       path?: never;
       cookie?: never;
@@ -856,167 +1044,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          "*/*": components["schemas"]["RandomKeywords"];
-        };
-      };
-    };
-  };
-  register: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["RandomKeywordRegisterRequest"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["RandomKeyword"];
-        };
-      };
-    };
-  };
-  signup: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: {
-        id_register?: boolean;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["SignupRequest"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["MeResponse"];
-        };
-      };
-    };
-  };
-  refresh: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: {
-        refresh_token?: string;
-      };
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["MeResponse"];
-        };
-      };
-    };
-  };
-  changePassword: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["PasswordChangeRequest"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  logout: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: {
-        refresh_token?: string;
-      };
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  login: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["LoginRequest"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["MeResponse"];
-        };
-      };
-    };
-  };
-  setting: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        id: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["VillageSettingView"];
+          "*/*": components["schemas"]["JudgeListResponse"];
         };
       };
     };
@@ -1065,14 +1093,48 @@ export interface operations {
       };
     };
   };
-  judges: {
+  list: {
+    parameters: {
+      query?: {
+        status?: string[];
+        charachip?: number[];
+        skill?: string[];
+        random?: boolean;
+        order?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["VillageListResponse"];
+        };
+      };
+    };
+  };
+  create: {
     parameters: {
       query?: never;
       header?: never;
       path?: never;
       cookie?: never;
     };
-    requestBody?: never;
+    requestBody?: {
+      content: {
+        "multipart/form-data": {
+          /** Format: binary */
+          dummyCharaImage?: string;
+          request: components["schemas"]["VillageCreateRequest"];
+        };
+      };
+    };
     responses: {
       /** @description OK */
       200: {
@@ -1080,54 +1142,12 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          "*/*": components["schemas"]["JudgeListResponse"];
+          "*/*": components["schemas"]["VillageCreateResponse"];
         };
       };
     };
   };
-  roomAssignment: {
-    parameters: {
-      query: {
-        personNum: number;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["RoomAssignmentResponse"];
-        };
-      };
-    };
-  };
-  list_3: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["CharachipListResponse"];
-        };
-      };
-    };
-  };
-  detail_1: {
+  setting: {
     parameters: {
       query?: never;
       header?: never;
@@ -1144,27 +1164,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          "*/*": components["schemas"]["Charachip"];
-        };
-      };
-    };
-  };
-  me: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "*/*": components["schemas"]["MeResponse"];
+          "*/*": components["schemas"]["VillageSettingView"];
         };
       };
     };

--- a/frontend/app/api/types.ts
+++ b/frontend/app/api/types.ts
@@ -131,6 +131,22 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/villages/{id}/setting": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["setting"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/skills": {
     parameters: {
       query?: never;
@@ -259,18 +275,6 @@ export interface components {
       keyword: string;
       contents: components["schemas"]["RandomContent"][];
     };
-    CampAllocation: {
-      campCode: string | null;
-      /** Format: int32 */
-      minNum: number | null;
-      /** Format: int32 */
-      maxNum?: number | null;
-      /** Format: int32 */
-      allocation: number | null;
-      /** Format: int32 */
-      reincarnationAllocation: number | null;
-      skillAllocation: components["schemas"]["SkillAllocation"][] | null;
-    };
     MessageTypeSayRestrict: {
       messageTypeCode: string | null;
       restrict: boolean | null;
@@ -278,17 +282,6 @@ export interface components {
       length?: number | null;
       /** Format: int32 */
       count?: number | null;
-    };
-    SkillAllocation: {
-      skillCode: string | null;
-      /** Format: int32 */
-      minNum: number | null;
-      /** Format: int32 */
-      maxNum?: number | null;
-      /** Format: int32 */
-      allocation: number | null;
-      /** Format: int32 */
-      reincarnationAllocation: number | null;
     };
     SkillSayRestrict: {
       skillCode: string | null;
@@ -344,15 +337,38 @@ export interface components {
       availableAction: boolean | null;
       randomOrganization: boolean | null;
       organization?: string | null;
-      campAllocationList?: components["schemas"]["CampAllocation"][] | null;
-      wolfAllocation?: components["schemas"]["WolfAllocation"] | null;
+      campAllocationList?: components["schemas"]["VillageCreateRequestCampAllocation"][] | null;
+      wolfAllocation?: components["schemas"]["VillageCreateRequestWolfAllocation"] | null;
       allowedSecretSayCode: string | null;
       sayRestrictList: components["schemas"]["SkillSayRestrict"][] | null;
       skillSayRestrictList: components["schemas"]["MessageTypeSayRestrict"][] | null;
       rpSayRestrictList: components["schemas"]["MessageTypeSayRestrict"][] | null;
       ageLimit?: string | null;
     };
-    WolfAllocation: {
+    VillageCreateRequestCampAllocation: {
+      campCode: string | null;
+      /** Format: int32 */
+      minNum: number | null;
+      /** Format: int32 */
+      maxNum?: number | null;
+      /** Format: int32 */
+      allocation: number | null;
+      /** Format: int32 */
+      reincarnationAllocation: number | null;
+      skillAllocation: components["schemas"]["VillageCreateRequestSkillAllocation"][] | null;
+    };
+    VillageCreateRequestSkillAllocation: {
+      skillCode: string | null;
+      /** Format: int32 */
+      minNum: number | null;
+      /** Format: int32 */
+      maxNum?: number | null;
+      /** Format: int32 */
+      allocation: number | null;
+      /** Format: int32 */
+      reincarnationAllocation: number | null;
+    };
+    VillageCreateRequestWolfAllocation: {
       /** Format: int32 */
       minNum: number | null;
       /** Format: int32 */
@@ -421,6 +437,173 @@ export interface components {
     VillageTag: {
       code: string;
       name: string;
+    };
+    AbilityType: {
+      code: string;
+      name: string;
+      setMessageType: components["schemas"]["MessageType"];
+    };
+    Camp: {
+      code: string;
+      name: string;
+      isFoxs: boolean;
+      isLovers: boolean;
+      isVillagers: boolean;
+      isWolfs: boolean;
+      isCriminals: boolean;
+    };
+    CampAllocation: {
+      camp: components["schemas"]["Camp"];
+      /** Format: int32 */
+      min: number;
+      /** Format: int32 */
+      max?: number | null;
+      /** Format: int32 */
+      initAllocation: number;
+      /** Format: int32 */
+      reincarnationAllocation: number;
+    };
+    MessageType: {
+      code: string;
+      name: string;
+      isOwlViewableType: boolean;
+      isSayType: boolean;
+    };
+    NormalSayRestriction: {
+      skill: components["schemas"]["Skill"];
+      messageType: components["schemas"]["MessageType"];
+      /** Format: int32 */
+      count: number;
+      /** Format: int32 */
+      length: number;
+    };
+    SayRestriction: {
+      normalSayRestriction: components["schemas"]["NormalSayRestriction"][];
+      skillSayRestriction: components["schemas"]["SkillSayRestriction"][];
+    };
+    SecretSayRange: {
+      code: string;
+      name: string;
+    };
+    Skill: {
+      code: string;
+      name: string;
+      shortName: string;
+      histories: components["schemas"]["SkillHistories"];
+      isRequestable: boolean;
+      isWolfCount: boolean;
+      ability?: components["schemas"]["AbilityType"];
+      isNoSound: boolean;
+      isNoDeadByAttack: boolean;
+      isShogiWolf: boolean;
+      isViewableWolfCharaName: boolean;
+      isSayableWerewolfSay: boolean;
+      isFoxCount: boolean;
+      isViewableSympathizeSay: boolean;
+      isDivineResultWolf: boolean;
+      isDeadByDivine: boolean;
+      isCounterDeadByInvestigate: boolean;
+      isOpenSkill: boolean;
+      isViewableTelepathy: boolean;
+      isSayableTelepathy: boolean;
+      isViewableWerewolfSay: boolean;
+      isViewableAttackMessage: boolean;
+      isViewableCoronerMessage: boolean;
+      isViewableLoversSay: boolean;
+      isSayableSympathizeSay: boolean;
+      isViewableFoxMessage: boolean;
+      isViewableGuruMessage: boolean;
+      isViewableInvestigateMessage: boolean;
+      isViewableLoversMessage: boolean;
+      isViewableDivineMessage: boolean;
+      isViewablePsychicMessage: boolean;
+      isViewableWiseMessage: boolean;
+      isNoCount: boolean;
+      isPsychicResultWolf: boolean;
+      isRevivable: boolean;
+      isCounterDeadByDivine: boolean;
+    };
+    SkillAllocation: {
+      skill: components["schemas"]["Skill"];
+      /** Format: int32 */
+      min: number;
+      /** Format: int32 */
+      max?: number | null;
+      /** Format: int32 */
+      initAllocation: number;
+      /** Format: int32 */
+      reincarnationAllocation: number;
+    };
+    SkillHistories: {
+      list: components["schemas"]["SkillHistory"][];
+    };
+    SkillHistory: {
+      skill: unknown;
+      /** Format: int32 */
+      day: number;
+    };
+    SkillSayRestriction: {
+      messageType: components["schemas"]["MessageType"];
+      /** Format: int32 */
+      count: number;
+      /** Format: int32 */
+      length: number;
+    };
+    VillageCharaSetting: {
+      isOriginalCharachip: boolean;
+      /** Format: int32 */
+      dummyCharaId: number;
+      dummyDay1Message?: string | null;
+      charachipIds: number[];
+    };
+    VillageOrganize: {
+      fixedOrganization: string;
+      randomOrganization: components["schemas"]["VillageRandomOrganize"];
+    };
+    VillageRandomOrganize: {
+      skillAllocation: components["schemas"]["SkillAllocation"][];
+      campAllocation: components["schemas"]["CampAllocation"][];
+      wolfAllocation?: components["schemas"]["WolfAllocation"] | null;
+    };
+    VillageRule: {
+      isOpenVote: boolean;
+      isPossibleSkillRequest: boolean;
+      isAvailableSpectate: boolean;
+      isCreatorIsProducer: boolean;
+      isAvailableSameWolfAttack: boolean;
+      isOpenSkillInGrave: boolean;
+      isVisibleGraveSpectateMessage: boolean;
+      isAvailableSuddenlyDeath: boolean;
+      isAvailableCommit: boolean;
+      isAvailableGuardSameTarget: boolean;
+      isAvailableAction: boolean;
+      isRandomOrganization: boolean;
+      isReincarnationSkillAll: boolean;
+      secretSayRange: components["schemas"]["SecretSayRange"];
+    };
+    VillageSettingView: {
+      chara: components["schemas"]["VillageCharaSetting"];
+      /** Format: int32 */
+      personMin: number;
+      /** Format: int32 */
+      personMax: number;
+      /** Format: date-time */
+      startDatetime: string;
+      /** Format: int32 */
+      dayChangeIntervalSeconds: number;
+      rule: components["schemas"]["VillageRule"];
+      organize: components["schemas"]["VillageOrganize"];
+      sayRestriction: components["schemas"]["SayRestriction"];
+      tags: components["schemas"]["VillageTags"];
+    };
+    VillageTags: {
+      list: components["schemas"]["VillageTag"][];
+    };
+    WolfAllocation: {
+      /** Format: int32 */
+      min: number;
+      /** Format: int32 */
+      max?: number | null;
     };
     SimpleSkillView: {
       code: string;
@@ -812,6 +995,28 @@ export interface operations {
         };
         content: {
           "*/*": components["schemas"]["MeResponse"];
+        };
+      };
+    };
+  };
+  setting: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["VillageSettingView"];
         };
       };
     };

--- a/frontend/app/features/villages/api.ts
+++ b/frontend/app/features/villages/api.ts
@@ -33,6 +33,16 @@ export const NOT_FINISHED_STATUSES = [
 export const FINISHED_STATUSES = [VillageStatusCode.completed, VillageStatusCode.canceled];
 
 /**
+ * 進行が終わった (エピローグ/終了/廃村) 村の status code。設定流用の候補で使う
+ * (正本は backend `VillageStatus.notProgressStatusLsit`)。
+ */
+export const NOT_PROGRESS_STATUSES = [
+  VillageStatusCode.epilogue,
+  VillageStatusCode.completed,
+  VillageStatusCode.canceled,
+];
+
+/**
  * 村一覧の絞り込み条件。すべて省略可 (省略時はその軸で絞らない)。
  * - `statuses`: village_status の code 配列 (トップ = 未終了)。
  * - `charachips`: キャラセット (CharaGroup) の id 配列。
@@ -62,6 +72,14 @@ export function fetchVillages(filter: VillageFilter = {}): Promise<VillageListRe
   if (filter.order != null) params.append("order", filter.order);
   const query = params.toString();
   return apiFetch<VillageListResponse>(`/api/v1/villages${query ? `?${query}` : ""}`);
+}
+
+/** 村設定 (`GET /api/v1/villages/{id}/setting`)。入村パスワードのみマスクした生データ。 */
+export type VillageSettingView = components["schemas"]["VillageSettingView"];
+
+/** 村設定を取得する (公開。設定流用などで使う)。 */
+export function fetchVillageSetting(id: number): Promise<VillageSettingView> {
+  return apiFetch<VillageSettingView>(`/api/v1/villages/${id}/setting`);
 }
 
 /** 村作成リクエスト (`POST /api/v1/villages` の JSON part)。 */

--- a/frontend/app/routes/new-village/CharachipSection.tsx
+++ b/frontend/app/routes/new-village/CharachipSection.tsx
@@ -18,10 +18,13 @@ const ORIGINAL_IMAGE_SIZE_MESSAGE = "ダミーキャラ画像は100kByte以内�
 
 /** キャラチップ設定 (キャラチップ利用 / キャラセット / ダミーキャラと発言)。 */
 export function CharachipSection({
+  charaSyncKey,
   originalImageFile,
   originalImageUrl,
   onSelectOriginalImage,
 }: {
+  /** 増えるたびにダミーキャラ由来の項目を選択中キャラへ同期し直す (流用での reset 後など)。 */
+  charaSyncKey: number;
   originalImageFile: File | null;
   originalImageUrl: string | null;
   onSelectOriginalImage: (file: File | null) => void;
@@ -77,17 +80,18 @@ export function CharachipSection({
   };
 
   // キャラ候補が確定/変更されたら選択中ダミーキャラを補正して反映する
-  // (候補に残っていればそのまま、いなければ先頭キャラ)
+  // (候補に残っていればそのまま、いなければ先頭キャラ)。
+  // 読み込み途中の部分的な候補で先頭キャラに誤補正しないよう、全キャラセットの取得完了を待つ
   const charasKey = charas.map((c) => c.id).join(",");
   useEffect(() => {
-    if (charas.length === 0) return;
+    if (isLoading || charas.length === 0) return;
     const manualChanged = manualChangeRef.current;
     manualChangeRef.current = false;
     const currentId = getValues("dummyCharaId");
     const chara = charas.find((c) => c.id === currentId) ?? charas[0];
     applyDummyChara(chara, manualChanged);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [charasKey]);
+  }, [charasKey, charaSyncKey]);
 
   const selectedChara = charas.find((c) => c.id === dummyCharaId);
   const characterSetError = getFieldState("characterSetId", formState).error;

--- a/frontend/app/routes/new-village/DivertSection.tsx
+++ b/frontend/app/routes/new-village/DivertSection.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+
+import { Button } from "~/components/ui/Button";
+import { fieldErrorClass, FormRow } from "~/components/ui/Form";
+import { selectClass } from "~/components/ui/Input";
+import { NOT_PROGRESS_STATUSES } from "~/features/villages/api";
+import { useVillages } from "~/features/villages/useVillages";
+import { SettingSection } from "./fields";
+
+/**
+ * 設定流用。エピローグ/終了/廃村の村を選び、その設定をフォームへ流し込む。
+ * 流し込み本体 (設定取得と reset) は親が行う。
+ */
+export function DivertSection({
+  diverting,
+  errorMessage,
+  onDivert,
+}: {
+  diverting: boolean;
+  errorMessage: string | null;
+  onDivert: (villageId: number) => void;
+}) {
+  const { data } = useVillages({ statuses: NOT_PROGRESS_STATUSES, order: "asc" });
+  const villages = data?.villages ?? [];
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const villageId = selectedId ?? villages[0]?.id ?? null;
+
+  return (
+    <SettingSection title="設定流用">
+      <FormRow label="他の村から流用する" htmlFor="divert-village" labelWidth="wide">
+        <div className="min-[768px]:w-1/3">
+          <select
+            id="divert-village"
+            className={selectClass}
+            value={villageId ?? ""}
+            onChange={(e) => {
+              setSelectedId(Number(e.target.value));
+            }}
+          >
+            {villages.map((v) => (
+              <option key={v.id} value={v.id}>
+                {`${String(v.id).padStart(4, "0")}: ${v.name}`}
+              </option>
+            ))}
+          </select>
+        </div>
+        <p className="mt-[10px]">
+          編集状態は一切保持されず、[村名、開始日時、入村発言、入村パスワード]以外が全て選択した村の設定内容になります。
+          <br />
+          また、選択した村を作成した時点で実装されていない役職については発言制限が無制限になっているので注意してください。
+        </p>
+      </FormRow>
+      {errorMessage && <p className={fieldErrorClass}>{errorMessage}</p>}
+      <div className="mb-[15px] flex justify-end">
+        <Button
+          disabled={villageId == null || diverting}
+          onClick={() => {
+            if (villageId != null) onDivert(villageId);
+          }}
+        >
+          流用する
+        </Button>
+      </div>
+    </SettingSection>
+  );
+}

--- a/frontend/app/routes/new-village/divert.ts
+++ b/frontend/app/routes/new-village/divert.ts
@@ -1,0 +1,114 @@
+import type { VillageSettingView } from "~/features/villages/api";
+import type { SimpleSkillView } from "~/features/skills/api";
+import { addPersonCountPrefix } from "./organization";
+import { createDefaultValues, type NewVillageFormInput } from "./schema";
+
+/**
+ * 流用元の村設定をフォーム値へ変換する (正本は backend `NewVillageForm.override`)。
+ *
+ * 既定値の上に流用元の設定を上書きする形のため、`override` が流用しない項目
+ * (村名・開始日時・入村パスワード・役職希望・ダミーキャラ名/略称/発言) は既定値に戻る。
+ * 流用元の村に存在しない役職・陣営・発言種別の行 (流用元の作成後に実装されたもの) は
+ * 既定値のまま = 発言制限は無制限扱いになる。
+ */
+export function toDivertValues(
+  setting: VillageSettingView,
+  skills: SimpleSkillView[],
+  now: Date,
+): NewVillageFormInput {
+  const defaults = createDefaultValues(skills, now);
+  const random = setting.organize.randomOrganization;
+  const charaValues = setting.chara.isOriginalCharachip
+    ? {}
+    : {
+        characterSetId: setting.chara.charachipIds,
+        dummyCharaId: setting.chara.dummyCharaId,
+      };
+  const welcomeTag = setting.tags.list.find(
+    (t) => t.code === "ANYONE_WELCOME" || t.code === "RELATIVES_ONLY",
+  );
+  const ageTag = setting.tags.list.find((t) => t.code === "R15" || t.code === "R18");
+  return {
+    ...defaults,
+    startPersonMinNum: setting.personMin,
+    personMaxNum: setting.personMax,
+    dayChangeIntervalHours: Math.floor(setting.dayChangeIntervalSeconds / 3600),
+    dayChangeIntervalMinutes: Math.floor((setting.dayChangeIntervalSeconds % 3600) / 60),
+    dayChangeIntervalSeconds: setting.dayChangeIntervalSeconds % 60,
+    shouldOriginalImage: setting.chara.isOriginalCharachip,
+    ...charaValues,
+    openVote: setting.rule.isOpenVote,
+    availableSameWolfAttack: setting.rule.isAvailableSameWolfAttack,
+    openSkillInGrave: setting.rule.isOpenSkillInGrave,
+    visibleGraveSpectateMessage: setting.rule.isVisibleGraveSpectateMessage,
+    allowedSecretSayCode: setting.rule.secretSayRange
+      .code as NewVillageFormInput["allowedSecretSayCode"],
+    availableSpectate: setting.rule.isAvailableSpectate,
+    creatorIsProducer: setting.rule.isCreatorIsProducer,
+    availableSuddonlyDeath: setting.rule.isAvailableSuddenlyDeath,
+    availableCommit: setting.rule.isAvailableCommit,
+    availableGuardSameTarget: setting.rule.isAvailableGuardSameTarget,
+    availableAction: setting.rule.isAvailableAction,
+    organization: addPersonCountPrefix(setting.organize.fixedOrganization),
+    randomOrganization: setting.rule.isRandomOrganization,
+    reincarnationSkillAll: setting.rule.isReincarnationSkillAll,
+    campAllocationList: defaults.campAllocationList.map((camp) => {
+      const dbCamp = random.campAllocation.find((c) => c.camp.code === camp.campCode);
+      return {
+        ...camp,
+        minNum: dbCamp?.min ?? 0,
+        maxNum: dbCamp?.max ?? null,
+        allocation: dbCamp?.initAllocation ?? 0,
+        reincarnationAllocation: dbCamp?.reincarnationAllocation ?? 50,
+        skillAllocation: camp.skillAllocation.map((skill) => {
+          const dbSkill = random.skillAllocation.find((s) => s.skill.code === skill.skillCode);
+          return {
+            ...skill,
+            minNum: dbSkill?.min ?? 0,
+            maxNum: dbSkill?.max ?? null,
+            allocation: dbSkill?.initAllocation ?? 0,
+            reincarnationAllocation: dbSkill?.reincarnationAllocation ?? 50,
+          };
+        }),
+      };
+    }),
+    // 流用元に人狼数配分が無い場合は既定値のまま (固定編成の村など)
+    wolfAllocation: random.wolfAllocation
+      ? { minNum: random.wolfAllocation.min, maxNum: random.wolfAllocation.max ?? null }
+      : defaults.wolfAllocation,
+    sayRestrictList: defaults.sayRestrictList.map((row) => {
+      const restrict = setting.sayRestriction.normalSayRestriction.find(
+        (r) => r.skill.code === row.skillCode,
+      );
+      return {
+        ...row,
+        restrict: restrict != null,
+        count: restrict?.count ?? 20,
+        length: restrict?.length ?? 400,
+      };
+    }),
+    skillSayRestrictList: defaults.skillSayRestrictList.map((row) =>
+      overrideMessageTypeRestrict(row, setting),
+    ),
+    rpSayRestrictList: defaults.rpSayRestrictList.map((row) =>
+      overrideMessageTypeRestrict(row, setting),
+    ),
+    welcomeRange: (welcomeTag?.code ?? "") as NewVillageFormInput["welcomeRange"],
+    ageLimit: (ageTag?.code ?? "") as NewVillageFormInput["ageLimit"],
+  };
+}
+
+function overrideMessageTypeRestrict(
+  row: NewVillageFormInput["skillSayRestrictList"][number],
+  setting: VillageSettingView,
+): NewVillageFormInput["skillSayRestrictList"][number] {
+  const restrict = setting.sayRestriction.skillSayRestriction.find(
+    (r) => r.messageType.code === row.messageTypeCode,
+  );
+  return {
+    ...row,
+    restrict: restrict != null,
+    count: restrict?.count ?? 20,
+    length: restrict?.length ?? 400,
+  };
+}

--- a/frontend/app/routes/new-village/divert.ts
+++ b/frontend/app/routes/new-village/divert.ts
@@ -9,7 +9,8 @@ import { createDefaultValues, type NewVillageFormInput } from "./schema";
  * 既定値の上に流用元の設定を上書きする形のため、`override` が流用しない項目
  * (村名・開始日時・入村パスワード・役職希望・ダミーキャラ名/略称/発言) は既定値に戻る。
  * 流用元の村に存在しない役職・陣営・発言種別の行 (流用元の作成後に実装されたもの) は
- * 既定値のまま = 発言制限は無制限扱いになる。
+ * `override` と同じフォールバックになる: 発言制限は無制限扱い、闇鍋配分は
+ * min 0 / max なし / 出現割合 0 / 転生配分 50。
  */
 export function toDivertValues(
   setting: VillageSettingView,

--- a/frontend/app/routes/new-village/route.tsx
+++ b/frontend/app/routes/new-village/route.tsx
@@ -10,7 +10,7 @@ import { PageLayout } from "~/components/layout/PageLayout";
 import { RequireAuth } from "~/features/auth/RequireAuth";
 import type { SimpleSkillView } from "~/features/skills/api";
 import { useSkillList } from "~/features/skills/useSkillList";
-import { createVillage } from "~/features/villages/api";
+import { createVillage, fetchVillageSetting } from "~/features/villages/api";
 import { ApiError } from "~/lib/api";
 import { siteMeta } from "~/lib/meta";
 import { zodResolver } from "~/lib/zodResolver";
@@ -19,6 +19,8 @@ import { CharachipSection } from "./CharachipSection";
 import { ConfirmModal } from "./ConfirmModal";
 import { toCreateRequest } from "./createRequest";
 import { DetailRuleSection } from "./DetailRuleSection";
+import { toDivertValues } from "./divert";
+import { DivertSection } from "./DivertSection";
 import { RequiredAfterCreationMark } from "./fields";
 import { RelativesSection, RpSection, SpecialRuleSection, SpectateSection } from "./OtherSections";
 import {
@@ -70,6 +72,11 @@ function NewVillageForm({ skills }: { skills: SimpleSkillView[] }) {
   const [originalImageFile, setOriginalImageFile] = useState<File | null>(null);
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
+  const [diverting, setDiverting] = useState(false);
+  const [divertError, setDivertError] = useState<string | null>(null);
+  // 流用などプログラム的にフォームを書き換えた後、ダミーキャラ由来の項目 (画像・名前・
+  // 略称・既定発言) を確認ダイアログなしで同期し直すためのキー
+  const [charaSyncKey, setCharaSyncKey] = useState(0);
 
   // オリジナル画像のプレビュー URL。選び直したら古い URL を破棄する
   const originalImageUrl = useMemo(
@@ -86,6 +93,21 @@ function NewVillageForm({ skills }: { skills: SimpleSkillView[] }) {
     setCreateError(null);
     setConfirmValues(values);
   });
+
+  const divert = async (villageId: number) => {
+    setDiverting(true);
+    setDivertError(null);
+    try {
+      const setting = await fetchVillageSetting(villageId);
+      form.reset(toDivertValues(setting, skills, new Date()));
+      setOriginalImageFile(null);
+      setCharaSyncKey((key) => key + 1);
+    } catch {
+      setDivertError("村設定の取得に失敗しました。時間をおいて再度お試しください。");
+    } finally {
+      setDiverting(false);
+    }
+  };
 
   const create = async () => {
     if (!confirmValues) return;
@@ -116,9 +138,11 @@ function NewVillageForm({ skills }: { skills: SimpleSkillView[] }) {
           <RequiredAfterCreationMark /> のついている項目は村作成後に変更できません。
         </p>
         <FormProvider {...form}>
+          <DivertSection diverting={diverting} errorMessage={divertError} onDivert={divert} />
           <form noValidate onSubmit={openConfirm}>
             <BasicSection nowYear={nowYear} />
             <CharachipSection
+              charaSyncKey={charaSyncKey}
               originalImageFile={originalImageFile}
               originalImageUrl={originalImageUrl}
               onSelectOriginalImage={setOriginalImageFile}


### PR DESCRIPTION
closes .issues/step-7.5-divert.md

## 概要

Step 7 (新規村作成) の最終サブ step。終了村 (エピローグ/終了/廃村) の設定をコピーして新規村フォームの初期値にする「設定流用」を REST + React 化。

## backend

- **`GET /api/v1/villages/{id}/setting` 新設** (permitAll、404 は `not_found`)。`VillageSettingView` はドメイン `VillageSetting` から**非公開の入村パスワードのみ除外**して直返し (REST API 設計方針: マスクが要る場合のみ Response DTO)
- **spec スキーマ名衝突の解消**: `VillageCreateRequest` のネスト DTO (`CampAllocation`/`SkillAllocation`/`WolfAllocation`) がドメイン `VillageRandomOrganize` のネスト型と単純名衝突し、SpringDoc が片方の定義で上書きしていた (response スキーマが request の形で生成される実バグ)。request 側に `@Schema(name = "VillageCreateRequestXxx")` を付与
- 流用候補一覧は既存 `GET /api/v1/villages?status=...&order=asc` を流用 (新設なし)

## frontend

- `/new-village` 最上部に**設定流用セクション** (`0123: 村名` 形式の終了村セレクト + 案内文 + 流用ボタン)
- 流用 = 設定 API 取得 → **`NewVillageForm.override` 相当の変換** (`divert.ts`) → `form.reset()`。override が流用しない項目 (村名・開始日時・入村パスワード・役職希望・ダミーキャラ名/略称/発言) は既定値に戻る。流用元に無い役職の発言制限は無制限 (legacy 案内文どおり)
- **`charaSyncKey`**: 流用 reset 後にダミーキャラ由来の項目 (画像・名前・略称・既定発言) を confirm なしで再同期 (legacy のページ再読込相当)。あわせてキャラ候補の部分読み込み中に先頭キャラへ誤補正する潜在問題を `isLoading` ガードで防止

## 検証

- backend `./gradlew test ktlintCheck` green (単体 2 件追加: 値写し + joinPassword 非露出)
- frontend typecheck / lint / format:check / build green、`pnpm gen:api` 再生成 commit 済
- **e2e 全 46 件 green** (流用シナリオ 1 件追加。流用候補が無い DB では skip)
- **`:8091` 突合**: master で特徴的な設定の村 (闇鍋・発言制限・R18 身内・パスワード付き) を作成→廃村化し、legacy `new-village/divert/{id}` と React 版の流用結果を全項目比較で一致確認 (役職希望が流用されない override の挙動も一致)。視覚も `:8091` に合わせ select 幅 1/3
- **意図的な差異 2 点**: (1) legacy はロード時に先頭キャラ (ゲルト) の既定発言が残留する quirk があり (選択ダミーキャラがモーリッツでもゲルトの発言が入る)、React 版は選択キャラの既定発言のみ自動入力。(2) 更新間隔の秒は select が 10 秒刻みのため、API 直叩きでしか作れない端数秒 (45 等) は legacy=0 扱い / React=値は保持して表示は空 (UI 経由の村では発生しない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)