### PR TITLE
feat: 村画面ベースを REST + React 化 (step-8.1)

### DIFF
--- a/.github/workflows/api-drift.yml
+++ b/.github/workflows/api-drift.yml
@@ -5,7 +5,8 @@ name: api-drift
 # 差分が出たら frontend で `pnpm gen:api` を実行して commit すれば解消する。
 on:
   pull_request:
-    branches: [feature/monorepo]
+    # feature/monorepo-step8 は村画面 (Step 8) の統合ブランチ。サブ step の PR でも drift を検知する
+    branches: [feature/monorepo, feature/monorepo-step8]
     paths:
       - backend/**
       - frontend/app/api/**

--- a/.issues/README.md
+++ b/.issues/README.md
@@ -24,7 +24,9 @@ monorepo 移行作業中につき **階層番号方式** (`step-<N>(.M)-<slug>.m
 
 | # | タイトル | type | status |
 | --- | --- | --- | --- |
-| (現在 open な Issue なし) | | | |
+| step-8.1 | 村画面ベース (レイアウト / 日付ナビ / 状況サマリ / ポーリング + situation 二層マスク基盤) | enhancement | open |
+
+> **Step 8 は統合ブランチ方式 (ユーザー指示 2026-06-12)**: `feature/monorepo-step8` を base にサブ step PR を積み、同ブランチへの squash merge は Claude 単独で可。`feature/monorepo` への merge は最終 PR でユーザー承認。
 
 > **Step 0・1・2 完了** 🎉 — Step 1 は `.java-version` 21 化 / README 整備 (PR #46)。
 > **Step 2 (monorepo 化) は 4 サブ step すべて完了**: 2.1 backend/ 移動 (PR #47 ✅) / 2.2 ktlint+hook+per-dir .gitignore (PR #48 ✅) / 2.3 frontend 雛形 (PR #49 ✅) / 2.4 e2e 雛形 (PR #50 ✅)。次は **Step 3 (認証 REST 化)**。

--- a/backend/src/main/kotlin/com/ort/app/api/village/VillageRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/VillageRestController.kt
@@ -25,6 +25,7 @@ import com.ort.app.fw.exception.WolfMansionBusinessException
 import com.ort.app.fw.exception.WolfMansionValidationException
 import com.ort.app.fw.exception.WolfMansionValidationException.FieldErrorItem
 import com.ort.app.fw.security.jwt.JwtPrincipal
+import io.swagger.v3.oas.annotations.Operation
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.context.MessageSource
 import org.springframework.http.HttpStatus
@@ -68,7 +69,12 @@ class VillageRestController(
         @ParameterObject request: VillageSearchRequest,
     ): VillageListResponse = VillageListResponse(villageService.findVillages(request.toQuery()))
 
-    /** 村詳細。公開情報のみ (入村パスワードは [VillageSettingView] が除外)。 */
+    /**
+     * 村詳細。公開情報のみ (入村パスワードは [VillageSettingView] が除外)。
+     * operationId は明示する (`detail`/`update` は他 Controller と単純名が衝突し、
+     * SpringDoc の自動連番が探索順で揺れて spec の不要差分になるため)。
+     */
+    @Operation(operationId = "getVillage")
     @GetMapping("/{id}")
     fun detail(
         @PathVariable id: Int,
@@ -78,6 +84,7 @@ class VillageRestController(
      * 村状況 (状況サマリ)。村全体の現況のため認証不要だが、ログインしていれば
      * スポイラーマスク (役職・能力欄・足音の表示形式) に視点を反映する。
      */
+    @Operation(operationId = "getVillageSituation")
     @GetMapping("/{id}/situation")
     fun situation(
         @AuthenticationPrincipal principal: JwtPrincipal?,
@@ -114,6 +121,7 @@ class VillageRestController(
     }
 
     /** 参加者本人の状態 (capability)。ログインユーザー固有のため認証必須。 */
+    @Operation(operationId = "getMyVillageSituation")
     @GetMapping("/{id}/situation/me")
     fun mySituation(
         @AuthenticationPrincipal principal: JwtPrincipal?,
@@ -150,6 +158,7 @@ class VillageRestController(
      * 応答の latestDay は日付更新前に取得した村のもので、更新が起きた場合は次回ポーリングで
      * 新しい日付を返す。
      */
+    @Operation(operationId = "updateVillage")
     @PostMapping("/{id}/update")
     fun update(
         @AuthenticationPrincipal principal: JwtPrincipal?,

--- a/backend/src/main/kotlin/com/ort/app/api/village/VillageRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/VillageRestController.kt
@@ -3,14 +3,25 @@ package com.ort.app.api.village
 import com.ort.app.api.request.validator.NewVillageFormValidator
 import com.ort.app.api.village.request.VillageCreateRequest
 import com.ort.app.api.village.request.VillageSearchRequest
+import com.ort.app.api.village.response.ParticipantSituationView
 import com.ort.app.api.village.response.VillageCreateResponse
+import com.ort.app.api.village.response.VillageDetailView
 import com.ort.app.api.village.response.VillageListResponse
 import com.ort.app.api.village.response.VillageSettingView
+import com.ort.app.api.village.response.VillageSituationView
+import com.ort.app.api.village.response.VillageUpdateResponse
+import com.ort.app.application.coordinator.DaychangeCoordinator
 import com.ort.app.application.coordinator.VillageCoordinator
+import com.ort.app.application.service.AbilityService
 import com.ort.app.application.service.CharaService
+import com.ort.app.application.service.FootstepApplicationService
 import com.ort.app.application.service.PlayerService
 import com.ort.app.application.service.VillageService
+import com.ort.app.application.service.VoteApplicationService
+import com.ort.app.domain.model.village.Village
+import com.ort.app.domain.service.SpoilerDomainService
 import com.ort.app.fw.exception.WolfMansionAuthException
+import com.ort.app.fw.exception.WolfMansionBusinessException
 import com.ort.app.fw.exception.WolfMansionValidationException
 import com.ort.app.fw.exception.WolfMansionValidationException.FieldErrorItem
 import com.ort.app.fw.security.jwt.JwtPrincipal
@@ -25,6 +36,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
@@ -41,8 +53,13 @@ import java.util.Locale
 class VillageRestController(
     private val villageService: VillageService,
     private val villageCoordinator: VillageCoordinator,
+    private val daychangeCoordinator: DaychangeCoordinator,
     private val playerService: PlayerService,
     private val charaService: CharaService,
+    private val voteService: VoteApplicationService,
+    private val footstepService: FootstepApplicationService,
+    private val abilityService: AbilityService,
+    private val spoilerDomainService: SpoilerDomainService,
     private val newVillageFormValidator: NewVillageFormValidator,
     private val messageSource: MessageSource,
 ) {
@@ -51,6 +68,103 @@ class VillageRestController(
         @ParameterObject request: VillageSearchRequest,
     ): VillageListResponse = VillageListResponse(villageService.findVillages(request.toQuery()))
 
+    /** 村詳細。公開情報のみ (入村パスワードは [VillageSettingView] が除外)。 */
+    @GetMapping("/{id}")
+    fun detail(
+        @PathVariable id: Int,
+    ): VillageDetailView = VillageDetailView(findVillageOrThrow(id))
+
+    /**
+     * 村状況 (状況サマリ)。村全体の現況のため認証不要だが、ログインしていれば
+     * スポイラーマスク (役職・能力欄・足音の表示形式) に視点を反映する。
+     */
+    @GetMapping("/{id}/situation")
+    fun situation(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+        @RequestParam(required = false) day: Int?,
+    ): VillageSituationView {
+        val village = findVillageOrThrow(id)
+        val targetDay = resolveDay(village, day)
+        val myself = principal?.let { villageService.findVillageParticipant(village.id, it.name) }
+        val player = principal?.let { playerService.findPlayer(it.name) }
+        val votes = voteService.findVotes(village.id)
+        val footsteps = footstepService.findFootsteps(village.id)
+        val abilities = abilityService.findAbilities(village.id)
+        val charachips =
+            village.setting.chara.let { charaService.findCharachips(it.charachipIds, it.isOriginalCharachip) }
+        val villageSituation =
+            villageCoordinator.findVillageSituation(
+                village = village,
+                myself = myself,
+                votes = votes,
+                abilities = abilities,
+                footsteps = footsteps,
+                day = targetDay,
+            )
+        return VillageSituationView(
+            village = village,
+            day = targetDay,
+            villageSituation = villageSituation,
+            charachips = charachips,
+            myself = myself,
+            player = player,
+            isViewableSpoilerContent = spoilerDomainService.isViewableSpoilerContent(village, myself),
+        )
+    }
+
+    /** 参加者本人の状態 (capability)。ログインユーザー固有のため認証必須。 */
+    @GetMapping("/{id}/situation/me")
+    fun mySituation(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+        @RequestParam(required = false) day: Int?,
+    ): ParticipantSituationView {
+        // principal は filter chain の authenticated() で保証済み (到達時は非 null)。防御的に確認する
+        principal ?: throw WolfMansionAuthException("ログインしてください")
+        val village = findVillageOrThrow(id)
+        val targetDay = resolveDay(village, day)
+        val myself = villageService.findVillageParticipant(village.id, principal.name)
+        val votes = voteService.findVotes(village.id)
+        val footsteps = footstepService.findFootsteps(village.id)
+        val abilities = abilityService.findAbilities(village.id)
+        val charachips =
+            village.setting.chara.let { charaService.findCharachips(it.charachipIds, it.isOriginalCharachip) }
+        return ParticipantSituationView(
+            villageCoordinator.findParticipantSituation(
+                village = village,
+                username = principal.name,
+                myself = myself,
+                votes = votes,
+                abilities = abilities,
+                footsteps = footsteps,
+                charachips = charachips,
+                day = targetDay,
+            ),
+        )
+    }
+
+    /**
+     * 村ポーリング。最終アクセス日時の更新と、更新時刻を過ぎていた場合の日付更新を行う
+     * (日付更新は本番でもポーリング駆動)。匿名の閲覧者もポーリングするため認証不要。
+     * 応答の latestDay は日付更新前に取得した村のもので、更新が起きた場合は次回ポーリングで
+     * 新しい日付を返す。
+     */
+    @PostMapping("/{id}/update")
+    fun update(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+    ): VillageUpdateResponse {
+        val village =
+            villageService.findVillage(id, excludeGone = false)
+                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "village not found")
+        principal
+            ?.let { villageService.findVillageParticipant(village.id, it.name) }
+            ?.let { villageService.updateLastAccessDatetime(it) }
+        daychangeCoordinator.changeDayIfNeeded(village)
+        return VillageUpdateResponse(latestDay = village.latestDay())
+    }
+
     /** 村設定。村画面で公開されている情報のため認証不要 (入村パスワードのみマスク)。 */
     @GetMapping("/{id}/setting")
     fun setting(
@@ -58,6 +172,22 @@ class VillageRestController(
     ): VillageSettingView =
         villageService.findVillage(id)?.let { VillageSettingView(it.setting) }
             ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "village not found")
+
+    private fun findVillageOrThrow(id: Int): Village =
+        villageService.findVillage(id)
+            ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "village not found")
+
+    /** 表示対象日。省略時は最新日、存在しない日は 400。 */
+    private fun resolveDay(
+        village: Village,
+        day: Int?,
+    ): Int {
+        day ?: return village.latestDay()
+        if (village.days.list.none { it.day == day }) {
+            throw WolfMansionBusinessException("存在しない日付です: $day")
+        }
+        return day
+    }
 
     /**
      * 村作成。multipart/form-data で JSON part (`request`) + オリジナルダミーキャラ画像

--- a/backend/src/main/kotlin/com/ort/app/api/village/response/ParticipantSituationView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/response/ParticipantSituationView.kt
@@ -1,0 +1,143 @@
+package com.ort.app.api.village.response
+
+import com.ort.app.domain.model.situation.ParticipantSituation
+import com.ort.app.domain.model.village.participant.VillageParticipant
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 参加者本人の状態 (ログインユーザー固有の capability)。認証必須 API でのみ返す。
+ * どの操作 UI を表示してよいかのフラグを担い、各操作の入力候補 (対象リスト等) は
+ * その操作の API を実装する際に追加する。
+ *
+ * ネスト DTO はドメインの situation と単純名が衝突しないよう `@Schema` で命名する
+ * (衝突すると SpringDoc がスキーマ定義を上書きしてしまう)。
+ */
+data class ParticipantSituationView(
+    /** 参加している場合の自分自身 (未参加は null) */
+    val myself: MyselfView?,
+    val participate: ParticipateView,
+    val skillRequest: SkillRequestView,
+    val commit: CommitView,
+    val say: SayView,
+    val rp: RpView,
+    val ability: AbilityView,
+    val vote: VoteView,
+    val admin: AdminView,
+    val creator: CreatorView,
+) {
+    constructor(situation: ParticipantSituation) : this(
+        myself = situation.participate.myself?.let { MyselfView(it) },
+        participate = ParticipateView(situation),
+        skillRequest = SkillRequestView(isAvailableSkillRequest = situation.skillRequest.isAvailableSkillRequest),
+        commit =
+            CommitView(
+                isAvailableCommit = situation.commit.isAvailableCommit,
+                isCommitting = situation.commit.isCommitting,
+            ),
+        say = SayView(isAvailableSay = situation.say.isAvailableSay),
+        rp =
+            RpView(
+                isAvailableChangeName = situation.rp.isAvailableChangeName,
+                isAvailableMemo = situation.rp.isAvailableMemo,
+                canAddImage = situation.rp.canAddImage,
+            ),
+        ability = AbilityView(canUseAbility = situation.ability.canUseAbility),
+        vote = VoteView(canVote = situation.vote.canVote),
+        admin = AdminView(isAdmin = situation.admin.isAdmin),
+        creator = CreatorView(situation),
+    )
+
+    @Schema(name = "ParticipantSituationViewMyself")
+    data class MyselfView(
+        val id: Int,
+        val charaId: Int,
+        /** 部屋番号付きの表示名 */
+        val name: String,
+        val shortName: String,
+        val isDead: Boolean,
+        val isSpectator: Boolean,
+    ) {
+        constructor(myself: VillageParticipant) : this(
+            id = myself.id,
+            charaId = myself.charaId,
+            name = myself.name(),
+            shortName = myself.shortName(),
+            isDead = myself.dead.isDead,
+            isSpectator = myself.isSpectator,
+        )
+    }
+
+    @Schema(name = "ParticipantSituationViewParticipate")
+    data class ParticipateView(
+        val isParticipating: Boolean,
+        val isAvailableParticipate: Boolean,
+        val isAvailableSpectate: Boolean,
+        val isAvailableSwitchParticipate: Boolean,
+        val isAvailableLeave: Boolean,
+    ) {
+        constructor(situation: ParticipantSituation) : this(
+            isParticipating = situation.participate.isParticipating,
+            isAvailableParticipate = situation.participate.isAvailableParticipate,
+            isAvailableSpectate = situation.participate.isAvailableSpectate,
+            isAvailableSwitchParticipate = situation.participate.isAvailableSwitchParticipate,
+            isAvailableLeave = situation.participate.isAvailableLeave,
+        )
+    }
+
+    @Schema(name = "ParticipantSituationViewSkillRequest")
+    data class SkillRequestView(
+        val isAvailableSkillRequest: Boolean,
+    )
+
+    @Schema(name = "ParticipantSituationViewCommit")
+    data class CommitView(
+        val isAvailableCommit: Boolean,
+        val isCommitting: Boolean,
+    )
+
+    @Schema(name = "ParticipantSituationViewSay")
+    data class SayView(
+        val isAvailableSay: Boolean,
+    )
+
+    @Schema(name = "ParticipantSituationViewRp")
+    data class RpView(
+        val isAvailableChangeName: Boolean,
+        val isAvailableMemo: Boolean,
+        val canAddImage: Boolean,
+    )
+
+    @Schema(name = "ParticipantSituationViewAbility")
+    data class AbilityView(
+        val canUseAbility: Boolean,
+    )
+
+    @Schema(name = "ParticipantSituationViewVote")
+    data class VoteView(
+        val canVote: Boolean,
+    )
+
+    @Schema(name = "ParticipantSituationViewAdmin")
+    data class AdminView(
+        val isAdmin: Boolean,
+    )
+
+    @Schema(name = "ParticipantSituationViewCreator")
+    data class CreatorView(
+        val isCreator: Boolean,
+        val isAvailableCreatorSay: Boolean,
+        val isAvailableCancelVillage: Boolean,
+        val isAvailableKick: Boolean,
+        val isAvailableModifySetting: Boolean,
+        val isAvailableExtendEpilogue: Boolean,
+    ) {
+        constructor(situation: ParticipantSituation) : this(
+            isCreator = situation.creator.isCreator,
+            isAvailableCreatorSay = situation.creator.isAvailableCreatorSay,
+            isAvailableCancelVillage = situation.creator.isAvailableCancelVillage,
+            isAvailableKick = situation.creator.isAvailableKick,
+            isAvailableModifySetting = situation.creator.isAvailableModifySetting,
+            isAvailableExtendEpilogue = situation.creator.isAvailableExtendEpilogue,
+        )
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/village/response/VillageDetailView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/response/VillageDetailView.kt
@@ -1,0 +1,31 @@
+package com.ort.app.api.village.response
+
+import com.ort.app.domain.model.village.Village
+import com.ort.app.domain.model.village.VillageDays
+import com.ort.app.domain.model.village.VillageStatus
+import com.ort.app.domain.model.village.room.RoomSize
+
+/**
+ * 村詳細。ドメインの [Village] から、ビューアに依らず公開してよい情報のみを返す。
+ * 入村パスワードは [VillageSettingView] が除外する。参加者まわりは視点依存マスクが
+ * 必要なため村状況 API (VillageSituationView) が担い、本ビューには含めない。
+ */
+data class VillageDetailView(
+    val id: Int,
+    val name: String,
+    val status: VillageStatus,
+    val days: VillageDays,
+    val epilogueDay: Int?,
+    val roomSize: RoomSize?,
+    val setting: VillageSettingView,
+) {
+    constructor(village: Village) : this(
+        id = village.id,
+        name = village.name,
+        status = village.status,
+        days = village.days,
+        epilogueDay = village.epilogueDay,
+        roomSize = village.roomSize,
+        setting = VillageSettingView(village.setting),
+    )
+}

--- a/backend/src/main/kotlin/com/ort/app/api/village/response/VillageSituationView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/response/VillageSituationView.kt
@@ -1,0 +1,65 @@
+package com.ort.app.api.village.response
+
+import com.ort.app.api.view.VillageContent
+import com.ort.app.api.view.village.VillageMemberContent
+import com.ort.app.api.view.village.VillageRoomAssignedRow
+import com.ort.app.domain.model.chara.Charachips
+import com.ort.app.domain.model.player.Player
+import com.ort.app.domain.model.situation.VillageSituation
+import com.ort.app.domain.model.village.Village
+import com.ort.app.domain.model.village.participant.VillageParticipant
+
+/**
+ * 村状況 (誰が取得しても同じ村全体の現況)。状況サマリの部屋割り / 参加者 / 投票 / 足音 /
+ * 日別状況に対応する。
+ *
+ * 視点依存のスポイラーマスクは backend で適用済みのデータのみを返す:
+ * - 部屋割りの役職名は [VillageRoomAssignedRow] が可視判定して null に倒す
+ * - 足音・日別状況の能力欄・投票の隠蔽日は domain service が可視判定して整形する
+ * フィールド構成はテンプレート向けの [VillageContent] の実フィールドを正本とする。
+ */
+data class VillageSituationView(
+    /** 部屋割り行 (部屋なし村は null) */
+    val roomAssignedRowList: List<VillageRoomAssignedRow>?,
+    /** 部屋の横サイズ */
+    val roomWidth: Int?,
+    /** ステータス別の参加者一覧 */
+    val memberList: List<VillageMemberContent>,
+    /** 投票表 (3日目以降のみ) */
+    val vote: VillageContent.VillageVoteContent?,
+    /** 日別の足音 */
+    val footstepList: List<VillageContent.VillageFootstepContent>,
+    /** 日別状況 (突然死/処刑/犠牲/復活/後追/能力) */
+    val situationList: List<VillageContent.VillageSituationContent>,
+    /** このビューアにスポイラー (役職・能力欄など) を表示してよいか */
+    val isViewableSpoilerContent: Boolean,
+) {
+    constructor(
+        village: Village,
+        day: Int,
+        villageSituation: VillageSituation,
+        charachips: Charachips,
+        myself: VillageParticipant?,
+        player: Player?,
+        isViewableSpoilerContent: Boolean,
+    ) : this(
+        roomAssignedRowList =
+            village.roomSize?.let { roomSize ->
+                List(roomSize.height) { columnIndex ->
+                    VillageRoomAssignedRow(village, day, columnIndex, charachips, myself, player)
+                }
+            },
+        roomWidth = village.roomSize?.width,
+        memberList =
+            villageSituation.live.list.map {
+                VillageMemberContent(
+                    status = it.status,
+                    statusMemberList = it.list.map { participant -> VillageMemberContent.VillageMemberDetailContent(participant) },
+                )
+            },
+        vote = if (day > 2) VillageContent.VillageVoteContent(village, villageSituation) else null,
+        footstepList = villageSituation.footstep.list.map { VillageContent.VillageFootstepContent(it.day, it.footstep) },
+        situationList = villageSituation.whole.list.map { VillageContent.VillageSituationContent(it) },
+        isViewableSpoilerContent = isViewableSpoilerContent,
+    )
+}

--- a/backend/src/main/kotlin/com/ort/app/api/village/response/VillageUpdateResponse.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/response/VillageUpdateResponse.kt
@@ -1,0 +1,10 @@
+package com.ort.app.api.village.response
+
+/**
+ * 村ポーリングの応答。クライアントは既知の最新日と比較して日付更新を検知する。
+ * 日付更新の判定・実行はサーバ側 (ポーリング駆動の daychange) が行うため、
+ * 本応答は検知に必要な最新日のみを返す。
+ */
+data class VillageUpdateResponse(
+    val latestDay: Int,
+)

--- a/backend/src/main/kotlin/com/ort/app/fw/security/WolfMansionWebSecurityConfig.kt
+++ b/backend/src/main/kotlin/com/ort/app/fw/security/WolfMansionWebSecurityConfig.kt
@@ -42,12 +42,15 @@ class WolfMansionWebSecurityConfig {
                         "/api/v1/auth/refresh",
                         "/api/v1/auth/logout",
                     ).permitAll()
-                    // 村一覧・キャラセット一覧・役職一覧・ルール情報・ランダムキーワードの閲覧は公開情報
-                    // (ランダムキーワードの書き込み系はログイン必須のため GET のみ)
+                    // 村一覧・村詳細・村状況・キャラセット一覧・役職一覧・ルール情報・ランダムキーワードの
+                    // 閲覧は公開情報 (ランダムキーワードの書き込み系はログイン必須のため GET のみ)。
+                    // 村状況はログイン時のみ視点をマスクに反映する (JWT filter が principal を積む)
                     .requestMatchers(
                         org.springframework.http.HttpMethod.GET,
                         "/api/v1/villages",
+                        "/api/v1/villages/{id}",
                         "/api/v1/villages/{id}/setting",
+                        "/api/v1/villages/{id}/situation",
                         "/api/v1/charachips",
                         "/api/v1/charachips/{id}",
                         "/api/v1/rooms",
@@ -56,6 +59,11 @@ class WolfMansionWebSecurityConfig {
                         "/api/v1/rule/judges",
                         "/api/v1/random-keywords",
                         "/api/v1/random-keywords/{id}",
+                    ).permitAll()
+                    // 村ポーリングは匿名の閲覧者も日付更新を駆動するため公開
+                    .requestMatchers(
+                        org.springframework.http.HttpMethod.POST,
+                        "/api/v1/villages/{id}/update",
                     ).permitAll()
                     .anyRequest()
                     .authenticated()

--- a/backend/src/test/kotlin/com/ort/app/api/village/response/ParticipantSituationViewTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/api/village/response/ParticipantSituationViewTest.kt
@@ -1,0 +1,127 @@
+package com.ort.app.api.village.response
+
+import com.ort.app.domain.model.message.MessageType
+import com.ort.app.domain.model.situation.ParticipantSituation
+import com.ort.app.domain.model.situation.participant.ParticipantAbilitySituation
+import com.ort.app.domain.model.situation.participant.ParticipantAdminSituation
+import com.ort.app.domain.model.situation.participant.ParticipantCommitSituation
+import com.ort.app.domain.model.situation.participant.ParticipantCreatorSituation
+import com.ort.app.domain.model.situation.participant.ParticipantParticipateSituation
+import com.ort.app.domain.model.situation.participant.ParticipantRpSituation
+import com.ort.app.domain.model.situation.participant.ParticipantSaySituation
+import com.ort.app.domain.model.situation.participant.ParticipantSkillRequestSituation
+import com.ort.app.domain.model.situation.participant.ParticipantVoteSituation
+import com.ort.app.domain.model.skill.Skill
+import com.ort.app.domain.model.village.createVillageParticipant
+import com.ort.dbflute.allcommon.CDef
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class ParticipantSituationViewTest {
+    @Test
+    fun `未参加でもフラグがそのまま写像される`() {
+        val view = ParticipantSituationView(createSituation(myselfParticipant = null))
+
+        assertNull(view.myself)
+        assertFalse(view.participate.isParticipating)
+        assertTrue(view.participate.isAvailableParticipate)
+        assertFalse(view.commit.isAvailableCommit)
+        assertFalse(view.say.isAvailableSay)
+        assertFalse(view.vote.canVote)
+        assertFalse(view.admin.isAdmin)
+        assertFalse(view.creator.isCreator)
+    }
+
+    @Test
+    fun `参加中は本人情報が返る`() {
+        val participant = createVillageParticipant(skill = Skill(CDef.Skill.村人), id = 2)
+        val view =
+            ParticipantSituationView(
+                createSituation(myselfParticipant = participant, isParticipating = true),
+            )
+
+        assertEquals(participant.id, view.myself!!.id)
+        assertEquals(participant.charaId, view.myself!!.charaId)
+        assertEquals(participant.name(), view.myself!!.name)
+        assertEquals(participant.shortName(), view.myself!!.shortName)
+        assertFalse(view.myself!!.isDead)
+        assertFalse(view.myself!!.isSpectator)
+        assertTrue(view.participate.isParticipating)
+    }
+
+    private fun createSituation(
+        myselfParticipant: com.ort.app.domain.model.village.participant.VillageParticipant?,
+        isParticipating: Boolean = false,
+    ): ParticipantSituation =
+        ParticipantSituation(
+            participate =
+                ParticipantParticipateSituation(
+                    isParticipating = isParticipating,
+                    isAvailableParticipate = true,
+                    isAvailableSpectate = false,
+                    isAvailableSwitchParticipate = false,
+                    selectableCharachipList = emptyList(),
+                    selectableCharaList = emptyList(),
+                    isAvailableLeave = false,
+                    myself = myselfParticipant,
+                ),
+            skillRequest =
+                ParticipantSkillRequestSituation(
+                    isAvailableSkillRequest = false,
+                    selectableSkillList = emptyList(),
+                    skillRequest = null,
+                ),
+            commit = ParticipantCommitSituation(isAvailableCommit = false, isCommitting = false),
+            say =
+                ParticipantSaySituation(
+                    isAvailableSay = false,
+                    selectableMessageTypeList = emptyList(),
+                    selectableCharaImageList = emptyList(),
+                    defaultMessageType = MessageType(CDef.MessageType.通常発言),
+                ),
+            rp =
+                ParticipantRpSituation(
+                    isAvailableChangeName = false,
+                    isAvailableMemo = false,
+                    canAddImage = false,
+                ),
+            ability =
+                ParticipantAbilitySituation(
+                    canUseAbility = false,
+                    type = null,
+                    targetList = emptyList(),
+                    targetFootstepList = emptyList(),
+                    attacker = null,
+                    target = null,
+                    targetFootstep = null,
+                    targetingMessage = null,
+                    footstep = null,
+                    isAvailableNoTarget = false,
+                    attackerList = emptyList(),
+                    skillHistoryList = emptyList(),
+                    wolfList = emptyList(),
+                    cMadmanList = emptyList(),
+                    foxList = emptyList(),
+                    loversList = emptyList(),
+                    masonsList = emptyList(),
+                    listenMasonsList = emptyList(),
+                    targetPrefix = null,
+                    targetSuffix = null,
+                    isTargetingAndFootstep = false,
+                ),
+            vote = ParticipantVoteSituation(canVote = false, targetList = emptyList(), target = null),
+            admin = ParticipantAdminSituation(isAdmin = false),
+            creator =
+                ParticipantCreatorSituation(
+                    isCreator = false,
+                    isAvailableCreatorSay = false,
+                    isAvailableCancelVillage = false,
+                    isAvailableKick = false,
+                    isAvailableModifySetting = false,
+                    isAvailableExtendEpilogue = false,
+                ),
+        )
+}

--- a/backend/src/test/kotlin/com/ort/app/api/village/response/VillageSituationViewTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/api/village/response/VillageSituationViewTest.kt
@@ -1,0 +1,57 @@
+package com.ort.app.api.village.response
+
+import com.ort.app.domain.model.chara.Charachips
+import com.ort.app.domain.model.situation.VillageSituation
+import com.ort.app.domain.model.situation.village.VillageDayFootstep
+import com.ort.app.domain.model.situation.village.VillageFootstepSituation
+import com.ort.app.domain.model.situation.village.VillageParticipantLiveSituation
+import com.ort.app.domain.model.situation.village.VillageRoomAssignedSituation
+import com.ort.app.domain.model.situation.village.VillageVoteSituation
+import com.ort.app.domain.model.situation.village.VillageWholeSituation
+import com.ort.app.domain.model.village.createPrologueVillage
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+internal class VillageSituationViewTest {
+    @Test
+    fun `部屋なし村は部屋割りと投票を返さない`() {
+        val village = createPrologueVillage()
+        val situation =
+            VillageSituation(
+                roomAssigned = VillageRoomAssignedSituation(columns = emptyList()),
+                live = VillageParticipantLiveSituation(village),
+                footstep =
+                    VillageFootstepSituation(
+                        list = listOf(VillageDayFootstep(day = 1, footstep = "01、02")),
+                    ),
+                vote = VillageVoteSituation(list = emptyList()),
+                whole = VillageWholeSituation(list = emptyList()),
+            )
+
+        val view =
+            VillageSituationView(
+                village = village,
+                day = 0,
+                villageSituation = situation,
+                charachips = Charachips(list = emptyList()),
+                myself = null,
+                player = null,
+                isViewableSpoilerContent = false,
+            )
+
+        assertNull(view.roomAssignedRowList)
+        assertNull(view.roomWidth)
+        assertNull(view.vote)
+        assertFalse(view.isViewableSpoilerContent)
+        // ステータス別の参加者グルーピングは live situation の構造をそのまま写す
+        assertEquals(
+            listOf("生存", "処刑死", "無惨", "後追", "突然", "見学"),
+            view.memberList.map { it.status },
+        )
+        assertEquals(1, view.footstepList.size)
+        assertEquals(1, view.footstepList[0].day)
+        assertEquals("01、02", view.footstepList[0].footstep)
+    }
+}

--- a/e2e/tests/village.spec.ts
+++ b/e2e/tests/village.spec.ts
@@ -1,0 +1,120 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * 村画面 (`/village/{id}`) e2e。
+ *
+ * 村の状態はローカル DB に依存するため、村一覧 API から対象を動的に探し、
+ * 該当する村が無い場合はスキップする。
+ */
+
+type SimpleVillage = { id: number; name: string };
+
+async function findVillages(page: Page, statuses: string[]): Promise<SimpleVillage[]> {
+  const query = statuses.map((s) => `status=${s}`).join("&");
+  const res = await page.request.get(`/wolf-mansion-api/api/v1/villages?${query}`);
+  expect(res.ok()).toBeTruthy();
+  const body = (await res.json()) as { villages: SimpleVillage[] };
+  return body.villages;
+}
+
+test("募集中の村画面が表示される (タイトル/日付ナビ/状況パネル/フッターメニュー)", async ({
+  page,
+}) => {
+  const villages = await findVillages(page, ["IN_PREPARATION"]);
+  test.skip(villages.length === 0, "募集中の村が無い DB のためスキップ");
+  const village = villages[villages.length - 1];
+
+  await page.goto(`village/${village.id}`);
+
+  await expect(page).toHaveTitle(`WOLF MANSION | ${village.name}`);
+  // 村番号 (4桁0埋め) + 村名の見出し
+  const number = String(village.id).padStart(4, "0");
+  await expect(page.getByRole("heading", { name: `${number}. ${village.name}` })).toBeVisible();
+  // 日付ナビ (現在日はリンクにならない)
+  await expect(page.getByText("プロローグ").first()).toBeVisible();
+  // 状況パネルと参加者タブ
+  await expect(page.getByRole("button", { name: "状況" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "参加者" })).toBeVisible();
+  await expect(page.getByText("生存 (", { exact: false }).first()).toBeVisible();
+  // フッターメニュー
+  await expect(page.getByRole("button", { name: "最上部へ" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "更新" })).toBeVisible();
+  // 募集中の村は次回更新までのカウントダウンが出る
+  await expect(page.getByText("更新まで")).toBeVisible();
+});
+
+test("存在しない村はその旨を表示する", async ({ page }) => {
+  await page.goto("village/99999");
+
+  await expect(page.getByText("村が見つかりませんでした。")).toBeVisible();
+});
+
+test("進行中以降の村で日付ナビ遷移と状況タブが動く", async ({ page }) => {
+  const villages = await findVillages(page, ["IN_PROGRESS", "EPILOGUE", "COMPLETED"]);
+  test.skip(villages.length === 0, "進行中以降の村が無い DB のためスキップ");
+  const village = villages[0];
+
+  await page.goto(`village/${village.id}`);
+  await expect(page.getByRole("button", { name: "状況" })).toBeVisible();
+
+  // 開始済みの村は部屋割りタブが初期表示される
+  await expect(page.getByRole("button", { name: "部屋割り当て" })).toBeVisible();
+
+  // 日付ナビでプロローグへ遷移できる
+  await page.getByRole("link", { name: "プロローグ" }).first().click();
+  await expect(page).toHaveURL(new RegExp(`/village/${village.id}/day/0$`));
+  // プロローグ表示では部屋割りタブが無く参加者タブが初期表示
+  await expect(page.getByRole("button", { name: "部屋割り当て" })).toHaveCount(0);
+  await expect(page.getByText("生存 (", { exact: false }).first()).toBeVisible();
+});
+
+test("進行中以降の村で投票・足音タブを切り替えられる", async ({ page }) => {
+  const villages = await findVillages(page, ["IN_PROGRESS", "EPILOGUE", "COMPLETED"]);
+  test.skip(villages.length === 0, "進行中以降の村が無い DB のためスキップ");
+  const village = villages[0];
+
+  await page.goto(`village/${village.id}`);
+  await expect(page.getByRole("button", { name: "状況" })).toBeVisible();
+
+  // 投票タブ (3日目以降のみ存在)。あれば切り替えて投票者ヘッダを確認
+  const voteTab = page.getByRole("button", { name: "投票" });
+  if ((await voteTab.count()) > 0) {
+    await voteTab.click();
+    await expect(page.getByRole("button", { name: "投票者" })).toBeVisible();
+  }
+
+  // 足音タブ (足音があれば存在)
+  const footstepTab = page.getByRole("button", { name: "足音" });
+  if ((await footstepTab.count()) > 0) {
+    await footstepTab.click();
+    await expect(page.getByText("足音が聞こえた").first()).toBeVisible();
+  }
+});
+
+test("未ログインでは situation/me が 401 になる (公開 API はマスク済み)", async ({ page }) => {
+  const villages = await findVillages(page, ["IN_PROGRESS", "EPILOGUE", "COMPLETED"]);
+  test.skip(villages.length === 0, "進行中以降の村が無い DB のためスキップ");
+  const village = villages[0];
+
+  const meRes = await page.request.get(
+    `/wolf-mansion-api/api/v1/villages/${village.id}/situation/me`,
+  );
+  expect(meRes.status()).toBe(401);
+
+  // 公開の村状況は取得でき、進行中の村では役職名がマスクされている
+  const res = await page.request.get(`/wolf-mansion-api/api/v1/villages/${village.id}/situation`);
+  expect(res.ok()).toBeTruthy();
+  const situation = (await res.json()) as {
+    isViewableSpoilerContent: boolean;
+    roomAssignedRowList: { roomAssignedList: { skillName: string | null }[] }[] | null;
+  };
+  const progressVillages = await findVillages(page, ["IN_PROGRESS"]);
+  if (progressVillages.some((v) => v.id === village.id)) {
+    expect(situation.isViewableSpoilerContent).toBe(false);
+    const skillNames = (situation.roomAssignedRowList ?? [])
+      .flatMap((row) => row.roomAssignedList)
+      .map((room) => room.skillName)
+      .filter((name) => name != null);
+    expect(skillNames).toHaveLength(0);
+  }
+});

--- a/frontend/app/api/openapi.json
+++ b/frontend/app/api/openapi.json
@@ -179,7 +179,7 @@
     },
     "/api/v1/charachips/{id}": {
       "get": {
-        "operationId": "detail_1",
+        "operationId": "detail_2",
         "parameters": [
           {
             "in": "path",
@@ -564,6 +564,35 @@
         "tags": ["village-rest-controller"]
       }
     },
+    "/api/v1/villages/{id}": {
+      "get": {
+        "operationId": "detail_1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/VillageDetailView"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": ["village-rest-controller"]
+      }
+    },
     "/api/v1/villages/{id}/setting": {
       "get": {
         "operationId": "setting",
@@ -584,6 +613,111 @@
               "*/*": {
                 "schema": {
                   "$ref": "#/components/schemas/VillageSettingView"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": ["village-rest-controller"]
+      }
+    },
+    "/api/v1/villages/{id}/situation": {
+      "get": {
+        "operationId": "situation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "in": "query",
+            "name": "day",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/VillageSituationView"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": ["village-rest-controller"]
+      }
+    },
+    "/api/v1/villages/{id}/situation/me": {
+      "get": {
+        "operationId": "mySituation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "in": "query",
+            "name": "day",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ParticipantSituationView"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": ["village-rest-controller"]
+      }
+    },
+    "/api/v1/villages/{id}/update": {
+      "post": {
+        "operationId": "update_1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/VillageUpdateResponse"
                 }
               }
             },
@@ -960,6 +1094,215 @@
         },
         "required": ["count", "length", "messageType", "skill"]
       },
+      "ParticipantSituationView": {
+        "type": "object",
+        "properties": {
+          "ability": {
+            "$ref": "#/components/schemas/ParticipantSituationViewAbility"
+          },
+          "admin": {
+            "$ref": "#/components/schemas/ParticipantSituationViewAdmin"
+          },
+          "commit": {
+            "$ref": "#/components/schemas/ParticipantSituationViewCommit"
+          },
+          "creator": {
+            "$ref": "#/components/schemas/ParticipantSituationViewCreator"
+          },
+          "myself": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ParticipantSituationViewMyself"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "participate": {
+            "$ref": "#/components/schemas/ParticipantSituationViewParticipate"
+          },
+          "rp": {
+            "$ref": "#/components/schemas/ParticipantSituationViewRp"
+          },
+          "say": {
+            "$ref": "#/components/schemas/ParticipantSituationViewSay"
+          },
+          "skillRequest": {
+            "$ref": "#/components/schemas/ParticipantSituationViewSkillRequest"
+          },
+          "vote": {
+            "$ref": "#/components/schemas/ParticipantSituationViewVote"
+          }
+        },
+        "required": [
+          "ability",
+          "admin",
+          "commit",
+          "creator",
+          "participate",
+          "rp",
+          "say",
+          "skillRequest",
+          "vote"
+        ]
+      },
+      "ParticipantSituationViewAbility": {
+        "type": "object",
+        "properties": {
+          "canUseAbility": {
+            "type": "boolean"
+          }
+        },
+        "required": ["canUseAbility"]
+      },
+      "ParticipantSituationViewAdmin": {
+        "type": "object",
+        "properties": {
+          "isAdmin": {
+            "type": "boolean"
+          }
+        },
+        "required": ["isAdmin"]
+      },
+      "ParticipantSituationViewCommit": {
+        "type": "object",
+        "properties": {
+          "isAvailableCommit": {
+            "type": "boolean"
+          },
+          "isCommitting": {
+            "type": "boolean"
+          }
+        },
+        "required": ["isAvailableCommit", "isCommitting"]
+      },
+      "ParticipantSituationViewCreator": {
+        "type": "object",
+        "properties": {
+          "isAvailableCancelVillage": {
+            "type": "boolean"
+          },
+          "isAvailableCreatorSay": {
+            "type": "boolean"
+          },
+          "isAvailableExtendEpilogue": {
+            "type": "boolean"
+          },
+          "isAvailableKick": {
+            "type": "boolean"
+          },
+          "isAvailableModifySetting": {
+            "type": "boolean"
+          },
+          "isCreator": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "isAvailableCancelVillage",
+          "isAvailableCreatorSay",
+          "isAvailableExtendEpilogue",
+          "isAvailableKick",
+          "isAvailableModifySetting",
+          "isCreator"
+        ]
+      },
+      "ParticipantSituationViewMyself": {
+        "type": "object",
+        "properties": {
+          "charaId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "isDead": {
+            "type": "boolean"
+          },
+          "isSpectator": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "shortName": {
+            "type": "string"
+          }
+        },
+        "required": ["charaId", "id", "isDead", "isSpectator", "name", "shortName"]
+      },
+      "ParticipantSituationViewParticipate": {
+        "type": "object",
+        "properties": {
+          "isAvailableLeave": {
+            "type": "boolean"
+          },
+          "isAvailableParticipate": {
+            "type": "boolean"
+          },
+          "isAvailableSpectate": {
+            "type": "boolean"
+          },
+          "isAvailableSwitchParticipate": {
+            "type": "boolean"
+          },
+          "isParticipating": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "isAvailableLeave",
+          "isAvailableParticipate",
+          "isAvailableSpectate",
+          "isAvailableSwitchParticipate",
+          "isParticipating"
+        ]
+      },
+      "ParticipantSituationViewRp": {
+        "type": "object",
+        "properties": {
+          "canAddImage": {
+            "type": "boolean"
+          },
+          "isAvailableChangeName": {
+            "type": "boolean"
+          },
+          "isAvailableMemo": {
+            "type": "boolean"
+          }
+        },
+        "required": ["canAddImage", "isAvailableChangeName", "isAvailableMemo"]
+      },
+      "ParticipantSituationViewSay": {
+        "type": "object",
+        "properties": {
+          "isAvailableSay": {
+            "type": "boolean"
+          }
+        },
+        "required": ["isAvailableSay"]
+      },
+      "ParticipantSituationViewSkillRequest": {
+        "type": "object",
+        "properties": {
+          "isAvailableSkillRequest": {
+            "type": "boolean"
+          }
+        },
+        "required": ["isAvailableSkillRequest"]
+      },
+      "ParticipantSituationViewVote": {
+        "type": "object",
+        "properties": {
+          "canVote": {
+            "type": "boolean"
+          }
+        },
+        "required": ["canVote"]
+      },
       "PasswordChangeRequest": {
         "type": "object",
         "properties": {
@@ -1074,6 +1417,20 @@
           }
         },
         "required": ["height", "roomNumbers", "width"]
+      },
+      "RoomSize": {
+        "type": "object",
+        "properties": {
+          "height": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "width": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": ["height", "width"]
       },
       "SayRestriction": {
         "type": "object",
@@ -1845,6 +2202,81 @@
         },
         "required": ["id"]
       },
+      "VillageDay": {
+        "type": "object",
+        "properties": {
+          "day": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "dayChangeDatetime": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": ["day", "dayChangeDatetime"]
+      },
+      "VillageDays": {
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VillageDay"
+            }
+          }
+        },
+        "required": ["list"]
+      },
+      "VillageDetailView": {
+        "type": "object",
+        "properties": {
+          "days": {
+            "$ref": "#/components/schemas/VillageDays"
+          },
+          "epilogueDay": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string"
+          },
+          "roomSize": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/RoomSize"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "setting": {
+            "$ref": "#/components/schemas/VillageSettingView"
+          },
+          "status": {
+            "$ref": "#/components/schemas/VillageStatus"
+          }
+        },
+        "required": ["days", "id", "name", "setting", "status"]
+      },
+      "VillageFootstepContent": {
+        "type": "object",
+        "properties": {
+          "day": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "footstep": {
+            "type": "string"
+          }
+        },
+        "required": ["day", "footstep"]
+      },
       "VillageListResponse": {
         "type": "object",
         "properties": {
@@ -1856,6 +2288,58 @@
           }
         },
         "required": ["villages"]
+      },
+      "VillageMemberContent": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
+          },
+          "statusMemberList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VillageMemberDetailContent"
+            }
+          }
+        },
+        "required": ["status", "statusMemberList"]
+      },
+      "VillageMemberDetailContent": {
+        "type": "object",
+        "properties": {
+          "charaName": {
+            "type": "string"
+          },
+          "deadDay": {
+            "type": ["string", "null"]
+          },
+          "lastAccess": {
+            "type": "string"
+          },
+          "lastAccessDatetime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "memo": {
+            "type": ["string", "null"]
+          }
+        },
+        "required": ["charaName", "lastAccess", "lastAccessDatetime"]
+      },
+      "VillageMemberVoteContent": {
+        "type": "object",
+        "properties": {
+          "charaName": {
+            "type": "string"
+          },
+          "voteTargetList": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["charaName", "voteTargetList"]
       },
       "VillageOrganize": {
         "type": "object",
@@ -1896,6 +2380,72 @@
           }
         },
         "required": ["campAllocation", "skillAllocation"]
+      },
+      "VillageRoomAssigned": {
+        "type": "object",
+        "properties": {
+          "charaImgHeight": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          },
+          "charaImgUrl": {
+            "type": ["string", "null"]
+          },
+          "charaImgWidth": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          },
+          "charaName": {
+            "type": ["string", "null"]
+          },
+          "charaShortName": {
+            "type": ["string", "null"]
+          },
+          "deadDay": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          },
+          "deadReason": {
+            "type": ["string", "null"]
+          },
+          "isDead": {
+            "type": ["boolean", "null"]
+          },
+          "isDummy": {
+            "type": ["boolean", "null"]
+          },
+          "maxHeight": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          },
+          "maxWidth": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          },
+          "participantId": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          },
+          "roomNumber": {
+            "type": "string"
+          },
+          "skillName": {
+            "type": ["string", "null"]
+          }
+        },
+        "required": ["roomNumber"]
+      },
+      "VillageRoomAssignedRow": {
+        "type": "object",
+        "properties": {
+          "roomAssignedList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VillageRoomAssigned"
+            }
+          }
+        },
+        "required": ["roomAssignedList"]
       },
       "VillageRule": {
         "type": "object",
@@ -2007,6 +2557,89 @@
           "tags"
         ]
       },
+      "VillageSituationContent": {
+        "type": "object",
+        "properties": {
+          "ability": {
+            "type": "string"
+          },
+          "attackedChara": {
+            "type": "string"
+          },
+          "day": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "executedChara": {
+            "type": "string"
+          },
+          "revivalChara": {
+            "type": "string"
+          },
+          "suddonlyDeathChara": {
+            "type": "string"
+          },
+          "suicideChara": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ability",
+          "attackedChara",
+          "day",
+          "executedChara",
+          "revivalChara",
+          "suddonlyDeathChara",
+          "suicideChara"
+        ]
+      },
+      "VillageSituationView": {
+        "type": "object",
+        "properties": {
+          "footstepList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VillageFootstepContent"
+            }
+          },
+          "isViewableSpoilerContent": {
+            "type": "boolean"
+          },
+          "memberList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VillageMemberContent"
+            }
+          },
+          "roomAssignedRowList": {
+            "type": ["array", "null"],
+            "items": {
+              "$ref": "#/components/schemas/VillageRoomAssignedRow"
+            }
+          },
+          "roomWidth": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          },
+          "situationList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VillageSituationContent"
+            }
+          },
+          "vote": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/VillageVoteContent"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": ["footstepList", "isViewableSpoilerContent", "memberList", "situationList"]
+      },
       "VillageStatus": {
         "type": "object",
         "properties": {
@@ -2077,6 +2710,32 @@
           }
         },
         "required": ["list"]
+      },
+      "VillageUpdateResponse": {
+        "type": "object",
+        "properties": {
+          "latestDay": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": ["latestDay"]
+      },
+      "VillageVoteContent": {
+        "type": "object",
+        "properties": {
+          "maxVoteCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "voteList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VillageMemberVoteContent"
+            }
+          }
+        },
+        "required": ["maxVoteCount", "voteList"]
       },
       "WolfAllocation": {
         "type": "object",

--- a/frontend/app/api/openapi.json
+++ b/frontend/app/api/openapi.json
@@ -179,7 +179,7 @@
     },
     "/api/v1/charachips/{id}": {
       "get": {
-        "operationId": "detail_2",
+        "operationId": "detail_1",
         "parameters": [
           {
             "in": "path",
@@ -566,7 +566,7 @@
     },
     "/api/v1/villages/{id}": {
       "get": {
-        "operationId": "detail_1",
+        "operationId": "getVillage",
         "parameters": [
           {
             "in": "path",
@@ -624,7 +624,7 @@
     },
     "/api/v1/villages/{id}/situation": {
       "get": {
-        "operationId": "situation",
+        "operationId": "getVillageSituation",
         "parameters": [
           {
             "in": "path",
@@ -662,7 +662,7 @@
     },
     "/api/v1/villages/{id}/situation/me": {
       "get": {
-        "operationId": "mySituation",
+        "operationId": "getMyVillageSituation",
         "parameters": [
           {
             "in": "path",
@@ -700,7 +700,7 @@
     },
     "/api/v1/villages/{id}/update": {
       "post": {
-        "operationId": "update_1",
+        "operationId": "updateVillage",
         "parameters": [
           {
             "in": "path",

--- a/frontend/app/api/types.ts
+++ b/frontend/app/api/types.ts
@@ -122,7 +122,7 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    get: operations["detail_2"];
+    get: operations["detail_1"];
     put?: never;
     post?: never;
     delete?: never;
@@ -250,7 +250,7 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    get: operations["detail_1"];
+    get: operations["getVillage"];
     put?: never;
     post?: never;
     delete?: never;
@@ -282,7 +282,7 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    get: operations["situation"];
+    get: operations["getVillageSituation"];
     put?: never;
     post?: never;
     delete?: never;
@@ -298,7 +298,7 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    get: operations["mySituation"];
+    get: operations["getMyVillageSituation"];
     put?: never;
     post?: never;
     delete?: never;
@@ -316,7 +316,7 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    post: operations["update_1"];
+    post: operations["updateVillage"];
     delete?: never;
     options?: never;
     head?: never;
@@ -1088,7 +1088,7 @@ export interface operations {
       };
     };
   };
-  detail_2: {
+  detail_1: {
     parameters: {
       query?: never;
       header?: never;
@@ -1364,7 +1364,7 @@ export interface operations {
       };
     };
   };
-  detail_1: {
+  getVillage: {
     parameters: {
       query?: never;
       header?: never;
@@ -1408,7 +1408,7 @@ export interface operations {
       };
     };
   };
-  situation: {
+  getVillageSituation: {
     parameters: {
       query?: {
         day?: number;
@@ -1432,7 +1432,7 @@ export interface operations {
       };
     };
   };
-  mySituation: {
+  getMyVillageSituation: {
     parameters: {
       query?: {
         day?: number;
@@ -1456,7 +1456,7 @@ export interface operations {
       };
     };
   };
-  update_1: {
+  updateVillage: {
     parameters: {
       query?: never;
       header?: never;

--- a/frontend/app/api/types.ts
+++ b/frontend/app/api/types.ts
@@ -122,7 +122,7 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    get: operations["detail_1"];
+    get: operations["detail_2"];
     put?: never;
     post?: never;
     delete?: never;
@@ -243,6 +243,22 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/villages/{id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["detail_1"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/villages/{id}/setting": {
     parameters: {
       query?: never;
@@ -253,6 +269,54 @@ export interface paths {
     get: operations["setting"];
     put?: never;
     post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/villages/{id}/situation": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["situation"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/villages/{id}/situation/me": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["mySituation"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/villages/{id}/update": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["update_1"];
     delete?: never;
     options?: never;
     head?: never;
@@ -384,6 +448,67 @@ export interface components {
       messageType: components["schemas"]["MessageType"];
       skill: components["schemas"]["Skill"];
     };
+    ParticipantSituationView: {
+      ability: components["schemas"]["ParticipantSituationViewAbility"];
+      admin: components["schemas"]["ParticipantSituationViewAdmin"];
+      commit: components["schemas"]["ParticipantSituationViewCommit"];
+      creator: components["schemas"]["ParticipantSituationViewCreator"];
+      myself?: components["schemas"]["ParticipantSituationViewMyself"] | null;
+      participate: components["schemas"]["ParticipantSituationViewParticipate"];
+      rp: components["schemas"]["ParticipantSituationViewRp"];
+      say: components["schemas"]["ParticipantSituationViewSay"];
+      skillRequest: components["schemas"]["ParticipantSituationViewSkillRequest"];
+      vote: components["schemas"]["ParticipantSituationViewVote"];
+    };
+    ParticipantSituationViewAbility: {
+      canUseAbility: boolean;
+    };
+    ParticipantSituationViewAdmin: {
+      isAdmin: boolean;
+    };
+    ParticipantSituationViewCommit: {
+      isAvailableCommit: boolean;
+      isCommitting: boolean;
+    };
+    ParticipantSituationViewCreator: {
+      isAvailableCancelVillage: boolean;
+      isAvailableCreatorSay: boolean;
+      isAvailableExtendEpilogue: boolean;
+      isAvailableKick: boolean;
+      isAvailableModifySetting: boolean;
+      isCreator: boolean;
+    };
+    ParticipantSituationViewMyself: {
+      /** Format: int32 */
+      charaId: number;
+      /** Format: int32 */
+      id: number;
+      isDead: boolean;
+      isSpectator: boolean;
+      name: string;
+      shortName: string;
+    };
+    ParticipantSituationViewParticipate: {
+      isAvailableLeave: boolean;
+      isAvailableParticipate: boolean;
+      isAvailableSpectate: boolean;
+      isAvailableSwitchParticipate: boolean;
+      isParticipating: boolean;
+    };
+    ParticipantSituationViewRp: {
+      canAddImage: boolean;
+      isAvailableChangeName: boolean;
+      isAvailableMemo: boolean;
+    };
+    ParticipantSituationViewSay: {
+      isAvailableSay: boolean;
+    };
+    ParticipantSituationViewSkillRequest: {
+      isAvailableSkillRequest: boolean;
+    };
+    ParticipantSituationViewVote: {
+      canVote: boolean;
+    };
     PasswordChangeRequest: {
       confirmPassword: string | null;
       password: string | null;
@@ -411,6 +536,12 @@ export interface components {
       /** Format: int32 */
       height: number;
       roomNumbers: number[];
+      /** Format: int32 */
+      width: number;
+    };
+    RoomSize: {
+      /** Format: int32 */
+      height: number;
       /** Format: int32 */
       width: number;
     };
@@ -631,8 +762,49 @@ export interface components {
       /** Format: int32 */
       id: number;
     };
+    VillageDay: {
+      /** Format: int32 */
+      day: number;
+      /** Format: date-time */
+      dayChangeDatetime: string;
+    };
+    VillageDays: {
+      list: components["schemas"]["VillageDay"][];
+    };
+    VillageDetailView: {
+      days: components["schemas"]["VillageDays"];
+      /** Format: int32 */
+      epilogueDay?: number | null;
+      /** Format: int32 */
+      id: number;
+      name: string;
+      roomSize?: components["schemas"]["RoomSize"] | null;
+      setting: components["schemas"]["VillageSettingView"];
+      status: components["schemas"]["VillageStatus"];
+    };
+    VillageFootstepContent: {
+      /** Format: int32 */
+      day: number;
+      footstep: string;
+    };
     VillageListResponse: {
       villages: components["schemas"]["SimpleVillageView"][];
+    };
+    VillageMemberContent: {
+      status: string;
+      statusMemberList: components["schemas"]["VillageMemberDetailContent"][];
+    };
+    VillageMemberDetailContent: {
+      charaName: string;
+      deadDay?: string | null;
+      lastAccess: string;
+      /** Format: date-time */
+      lastAccessDatetime: string;
+      memo?: string | null;
+    };
+    VillageMemberVoteContent: {
+      charaName: string;
+      voteTargetList: string[];
     };
     VillageOrganize: {
       fixedOrganization: string;
@@ -642,6 +814,31 @@ export interface components {
       campAllocation: components["schemas"]["CampAllocation"][];
       skillAllocation: components["schemas"]["SkillAllocation"][];
       wolfAllocation?: components["schemas"]["WolfAllocation"] | null;
+    };
+    VillageRoomAssigned: {
+      /** Format: int32 */
+      charaImgHeight?: number | null;
+      charaImgUrl?: string | null;
+      /** Format: int32 */
+      charaImgWidth?: number | null;
+      charaName?: string | null;
+      charaShortName?: string | null;
+      /** Format: int32 */
+      deadDay?: number | null;
+      deadReason?: string | null;
+      isDead?: boolean | null;
+      isDummy?: boolean | null;
+      /** Format: int32 */
+      maxHeight?: number | null;
+      /** Format: int32 */
+      maxWidth?: number | null;
+      /** Format: int32 */
+      participantId?: number | null;
+      roomNumber: string;
+      skillName?: string | null;
+    };
+    VillageRoomAssignedRow: {
+      roomAssignedList: components["schemas"]["VillageRoomAssigned"][];
     };
     VillageRule: {
       isAvailableAction: boolean;
@@ -674,6 +871,26 @@ export interface components {
       startDatetime: string;
       tags: components["schemas"]["VillageTags"];
     };
+    VillageSituationContent: {
+      ability: string;
+      attackedChara: string;
+      /** Format: int32 */
+      day: number;
+      executedChara: string;
+      revivalChara: string;
+      suddonlyDeathChara: string;
+      suicideChara: string;
+    };
+    VillageSituationView: {
+      footstepList: components["schemas"]["VillageFootstepContent"][];
+      isViewableSpoilerContent: boolean;
+      memberList: components["schemas"]["VillageMemberContent"][];
+      roomAssignedRowList?: components["schemas"]["VillageRoomAssignedRow"][] | null;
+      /** Format: int32 */
+      roomWidth?: number | null;
+      situationList: components["schemas"]["VillageSituationContent"][];
+      vote?: components["schemas"]["VillageVoteContent"] | null;
+    };
     VillageStatus: {
       code: string;
       isCanceled: boolean;
@@ -692,6 +909,15 @@ export interface components {
     };
     VillageTags: {
       list: components["schemas"]["VillageTag"][];
+    };
+    VillageUpdateResponse: {
+      /** Format: int32 */
+      latestDay: number;
+    };
+    VillageVoteContent: {
+      /** Format: int32 */
+      maxVoteCount: number;
+      voteList: components["schemas"]["VillageMemberVoteContent"][];
     };
     WolfAllocation: {
       /** Format: int32 */
@@ -862,7 +1088,7 @@ export interface operations {
       };
     };
   };
-  detail_1: {
+  detail_2: {
     parameters: {
       query?: never;
       header?: never;
@@ -1138,6 +1364,28 @@ export interface operations {
       };
     };
   };
+  detail_1: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["VillageDetailView"];
+        };
+      };
+    };
+  };
   setting: {
     parameters: {
       query?: never;
@@ -1156,6 +1404,76 @@ export interface operations {
         };
         content: {
           "*/*": components["schemas"]["VillageSettingView"];
+        };
+      };
+    };
+  };
+  situation: {
+    parameters: {
+      query?: {
+        day?: number;
+      };
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["VillageSituationView"];
+        };
+      };
+    };
+  };
+  mySituation: {
+    parameters: {
+      query?: {
+        day?: number;
+      };
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ParticipantSituationView"];
+        };
+      };
+    };
+  };
+  update_1: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["VillageUpdateResponse"];
         };
       };
     };

--- a/frontend/app/components/layout/PageLayout.tsx
+++ b/frontend/app/components/layout/PageLayout.tsx
@@ -10,13 +10,22 @@ import { Header } from "~/components/layout/Header";
  *
  * ホーム (`/`) は大きいバナー画像を route 内に直接持つため、このシェルは使わない。
  */
-export function PageLayout({ children, header = true }: { children: ReactNode; header?: boolean }) {
+export function PageLayout({
+  children,
+  header = true,
+  noAd = false,
+}: {
+  children: ReactNode;
+  header?: boolean;
+  /** R18 村など広告を出さないページで true。 */
+  noAd?: boolean;
+}) {
   return (
     <div className="min-h-screen bg-wm-base text-xs text-white">
       <div className="mx-auto w-full min-[768px]:max-w-[750px] min-[992px]:max-w-[970px] min-[1200px]:max-w-[1170px]">
         {header && <Header />}
         {children}
-        <Footer />
+        <Footer noAd={noAd} />
       </div>
     </div>
   );

--- a/frontend/app/features/village/api.ts
+++ b/frontend/app/features/village/api.ts
@@ -1,0 +1,46 @@
+import type { components } from "~/api/types";
+import { apiFetch } from "~/lib/api";
+
+/** 村詳細 (`GET /api/v1/villages/{id}`)。公開情報のみ (入村パスワードはマスク済み)。 */
+export type VillageDetailView = components["schemas"]["VillageDetailView"];
+/** 村状況 (`GET /api/v1/villages/{id}/situation`)。スポイラーマスク適用済み。 */
+export type VillageSituationView = components["schemas"]["VillageSituationView"];
+/** 参加者本人の状態 (`GET /api/v1/villages/{id}/situation/me`)。要認証。 */
+export type ParticipantSituationView = components["schemas"]["ParticipantSituationView"];
+/** 村ポーリング (`POST /api/v1/villages/{id}/update`) の応答。 */
+export type VillageUpdateResponse = components["schemas"]["VillageUpdateResponse"];
+
+export type VillageRoomAssignedRow = components["schemas"]["VillageRoomAssignedRow"];
+export type VillageRoomAssigned = components["schemas"]["VillageRoomAssigned"];
+export type VillageMemberContent = components["schemas"]["VillageMemberContent"];
+export type VillageVoteContent = components["schemas"]["VillageVoteContent"];
+export type VillageFootstepContent = components["schemas"]["VillageFootstepContent"];
+export type VillageSituationContent = components["schemas"]["VillageSituationContent"];
+
+/** 村詳細を取得する (公開)。存在しない村は 404 (`ApiError.code === "not_found"`)。 */
+export function fetchVillage(id: number): Promise<VillageDetailView> {
+  return apiFetch<VillageDetailView>(`/api/v1/villages/${id}`);
+}
+
+/** 村状況を取得する (公開・ログイン時は視点がマスクに反映される)。 */
+export function fetchVillageSituation(id: number, day?: number): Promise<VillageSituationView> {
+  const query = day != null ? `?day=${day}` : "";
+  return apiFetch<VillageSituationView>(`/api/v1/villages/${id}/situation${query}`);
+}
+
+/** 参加者本人の状態を取得する (要認証)。 */
+export function fetchMyVillageSituation(
+  id: number,
+  day?: number,
+): Promise<ParticipantSituationView> {
+  const query = day != null ? `?day=${day}` : "";
+  return apiFetch<ParticipantSituationView>(`/api/v1/villages/${id}/situation/me${query}`);
+}
+
+/**
+ * 村ポーリング。最終アクセス更新と日付更新の駆動を行い、最新日を返す。
+ * 日付更新が起きた直後の応答は更新前の最新日のままで、次回ポーリングで新しい日付になる。
+ */
+export function postVillageUpdate(id: number): Promise<VillageUpdateResponse> {
+  return apiFetch<VillageUpdateResponse>(`/api/v1/villages/${id}/update`, { method: "POST" });
+}

--- a/frontend/app/features/village/useVillage.ts
+++ b/frontend/app/features/village/useVillage.ts
@@ -1,0 +1,105 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { useMe } from "~/features/auth/useMe";
+import {
+  fetchMyVillageSituation,
+  fetchVillage,
+  fetchVillageSituation,
+  postVillageUpdate,
+} from "./api";
+
+export const VILLAGE_QUERY_KEY = "village";
+export const VILLAGE_SITUATION_QUERY_KEY = "village-situation";
+export const MY_VILLAGE_SITUATION_QUERY_KEY = "my-village-situation";
+
+/** 村詳細を取得する。 */
+export function useVillage(id: number) {
+  return useQuery({
+    queryKey: [VILLAGE_QUERY_KEY, id],
+    queryFn: () => fetchVillage(id),
+    retry: false,
+  });
+}
+
+/** 村状況を取得する。ログイン状態で視点マスクが変わるため me と合わせてキャッシュを分ける。 */
+export function useVillageSituation(
+  id: number,
+  day: number | undefined,
+  viewerName: string | null,
+) {
+  return useQuery({
+    queryKey: [VILLAGE_SITUATION_QUERY_KEY, id, day ?? "latest", viewerName],
+    queryFn: () => fetchVillageSituation(id, day),
+    retry: false,
+  });
+}
+
+/**
+ * 参加者本人の状態を取得する。未ログインの間は呼ばない。
+ * ログイン中のはずなのに 401 (access 切れ + refresh も失敗) になった場合、このクエリの
+ * error がセッション失効の検知点になる (apiFetch が refresh を試した後の 401 のため)。
+ */
+export function useMyVillageSituation(id: number, day: number | undefined) {
+  const { me, isLoading } = useMe();
+  return useQuery({
+    queryKey: [MY_VILLAGE_SITUATION_QUERY_KEY, id, day ?? "latest", me?.name],
+    queryFn: () => fetchMyVillageSituation(id, day),
+    enabled: !isLoading && me != null,
+    retry: false,
+  });
+}
+
+/** 村系クエリをまとめて無効化する (日付更新・手動更新時)。 */
+export function useInvalidateVillage(id: number) {
+  const queryClient = useQueryClient();
+  return useCallback(
+    () =>
+      Promise.all([
+        queryClient.invalidateQueries({ queryKey: [VILLAGE_QUERY_KEY, id] }),
+        queryClient.invalidateQueries({ queryKey: [VILLAGE_SITUATION_QUERY_KEY, id] }),
+        queryClient.invalidateQueries({ queryKey: [MY_VILLAGE_SITUATION_QUERY_KEY, id] }),
+      ]),
+    [queryClient, id],
+  );
+}
+
+const POLLING_INTERVAL_MS = 30_000;
+
+/**
+ * 村ポーリング。30 秒ごとに村状態の更新 (最終アクセス・日付更新の駆動) を行い、
+ * 既知の最新日より新しい日付を検知したら村系クエリを無効化して true を返す。
+ * 初回マウント直後にも 1 回実行する。失敗 (ネットワーク断など) は次回ポーリングに任せる。
+ */
+export function useVillagePolling(id: number, knownLatestDay: number | undefined): boolean {
+  const invalidate = useInvalidateVillage(id);
+  const [daychangeDetected, setDaychangeDetected] = useState(false);
+  // ポーリングの比較基準。表示中データの最新日に追従する
+  const latestDayRef = useRef<number | undefined>(knownLatestDay);
+  latestDayRef.current = knownLatestDay;
+
+  useEffect(() => {
+    let active = true;
+    const poll = async () => {
+      try {
+        const response = await postVillageUpdate(id);
+        if (!active) return;
+        const known = latestDayRef.current;
+        if (known != null && response.latestDay > known) {
+          setDaychangeDetected(true);
+          await invalidate();
+        }
+      } catch {
+        // 次回ポーリングに任せる
+      }
+    };
+    poll();
+    const timer = setInterval(poll, POLLING_INTERVAL_MS);
+    return () => {
+      active = false;
+      clearInterval(timer);
+    };
+  }, [id, invalidate]);
+
+  return daychangeDetected;
+}

--- a/frontend/app/lib/api.ts
+++ b/frontend/app/lib/api.ts
@@ -93,18 +93,66 @@ type ApiFetchOptions = {
 };
 
 /**
+ * access token (15分) 切れの 401 を refresh token で立て直す。並行リクエストが同時に 401 に
+ * なっても refresh は 1 回だけ走らせる (rotation 方式のため同じ refresh token の二重提示は
+ * 漏洩検知で全失効してしまう)。refresh 自体が失敗したら未ログインとして扱う。
+ */
+let refreshPromise: Promise<boolean> | null = null;
+
+function refreshTokens(): Promise<boolean> {
+  refreshPromise ??= fetch(`${API_BASE}/api/v1/auth/refresh`, {
+    method: "POST",
+    credentials: "include",
+  })
+    .then(async (res) => {
+      // body を消費しないとリクエストが完了扱いにならず残り続ける (中身は使わない)
+      await res.text().catch(() => {});
+      return res.ok;
+    })
+    .catch(() => false)
+    .finally(() => {
+      refreshPromise = null;
+    });
+  return refreshPromise;
+}
+
+/**
+ * refresh によるリトライをしないパス。login/signup の 401 は資格情報の誤り、logout/refresh は
+ * それ自体がトークン操作なのでリトライしない。`/auth/me` は対象に含める (access 切れでも
+ * refresh が生きていればログイン中と判定できる)。
+ */
+const NO_REFRESH_PATHS = [
+  "/api/v1/auth/login",
+  "/api/v1/auth/signup",
+  "/api/v1/auth/logout",
+  "/api/v1/auth/refresh",
+];
+
+function isNoRefreshPath(path: string): boolean {
+  return NO_REFRESH_PATHS.includes(path);
+}
+
+/**
  * API を叩いて JSON を返す。204 (No Content) は `undefined` を返す。
- * 非 2xx は {@link ApiError} を throw する。
+ * 非 2xx は {@link ApiError} を throw する。401 は一度だけ refresh → リトライする
+ * (auth 系パスを除く。FormData はストリーム消費済みの可能性がないのでそのまま再送できる)。
  */
 export async function apiFetch<T>(path: string, options: ApiFetchOptions = {}): Promise<T> {
   const { method = "GET", body } = options;
   const isFormData = body instanceof FormData;
-  const response = await fetch(`${API_BASE}${path}`, {
-    method,
-    credentials: "include",
-    headers: body === undefined || isFormData ? undefined : { "Content-Type": "application/json" },
-    body: body === undefined ? undefined : isFormData ? body : JSON.stringify(body),
-  });
+  const doFetch = () =>
+    fetch(`${API_BASE}${path}`, {
+      method,
+      credentials: "include",
+      headers:
+        body === undefined || isFormData ? undefined : { "Content-Type": "application/json" },
+      body: body === undefined ? undefined : isFormData ? body : JSON.stringify(body),
+    });
+
+  let response = await doFetch();
+  if (response.status === 401 && !isNoRefreshPath(path) && (await refreshTokens())) {
+    response = await doFetch();
+  }
 
   if (!response.ok) {
     throw await toApiError(response);

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -8,6 +8,7 @@ export default [
   route("practice", "routes/practice/route.tsx"),
   route("announce", "routes/announce/route.tsx"),
   route("village-list", "routes/village-list/route.tsx"),
+  route("village/:villageId/day?/:day?", "routes/village/route.tsx"),
   route("new-village", "routes/new-village/route.tsx"),
   route("skill", "routes/skill/route.tsx"),
   route("rule", "routes/rule/route.tsx"),

--- a/frontend/app/routes/village/DayList.tsx
+++ b/frontend/app/routes/village/DayList.tsx
@@ -1,0 +1,41 @@
+import { Link } from "react-router";
+
+import { dayLabel } from "./dayLabel";
+
+/**
+ * 日付ナビゲーション。現在表示中の日はリンクにしない。
+ * 先頭の「情報」は村情報モーダルを開く導線 (モーダル実装までは無効表示)。
+ */
+export function DayList({
+  villageId,
+  dayList,
+  currentDay,
+  epilogueDay,
+}: {
+  villageId: number;
+  dayList: number[];
+  currentDay: number;
+  epilogueDay: number | null | undefined;
+}) {
+  return (
+    <ul className="pl-0 text-[10.32px]">
+      <li className="mr-[10px] inline list-none">
+        <span className="text-wm-accent opacity-50">情報</span>
+      </li>
+      {dayList.map((day) => (
+        <li key={day} className="mr-[10px] inline list-none">
+          {day === currentDay ? (
+            <span>{dayLabel(day, epilogueDay)}</span>
+          ) : (
+            <Link
+              to={`/village/${villageId}/day/${day}`}
+              className="text-wm-accent hover:underline"
+            >
+              {dayLabel(day, epilogueDay)}
+            </Link>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/app/routes/village/FooterMenu.tsx
+++ b/frontend/app/routes/village/FooterMenu.tsx
@@ -1,0 +1,76 @@
+import {
+  ArrowDownIcon,
+  ArrowPathIcon,
+  ArrowUpIcon,
+  Cog6ToothIcon,
+  FunnelIcon,
+  InformationCircleIcon,
+} from "@heroicons/react/24/outline";
+import type { ReactNode } from "react";
+
+const buttonBaseClass =
+  "flex flex-1 items-center justify-center gap-[2px] border border-[#00bc8c] bg-wm-base px-[5px] pt-[4px] pb-[4px] text-[13px] text-[#00bc8c] first:rounded-l-[3px] last:rounded-r-[3px]";
+
+function MenuButton({
+  icon,
+  label,
+  onClick,
+  disabled = false,
+}: {
+  icon: ReactNode;
+  label: string;
+  onClick?: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      className={`${buttonBaseClass} ${
+        disabled ? "opacity-50" : "cursor-pointer hover:bg-[#00bc8c] hover:text-white"
+      }`}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      {icon}
+      <span className="max-[768px]:hidden">{label}</span>
+    </button>
+  );
+}
+
+/**
+ * 画面下部に固定表示する操作メニュー。抽出 / 情報 / 設定はそれぞれのモーダル実装までは
+ * 無効状態で出す (ボタン構成は最終形を保つ)。
+ */
+export function FooterMenu({ onRefresh }: { onRefresh: () => void }) {
+  const iconClass = "h-[14px] w-[14px]";
+  const gotoTop = () => window.scrollTo({ top: 0 });
+  const gotoBottom = () => {
+    const bottom = document.getElementById("bottom");
+    if (bottom) bottom.scrollIntoView();
+  };
+
+  return (
+    <div className="fixed bottom-0 left-0 z-20 w-screen">
+      <div className="flex rounded-[4px] bg-[#303030] p-[3px]">
+        <MenuButton
+          icon={<ArrowUpIcon className={iconClass} />}
+          label="最上部へ"
+          onClick={gotoTop}
+        />
+        <MenuButton
+          icon={<ArrowDownIcon className={iconClass} />}
+          label="最下部へ"
+          onClick={gotoBottom}
+        />
+        <MenuButton
+          icon={<ArrowPathIcon className={iconClass} />}
+          label="更新"
+          onClick={onRefresh}
+        />
+        <MenuButton icon={<FunnelIcon className={iconClass} />} label="抽出" disabled />
+        <MenuButton icon={<InformationCircleIcon className={iconClass} />} label="情報" disabled />
+        <MenuButton icon={<Cog6ToothIcon className={iconClass} />} label="設定" disabled />
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/routes/village/FootstepTab.tsx
+++ b/frontend/app/routes/village/FootstepTab.tsx
@@ -1,0 +1,39 @@
+import type { VillageFootstepContent, VillageRoomAssignedRow } from "~/features/village/api";
+import { RoomLegend } from "./RoomLegend";
+
+const cellBorderClass = "border border-[#464545]";
+
+/** 日別の足音一覧。表示形式 (詳細/簡略) はサーバがビューアごとに整形済み。 */
+export function FootstepTab({
+  footstepList,
+  roomAssignedRows,
+}: {
+  footstepList: VillageFootstepContent[];
+  roomAssignedRows: VillageRoomAssignedRow[] | null | undefined;
+}) {
+  return (
+    <div className="pt-[10px] pb-[10px]">
+      <div className="overflow-x-auto">
+        <table className={`${cellBorderClass} border-collapse text-[10.32px]`}>
+          <tbody>
+            {roomAssignedRows && (
+              <tr>
+                <td className={`${cellBorderClass} p-[5px] whitespace-nowrap`} colSpan={2}>
+                  <RoomLegend rows={roomAssignedRows} />
+                </td>
+              </tr>
+            )}
+            {footstepList.map((footstep) => (
+              <tr key={footstep.day}>
+                <td className={`${cellBorderClass} p-[5px] text-center`}>{footstep.day}d</td>
+                <td className={`${cellBorderClass} p-[5px] whitespace-pre-line`}>
+                  {footstep.footstep}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/routes/village/MemberListTab.tsx
+++ b/frontend/app/routes/village/MemberListTab.tsx
@@ -1,0 +1,47 @@
+import type { VillageMemberContent } from "~/features/village/api";
+
+const cellBorderClass = "border border-[#464545]";
+
+function MemberTable({ group }: { group: VillageMemberContent }) {
+  const members = group.statusMemberList ?? [];
+  return (
+    <table className={`${cellBorderClass} mb-[21px] w-full border-collapse text-[10.32px]`}>
+      <tbody>
+        <tr>
+          <th className={`${cellBorderClass} p-[5px] text-left align-top`}>
+            {group.status} ({members.length}人)
+          </th>
+        </tr>
+        {members.map((member, index) => (
+          <tr key={index}>
+            <td className={`${cellBorderClass} p-[5px]`}>
+              {member.deadDay != null ? `${member.deadDay} ` : ""}
+              {member.charaName}
+              {member.memo != null ? `　[${member.memo}]` : ""}
+            </td>
+          </tr>
+        ))}
+        {members.length === 0 && (
+          <tr>
+            <td className={`${cellBorderClass} p-[5px]`}>なし</td>
+          </tr>
+        )}
+      </tbody>
+    </table>
+  );
+}
+
+/** ステータス別の参加者一覧。先頭グループ (生存) を左列、残りを右列に出す。 */
+export function MemberListTab({ memberList }: { memberList: VillageMemberContent[] }) {
+  const [first, ...rest] = memberList;
+  return (
+    <div className="flex pt-[10px] pb-[10px]">
+      <div className="w-1/2 px-[15px]">{first && <MemberTable group={first} />}</div>
+      <div className="w-1/2 px-[15px]">
+        {rest.map((group) => (
+          <MemberTable key={group.status} group={group} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/routes/village/MemberListTab.tsx
+++ b/frontend/app/routes/village/MemberListTab.tsx
@@ -12,8 +12,8 @@ function MemberTable({ group }: { group: VillageMemberContent }) {
             {group.status} ({members.length}人)
           </th>
         </tr>
-        {members.map((member, index) => (
-          <tr key={index}>
+        {members.map((member) => (
+          <tr key={member.charaName}>
             <td className={`${cellBorderClass} p-[5px]`}>
               {member.deadDay != null ? `${member.deadDay} ` : ""}
               {member.charaName}

--- a/frontend/app/routes/village/RoomAssignedTab.tsx
+++ b/frontend/app/routes/village/RoomAssignedTab.tsx
@@ -1,0 +1,122 @@
+import type { VillageRoomAssignedRow, VillageSituationContent } from "~/features/village/api";
+import { deadMark } from "./dead";
+
+const cellBorderClass = "border border-[#464545]";
+
+/** 役職名は 5 文字を超えると先頭 4 文字 + 省略記号にする (部屋セル幅に収めるため)。 */
+function shortenSkillName(skillName: string): string {
+  return skillName.length > 5 ? `${skillName.slice(0, 4)}...` : skillName;
+}
+
+/** 部屋割りグリッド + 日別状況テーブル。 */
+export function RoomAssignedTab({
+  rows,
+  situationList,
+  isViewableSpoilerContent,
+}: {
+  rows: VillageRoomAssignedRow[];
+  situationList: VillageSituationContent[];
+  isViewableSpoilerContent: boolean;
+}) {
+  return (
+    <div className="pt-[10px] pb-[10px]">
+      <div className="overflow-x-auto">
+        <table className={`${cellBorderClass} border-collapse text-[10.32px]`}>
+          <tbody>
+            {rows.map((row, rowIndex) => (
+              <tr key={rowIndex}>
+                {(row.roomAssignedList ?? []).map((room) => (
+                  <td
+                    key={room.roomNumber}
+                    className={`${cellBorderClass} relative p-0 text-center align-middle`}
+                    style={{
+                      width: room.maxWidth ?? undefined,
+                      minWidth: room.maxWidth ?? undefined,
+                      height: room.maxHeight ?? undefined,
+                    }}
+                  >
+                    <div
+                      title={room.charaName ?? undefined}
+                      className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
+                      style={{
+                        width: room.charaImgWidth ?? room.maxWidth ?? undefined,
+                        height: room.charaImgHeight ?? room.maxHeight ?? undefined,
+                        ...(room.charaImgUrl
+                          ? {
+                              backgroundImage: `url(${room.charaImgUrl})`,
+                              backgroundRepeat: "no-repeat",
+                              backgroundSize: "contain",
+                            }
+                          : {}),
+                        ...(room.isDead == null || room.isDead ? { opacity: 0.3 } : {}),
+                      }}
+                    />
+                    <div className="absolute bottom-0 left-1/2 -translate-x-1/2 opacity-80">
+                      <span className="bg-wm-base whitespace-nowrap">
+                        {room.roomNumber} {room.charaShortName ?? ""}
+                      </span>
+                      {room.isDead && room.charaShortName != null && (
+                        <span className="bg-wm-base whitespace-nowrap">
+                          <br />
+                          {room.deadDay}d {deadMark(room.deadReason)}
+                        </span>
+                      )}
+                      {room.isDummy && (
+                        <span className="bg-wm-base whitespace-nowrap">
+                          <br />
+                          ダミー
+                        </span>
+                      )}
+                      {room.skillName != null && (
+                        <span className="bg-wm-base whitespace-nowrap">
+                          <br />
+                          {shortenSkillName(room.skillName)}
+                        </span>
+                      )}
+                    </div>
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {situationList.length > 0 && (
+        <div className="mt-[10px]">
+          <table className={`${cellBorderClass} border-collapse text-[10.32px]`}>
+            <thead>
+              <tr>
+                <th className={`${cellBorderClass} p-[5px] text-center`}>日付</th>
+                <th className={`${cellBorderClass} p-[5px] text-left`}>突然死</th>
+                <th className={`${cellBorderClass} p-[5px] text-left`}>処刑</th>
+                <th className={`${cellBorderClass} p-[5px] text-left`}>犠牲</th>
+                <th className={`${cellBorderClass} p-[5px] text-left`}>復活</th>
+                <th className={`${cellBorderClass} p-[5px] text-left`}>後追</th>
+                {isViewableSpoilerContent && (
+                  <th className={`${cellBorderClass} p-[5px] text-left`}>能力</th>
+                )}
+              </tr>
+            </thead>
+            <tbody>
+              {situationList.map((situation) => (
+                <tr key={situation.day}>
+                  <td className={`${cellBorderClass} p-[5px] text-center`}>{situation.day}d</td>
+                  <td className={`${cellBorderClass} p-[5px]`}>{situation.suddonlyDeathChara}</td>
+                  <td className={`${cellBorderClass} p-[5px]`}>{situation.executedChara}</td>
+                  <td className={`${cellBorderClass} p-[5px]`}>{situation.attackedChara}</td>
+                  <td className={`${cellBorderClass} p-[5px]`}>{situation.revivalChara}</td>
+                  <td className={`${cellBorderClass} p-[5px]`}>{situation.suicideChara}</td>
+                  {isViewableSpoilerContent && (
+                    <td className={`${cellBorderClass} p-[5px] whitespace-pre-line`}>
+                      {situation.ability}
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/routes/village/RoomLegend.tsx
+++ b/frontend/app/routes/village/RoomLegend.tsx
@@ -1,0 +1,31 @@
+import type { VillageRoomAssignedRow } from "~/features/village/api";
+import { deadColor } from "./dead";
+
+/**
+ * 部屋番号と参加者の対応一覧 (投票・足音タブの先頭に出す)。死亡者は死因の系統で色分けし、
+ * 空き部屋は番号 + 全角アンダースコアで示す。
+ */
+export function RoomLegend({ rows }: { rows: VillageRoomAssignedRow[] }) {
+  return (
+    <>
+      {rows.map((row, rowIndex) => (
+        <span key={rowIndex}>
+          {(row.roomAssignedList ?? []).map((room, roomIndex) => {
+            const isVacant = room.isDead == null || room.charaShortName == null;
+            const color = room.isDead ? deadColor(room.deadReason) : null;
+            return (
+              <span key={room.roomNumber}>
+                <span style={color ? { color } : undefined}>
+                  {isVacant ? `${room.roomNumber}＿` : `${room.roomNumber}${room.charaShortName}`}
+                </span>
+                {roomIndex < (row.roomAssignedList?.length ?? 0) - 1 && <span>　</span>}
+              </span>
+            );
+          })}
+          <br />
+          {rowIndex < rows.length - 1 && <br />}
+        </span>
+      ))}
+    </>
+  );
+}

--- a/frontend/app/routes/village/SituationPanel.tsx
+++ b/frontend/app/routes/village/SituationPanel.tsx
@@ -1,0 +1,90 @@
+import { useId, useState } from "react";
+
+import type { VillageSituationView } from "~/features/village/api";
+import { FootstepTab } from "./FootstepTab";
+import { MemberListTab } from "./MemberListTab";
+import { RoomAssignedTab } from "./RoomAssignedTab";
+import { VoteTab } from "./VoteTab";
+
+type TabKey = "room" | "member" | "vote" | "footstep";
+
+/**
+ * 状況サマリ。部屋割り / 参加者 / 投票 / 足音 をタブで切り替える。
+ * 部屋割りタブは部屋が割り当てられた 1 日目以降のみ表示する。
+ */
+export function SituationPanel({
+  situation,
+  day,
+}: {
+  situation: VillageSituationView;
+  day: number;
+}) {
+  const hasRoomTab = situation.roomWidth != null && day > 0;
+  const hasVoteTab = situation.vote != null;
+  const hasFootstepTab = (situation.footstepList ?? []).length > 0;
+
+  const [open, setOpen] = useState(true);
+  const [activeTab, setActiveTab] = useState<TabKey>(hasRoomTab ? "room" : "member");
+  const bodyId = useId();
+
+  const tabs: { key: TabKey; label: string }[] = [
+    ...(hasRoomTab ? [{ key: "room" as const, label: "部屋割り当て" }] : []),
+    { key: "member", label: "参加者" },
+    ...(hasVoteTab ? [{ key: "vote" as const, label: "投票" }] : []),
+    ...(hasFootstepTab ? [{ key: "footstep" as const, label: "足音" }] : []),
+  ];
+
+  return (
+    <div className="mb-[20px] rounded border border-[#464545] bg-[#303030]">
+      <div className="rounded-t bg-[#464545] px-[15px] py-[10px]">
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-controls={bodyId}
+          onClick={() => setOpen((v) => !v)}
+          className="cursor-pointer text-[15px] text-white hover:underline"
+        >
+          状況
+        </button>
+      </div>
+      {open && (
+        <div id={bodyId} className="p-[15px]">
+          <ul className="flex border-b border-[#464545]">
+            {tabs.map((tab) => (
+              <li key={tab.key} className="-mb-px">
+                <button
+                  type="button"
+                  onClick={() => setActiveTab(tab.key)}
+                  className={`mr-[2px] block rounded-t-[4px] border px-[15px] py-[10px] text-[12px] ${
+                    activeTab === tab.key
+                      ? "bg-wm-base border-[#464545] border-b-transparent text-[#00bc8c]"
+                      : "text-wm-accent cursor-pointer border-transparent hover:border-[#464545] hover:bg-[#303030]"
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              </li>
+            ))}
+          </ul>
+          {activeTab === "room" && hasRoomTab && (
+            <RoomAssignedTab
+              rows={situation.roomAssignedRowList ?? []}
+              situationList={situation.situationList ?? []}
+              isViewableSpoilerContent={situation.isViewableSpoilerContent ?? false}
+            />
+          )}
+          {activeTab === "member" && <MemberListTab memberList={situation.memberList ?? []} />}
+          {activeTab === "vote" && situation.vote != null && (
+            <VoteTab vote={situation.vote} roomAssignedRows={situation.roomAssignedRowList} />
+          )}
+          {activeTab === "footstep" && (
+            <FootstepTab
+              footstepList={situation.footstepList ?? []}
+              roomAssignedRows={situation.roomAssignedRowList}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/routes/village/VoteTab.tsx
+++ b/frontend/app/routes/village/VoteTab.tsx
@@ -77,8 +77,8 @@ export function VoteTab({
             </tr>
           </thead>
           <tbody>
-            {sortedList.map((member, index) => (
-              <tr key={index}>
+            {sortedList.map((member) => (
+              <tr key={member.charaName}>
                 <td className={`${cellBorderClass} p-[5px]`}>{member.charaName}</td>
                 {(member.voteTargetList ?? []).map((target, targetIndex) => (
                   <td

--- a/frontend/app/routes/village/VoteTab.tsx
+++ b/frontend/app/routes/village/VoteTab.tsx
@@ -1,0 +1,101 @@
+import { useMemo, useState } from "react";
+
+import type { VillageRoomAssignedRow, VillageVoteContent } from "~/features/village/api";
+import { RoomLegend } from "./RoomLegend";
+
+const cellBorderClass = "border border-[#464545]";
+
+/**
+ * 投票表。日付見出しをクリックするとその日の投票先でソートし、セルをクリックすると
+ * 同じ投票先のセルを色付けする (議論の追跡用)。
+ */
+export function VoteTab({
+  vote,
+  roomAssignedRows,
+}: {
+  vote: VillageVoteContent;
+  roomAssignedRows: VillageRoomAssignedRow[] | null | undefined;
+}) {
+  const [sortDayIndex, setSortDayIndex] = useState(0);
+  const [highlightTarget, setHighlightTarget] = useState<string | null>(null);
+
+  const maxVoteCount = vote.maxVoteCount ?? 0;
+
+  const sortedList = useMemo(() => {
+    const voteList = vote.voteList ?? [];
+    if (sortDayIndex === 0) return voteList;
+    // クリックした日の投票先 (なし = 末尾) で並べ替える
+    const targetIndex = sortDayIndex - 1;
+    return [...voteList].sort((a, b) => {
+      const aTarget = a.voteTargetList?.[targetIndex] || "";
+      const bTarget = b.voteTargetList?.[targetIndex] || "";
+      if (aTarget === bTarget) return 0;
+      if (aTarget === "") return 1;
+      if (bTarget === "") return -1;
+      return aTarget.localeCompare(bTarget);
+    });
+  }, [vote, sortDayIndex]);
+
+  const onCellClick = (target: string) => {
+    if (target === "") return;
+    setHighlightTarget((prev) => (prev === target ? null : target));
+  };
+
+  return (
+    <div className="pt-[10px] pb-[10px]">
+      <div className="overflow-x-auto">
+        <table className={`${cellBorderClass} border-collapse text-[10.32px]`}>
+          <thead>
+            {roomAssignedRows && (
+              <tr>
+                <td className={`${cellBorderClass} p-[5px]`} colSpan={maxVoteCount + 1}>
+                  <RoomLegend rows={roomAssignedRows} />
+                </td>
+              </tr>
+            )}
+            <tr>
+              <th className={`${cellBorderClass} p-[5px] text-left`}>
+                <button
+                  type="button"
+                  className="text-wm-accent cursor-pointer hover:underline"
+                  onClick={() => setSortDayIndex(0)}
+                >
+                  投票者
+                </button>
+              </th>
+              {Array.from({ length: maxVoteCount }, (_, i) => i + 2).map((day) => (
+                <th key={day} className={`${cellBorderClass} p-[5px] text-center`}>
+                  <button
+                    type="button"
+                    className="text-wm-accent cursor-pointer hover:underline"
+                    onClick={() => setSortDayIndex(day - 1)}
+                  >
+                    {day}d
+                  </button>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {sortedList.map((member, index) => (
+              <tr key={index}>
+                <td className={`${cellBorderClass} p-[5px]`}>{member.charaName}</td>
+                {(member.voteTargetList ?? []).map((target, targetIndex) => (
+                  <td
+                    key={targetIndex}
+                    className={`${cellBorderClass} cursor-pointer p-[5px] ${
+                      highlightTarget != null && target === highlightTarget ? "bg-[#3498db]" : ""
+                    }`}
+                    onClick={() => onCellClick(target)}
+                  >
+                    {target}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/routes/village/dayLabel.ts
+++ b/frontend/app/routes/village/dayLabel.ts
@@ -1,0 +1,11 @@
+/**
+ * 日付の表示ラベル。0 日目はプロローグ、エピローグ日はエピローグ、その翌日は終了。
+ */
+export function dayLabel(day: number, epilogueDay: number | null | undefined): string {
+  if (day === 0) return "プロローグ";
+  if (epilogueDay != null) {
+    if (day === epilogueDay) return "エピローグ";
+    if (day - 1 === epilogueDay) return "終了";
+  }
+  return `${day}日目`;
+}

--- a/frontend/app/routes/village/dead.ts
+++ b/frontend/app/routes/village/dead.ts
@@ -1,0 +1,25 @@
+/** 死因コード → 部屋割りグリッドの死亡マーク。 */
+export function deadMark(deadReason: string | null | undefined): string {
+  switch (deadReason) {
+    case "SUDDON":
+      return "凸";
+    case "EXECUTE":
+      return "▼";
+    case "SUICIDE":
+      return "❤︎";
+    default:
+      return "▲";
+  }
+}
+
+/** 無惨系 (襲撃/呪殺/罠死/爆死/雑魚) の死因コード。部屋番号一覧で赤表示する。 */
+const MISERABLE_REASONS = ["ATTACK", "DIVINED", "TRAPPED", "BOMBED", "ZAKO"];
+
+/** 死因コード → 部屋番号一覧の文字色 (生存・該当なしは null)。 */
+export function deadColor(deadReason: string | null | undefined): string | null {
+  if (deadReason == null) return null;
+  if (MISERABLE_REASONS.includes(deadReason)) return "#ff0000";
+  if (deadReason === "EXECUTE" || deadReason === "SUDDON") return "#3498db";
+  if (deadReason === "SUICIDE") return "#db3498";
+  return null;
+}

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -1,0 +1,195 @@
+import { useEffect } from "react";
+import { Link } from "react-router";
+
+import { PageLayout } from "~/components/layout/PageLayout";
+import { LinkButton } from "~/components/ui/Button";
+import { useMe } from "~/features/auth/useMe";
+import type { VillageDetailView } from "~/features/village/api";
+import {
+  useInvalidateVillage,
+  useMyVillageSituation,
+  useVillage,
+  useVillagePolling,
+  useVillageSituation,
+} from "~/features/village/useVillage";
+import { ApiError } from "~/lib/api";
+import { siteMeta } from "~/lib/meta";
+import { DayList } from "./DayList";
+import { FooterMenu } from "./FooterMenu";
+import { SituationPanel } from "./SituationPanel";
+import { useCountdown } from "./useCountdown";
+import type { Route } from "./+types/route";
+
+export function meta(_: Route.MetaArgs) {
+  // 村名は CSR で取得するため、確定後に document.title を村名へ差し替える (タイトルは村名のみ)
+  return siteMeta();
+}
+
+function latestDayOf(village: VillageDetailView): number {
+  const days = village.days.list ?? [];
+  return days.length > 0 ? days[days.length - 1].day : 0;
+}
+
+/** 村番号は 4 桁 0 埋めで表示する。 */
+function villageNumber(id: number): string {
+  return String(id).padStart(4, "0");
+}
+
+function formatStartDatetime(iso: string): string {
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}/${pad(d.getMonth() + 1)}/${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/**
+ * 村の共有ツイートボタン。村名 (募集中は開始予定日時も) + ハッシュタグを共有する。
+ * 公式 widget script は読み込まず、同じ共有 URL を開くボタンで代替する。
+ */
+function TweetButton({ village }: { village: VillageDetailView }) {
+  const lines = [village.name];
+  if (latestDayOf(village) === 0) {
+    lines.push(`開始予定: ${formatStartDatetime(village.setting.startDatetime)}`);
+  }
+  const url = `https://twitter.com/share?text=${encodeURIComponent(lines.join("\n") + "\n")}&hashtags=WOLF_MANSION`;
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noreferrer"
+      className="rounded-full bg-[#1d9bf0] px-[12px] py-[4px] text-[11px] font-bold text-white hover:bg-[#0c7abf]"
+    >
+      ツイート
+    </a>
+  );
+}
+
+export default function Village({ params }: Route.ComponentProps) {
+  const villageId = Number(params.villageId);
+  const dayParam = params.day != null ? Number(params.day) : undefined;
+
+  const { me } = useMe();
+  const { data: village, error: villageError } = useVillage(villageId);
+  const { data: situation } = useVillageSituation(villageId, dayParam, me?.name ?? null);
+  const { error: mySituationError } = useMyVillageSituation(villageId, dayParam);
+  const invalidate = useInvalidateVillage(villageId);
+
+  const latestDay = village != null ? latestDayOf(village) : undefined;
+  const currentDay = dayParam ?? latestDay ?? 0;
+
+  const daychangeDetected = useVillagePolling(villageId, latestDay);
+  // ログイン中のはずなのに認証が立て直せない (refresh 失敗) 場合は再ログインを促す
+  const sessionExpired =
+    me != null && mySituationError instanceof ApiError && mySituationError.status === 401;
+
+  const dayChangeDatetime =
+    village != null && !village.status.isFinished
+      ? (village.days.list?.[village.days.list.length - 1]?.dayChangeDatetime ?? null)
+      : null;
+  const leftTime = useCountdown(dayChangeDatetime);
+
+  useEffect(() => {
+    if (village != null) document.title = `WOLF MANSION | ${village.name}`;
+  }, [village]);
+
+  if (villageError instanceof ApiError && villageError.status === 404) {
+    return (
+      <PageLayout>
+        <div className="px-[15px] py-[30px]">村が見つかりませんでした。</div>
+      </PageLayout>
+    );
+  }
+  if (village == null) {
+    return (
+      <PageLayout>
+        <div className="px-[15px] py-[30px] text-gray-400">読み込み中...</div>
+      </PageLayout>
+    );
+  }
+
+  const noAd = (village.setting.tags.list ?? []).some((tag) => tag.code === "R18");
+
+  return (
+    <PageLayout noAd={noAd}>
+      <div className="px-[15px] pb-[45px]">
+        {/* 村タイトル */}
+        <div className="flex">
+          <h1 className="my-[10.5px] flex-1 text-[15px] font-normal">
+            {villageNumber(village.id)}. {village.name}
+          </h1>
+          <div className="my-[10.5px]">
+            <TweetButton village={village} />
+          </div>
+        </div>
+        <hr className="mt-[5px] mb-[10px] border-[#464545]" />
+
+        <DayList
+          villageId={villageId}
+          dayList={(village.days.list ?? []).map((d) => d.day)}
+          currentDay={currentDay}
+          epilogueDay={village.epilogueDay}
+        />
+
+        {/* 発言ログ (メッセージ表示は未実装) */}
+        <div className="text-gray-400">読み込み中...</div>
+        {!noAd && (
+          <div className="mt-[15px] min-h-[90px] border border-dashed border-gray-600 p-2 text-center text-gray-400">
+            広告（移行中はプレースホルダー）
+          </div>
+        )}
+        <hr className="mt-[5px] mb-[10px] border-[#464545]" />
+
+        {/* 最下部への移動先 (発言後のスクロール先) */}
+        <div id="bottom" />
+
+        {situation != null && <SituationPanel situation={situation} day={currentDay} />}
+
+        <DayList
+          villageId={villageId}
+          dayList={(village.days.list ?? []).map((d) => d.day)}
+          currentDay={currentDay}
+          epilogueDay={village.epilogueDay}
+        />
+
+        <div className="mb-[10px]">
+          <LinkButton to="/" variant="default">
+            サイトトップへ
+          </LinkButton>
+          <LinkButton
+            to={`/village/${villageId}/scrap`}
+            target="_blank"
+            variant="success"
+            className="ml-[10px]"
+          >
+            切り抜き画面へ
+          </LinkButton>
+        </div>
+      </div>
+
+      <FooterMenu onRefresh={() => invalidate()} />
+
+      {/* 通知系のオーバーレイ */}
+      {daychangeDetected && (
+        <div className="fixed top-0 right-[5px] left-[5px] z-[105] rounded bg-[#00bc8c] p-[15px] text-white">
+          日付が更新されました。ページを再読み込みしてください。
+        </div>
+      )}
+      {leftTime != null && (
+        <div className="fixed top-[5px] right-[5px] z-[100] rounded bg-[#3498db] p-[5px] text-white">
+          更新まで <span>{leftTime}</span>
+        </div>
+      )}
+      {me != null && !sessionExpired && (
+        <Link to={`/user/${me.name}`} target="_blank">
+          <div className="fixed top-[5px] left-[5px] z-[100] rounded bg-[#3498db] p-[5px] text-white">
+            ユーザID: {me.name}
+          </div>
+        </Link>
+      )}
+      {sessionExpired && (
+        <div className="fixed top-[5px] left-[5px] z-[100] rounded bg-[#e74c3c] p-[5px] text-white">
+          要再ログイン
+        </div>
+      )}
+    </PageLayout>
+  );
+}

--- a/frontend/app/routes/village/useCountdown.ts
+++ b/frontend/app/routes/village/useCountdown.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+
+function pad(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+function format(diffMs: number): string {
+  const diff = Math.max(diffMs, 0);
+  // 100 時間以上はカンスト表示 (募集中の村は開始まで数日あるため)
+  if (diff >= 100 * 60 * 60 * 1000) return "99:59:59";
+  const hours = Math.floor(diff / (60 * 60 * 1000));
+  const minutes = Math.floor((diff % (60 * 60 * 1000)) / (60 * 1000));
+  const seconds = Math.floor((diff % (60 * 1000)) / 1000);
+  return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+}
+
+/**
+ * 次回更新までの残り時間 (HH:MM:SS)。500ms ごとに更新する。
+ * 更新日時が無い (終了した村) 場合は null を返す。
+ */
+export function useCountdown(dayChangeDatetime: string | null | undefined): string | null {
+  const [leftTime, setLeftTime] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (dayChangeDatetime == null) {
+      setLeftTime(null);
+      return;
+    }
+    const target = new Date(dayChangeDatetime).getTime();
+    const update = () => setLeftTime(format(target - Date.now()));
+    update();
+    const timer = setInterval(update, 500);
+    return () => clearInterval(timer);
+  }, [dayChangeDatetime]);
+
+  return leftTime;
+}


### PR DESCRIPTION
closes .issues/step-8.1-village-base.md

## 概要

村画面ベース (Step 8 の土台) を REST + React 化する。**`VillageSituation` (村全体・公開) / `ParticipantSituation` (本人・認証) の二層 + `isViewableSpoilerContent` を村取得 API のマスク基盤として確立**し、レイアウト / 日付ナビ / 状況サマリ 4 タブ / 30 秒ポーリング / 残り時間カウントダウンを実装する。

> **Step 8 統合ブランチ方式**: base は `feature/monorepo-step8`。ユーザー指示 (2026-06-12) により、この PR の同ブランチへの squash merge は Claude 単独で実施する。`feature/monorepo` への取り込みは最終 PR でユーザーレビューを受ける。

## backend

新設 REST (すべて `VillageRestController`):

| エンドポイント | 認可 | 内容 |
|---|---|---|
| `GET /api/v1/villages/{id}` | permitAll | 村詳細 `VillageDetailView` (id/name/status/days/epilogueDay/roomSize/setting)。参加者情報は含めない (視点依存マスクは situation API の責務)。joinPassword は既存 `VillageSettingView` が除外 |
| `GET /api/v1/villages/{id}/situation?day=` | permitAll (視点反映) | 村状況 `VillageSituationView` = 状況サマリの実データ (部屋割り行 / ステータス別参加者 / 投票表 / 足音 / 日別状況)。**マスクは backend 完結**: 部屋割り役職名は既存 `VillageRoomAssignedRow` の可視判定、足音・能力欄・投票隠蔽日は既存 domain service の判定をそのまま流用 (マスクロジックの重複実装をしない)。`VillageContent` の実フィールドを正本にした (village-base.md の確定方針) |
| `GET /api/v1/villages/{id}/situation/me?day=` | 認証必須 | `ParticipantSituationView` = capability フラグ (participate/skillRequest/commit/say/rp/ability/vote/admin/creator) + 本人最小情報。**8.1 はフラグのみ**で、各操作の入力候補はその操作を実装するサブ step で追加する。ネスト DTO は `@Schema` で命名 (単純名衝突による spec 上書き対策) |
| `POST /api/v1/villages/{id}/update` | permitAll | 村ポーリング。最終アクセス更新 + `DaychangeCoordinator.changeDayIfNeeded` (本番でもポーリング駆動の日付更新)。匿名閲覧者も daychange を駆動するため公開。応答は `{latestDay}` のみ (旧 `login` フラグは廃止し、セッション失効検知は situation/me の 401 へ移行) |

- `day` パラメータは省略時最新日、存在しない日は 400 (`resolveDay`)
- security: 公開 GET 2 本 + POST update を permitAll に追加
- 単体テスト: `ParticipantSituationViewTest` (フラグ写像) / `VillageSituationViewTest` (部屋なし村のマスク構造)

## frontend

- ルート `village/:villageId/day?/:day?` (`routes/village/`、colocation)。`features/village/` (単数形) に API クライアント + hooks
- **状況サマリ 4 タブ** (部屋割り当て / 参加者 / 投票 / 足音): 部屋割りグリッド (キャラ画像・死亡マーク 凸▼❤︎▲・役職名)、日別状況、2 列参加者一覧、投票表 (日付クリックでソート / セルクリックで同一投票先ハイライト)、足音一覧 + 部屋番号凡例 (死因系統で色分け)
- **ポーリング** (`useVillagePolling`): 30 秒ごと + 初回に `POST update` → 既知最新日より進んだら村系クエリ無効化 + 日付更新アラート表示
- **カウントダウン** (`useCountdown`): 500ms 更新、`HH:MM:SS`、100 時間以上は `99:59:59`、終了村は非表示
- **`apiFetch` に 401 → refresh → リトライ (single-flight) を追加**: 村画面は長時間滞在するため access token (15分) の自動更新が必須になった。refresh の rotation 二重提示 (漏洩検知の全失効) を防ぐため並行リクエストでも refresh は 1 回。`/auth/me` も対象 (リロード時に access 切れでもログイン継続)。login/signup/logout/refresh 自身は対象外
- フッターメニュー (固定): 最上部へ / 最下部へ / 更新 + 抽出・情報・設定 (各モーダルのサブ step まで disabled)
- アラート類: 日付更新 (上部固定)・残り時間 (右上)・ユーザID (左上、`/user/{name}` への SPA リンク)・要再ログイン (refresh 失敗時)
- title はページ確定後に `WOLF MANSION | <村名>` へ差し替え。R18 村は広告非表示 (`PageLayout` に `noAd` 追加)
- メッセージエリアはプレースホルダー (発言ログ表示は次サブ step)

## 検証

- `:8091` 突合: 募集中村 + 進行中村 (テスト村 5 を debug 機能で 3 日目まで進行) で全タブのスクショ比較・computed style 実測合わせ (h1 15px / 日付ナビ 10.32px / タブ active #00bc8c on #222 / テーブル 10.32px・p5px・border #464545 / フッターボタン 13px / アラート #3498db p5px)
- **`:8091` (旧コードベース) との意図的差異**: 旧版は部屋割りの役職名 span を出力しないが、**本リポジトリの SSR (移行正本) は admin/墓下公開視点で出力する**。React は本リポジトリ準拠 (8089 SSR 実測で確認)
- マスク実測: 匿名 = 役職名ゼロ・能力欄空・足音簡略形式・situation/me 401 / admin = 役職名 17 件。`POST update` は `{latestDay}` を返し、無効 day は 400
- Twitter 共有は widget script を読み込まず同一共有 URL のボタンで代替 (意図的差異)
- backend: ktlintCheck / test green。frontend: typecheck / lint / format / build green。`pnpm gen:api` 差分ゼロ (**本 PR は CI api-drift が走らないため branches フィルタに `feature/monorepo-step8` を追加済み**)
- e2e: village.spec 5 件追加 (村の状態は DB から動的に探し、無ければ skip)

## 申し送り

- 状況パネルの「固定」(bottom-fix) と表示設定 Cookie は 8.13、ネタバレ防止トグルは 8.3 (フィルタモーダル)、村情報モーダルは 8.14、年齢制限確認モーダルは 8.2 (メッセージ表示) で実装
- 共有 DB に村 5「step8 動作確認用の村」(進行中・3日目) を残置。e2e の進行中村テストが利用。不要になったら廃村可

🤖 Generated with [Claude Code](https://claude.com/claude-code)
