### PR TITLE
feat: 村画面の発言抽出を REST + React 化 (step-8.3)

### DIFF
--- a/.issues/README.md
+++ b/.issues/README.md
@@ -24,7 +24,7 @@ monorepo 移行作業中につき **階層番号方式** (`step-<N>(.M)-<slug>.m
 
 | # | タイトル | type | status |
 | --- | --- | --- | --- |
-| (現在 open な Issue なし) | | | |
+| step-8.3 | 村画面メッセージフィルタ (抽出モーダル / ハッシュタグ連動 / ネタバレ防止トグル) | enhancement | open |
 
 > **Step 8 は統合ブランチ方式 (ユーザー指示 2026-06-12)**: `feature/monorepo-step8` を base にサブ step PR を積み、同ブランチへの squash merge は Claude 単独で可。`feature/monorepo` への merge は最終 PR でユーザー承認。8.1 完了 ✅ (#71)、8.2 完了 ✅ (#72)。
 

--- a/backend/src/main/kotlin/com/ort/app/api/village/response/ParticipantSituationView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/response/ParticipantSituationView.kt
@@ -56,6 +56,8 @@ data class ParticipantSituationView(
         val shortName: String,
         val isDead: Boolean,
         val isSpectator: Boolean,
+        /** Discord 通知キーワード (スペース区切り、未設定は null)。発言抽出のショートカットが使う */
+        val notificationKeyword: String?,
     ) {
         constructor(myself: VillageParticipant) : this(
             id = myself.id,
@@ -64,6 +66,12 @@ data class ParticipantSituationView(
             shortName = myself.shortName(),
             isDead = myself.dead.isDead,
             isSpectator = myself.isSpectator,
+            notificationKeyword =
+                myself.notification
+                    ?.message
+                    ?.keywords
+                    ?.takeIf { it.isNotEmpty() }
+                    ?.joinToString(separator = " "),
         )
     }
 

--- a/backend/src/main/kotlin/com/ort/app/api/village/response/VillageSituationView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/response/VillageSituationView.kt
@@ -1,6 +1,7 @@
 package com.ort.app.api.village.response
 
 import com.ort.app.api.view.VillageContent
+import com.ort.app.api.view.village.VillageFilterParticipantContent
 import com.ort.app.api.view.village.VillageMemberContent
 import com.ort.app.api.view.village.VillageRoomAssignedRow
 import com.ort.app.domain.model.chara.Charachips
@@ -25,6 +26,8 @@ data class VillageSituationView(
     val roomWidth: Int?,
     /** ステータス別の参加者一覧 */
     val memberList: List<VillageMemberContent>,
+    /** 発言抽出用の参加者一覧 (部屋番号順) */
+    val participantList: List<VillageFilterParticipantContent>,
     /** 投票表 (3日目以降のみ) */
     val vote: VillageContent.VillageVoteContent?,
     /** 日別の足音 */
@@ -56,6 +59,10 @@ data class VillageSituationView(
                     status = it.status,
                     statusMemberList = it.list.map { participant -> VillageMemberContent.VillageMemberDetailContent(participant) },
                 )
+            },
+        participantList =
+            village.allParticipants().sortedByRoomNumber().list.map {
+                VillageFilterParticipantContent(village, it, charachips)
             },
         vote = if (day > 2) VillageContent.VillageVoteContent(village, villageSituation) else null,
         footstepList = villageSituation.footstep.list.map { VillageContent.VillageFootstepContent(it.day, it.footstep) },

--- a/e2e/tests/village-message-filter.spec.ts
+++ b/e2e/tests/village-message-filter.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * 村画面の発言抽出 e2e。村はローカル DB から動的に探し、無ければスキップする。
+ */
+
+type SimpleVillage = { id: number; name: string };
+
+async function findVillages(page: Page, statuses: string[]): Promise<SimpleVillage[]> {
+  const query = statuses.map((s) => `status=${s}`).join("&");
+  const res = await page.request.get(`/wolf-mansion-api/api/v1/villages?${query}`);
+  expect(res.ok()).toBeTruthy();
+  const body = (await res.json()) as { villages: SimpleVillage[] };
+  return body.villages;
+}
+
+test("URL の typ パラメータで種別が絞り込まれる (共有 URL の再現)", async ({ page }) => {
+  const villages = await findVillages(page, ["IN_PREPARATION", "IN_PROGRESS"]);
+  test.skip(villages.length === 0, "表示できる村が無い DB のためスキップ");
+  const village = villages[villages.length - 1];
+
+  // 公開システムメッセージのみに絞る (どの村にも村オープン時の定型文がある)
+  await page.goto(`village/${village.id}?typ=PUBLIC_SYSTEM`);
+
+  await expect(page.locator(".message").first()).toBeVisible({ timeout: 15000 });
+  // 通常発言の吹き出しが出ない (種別フィルタが効いている)
+  await expect(page.locator(".message-normal")).toHaveCount(0);
+  // footer のボタンが「抽出中」表示になる
+  await expect(page.getByRole("button", { name: "抽出中" })).toBeVisible();
+});
+
+test("抽出モーダルからキーワード抽出すると URL に保存される", async ({ page }) => {
+  const villages = await findVillages(page, ["IN_PREPARATION", "IN_PROGRESS"]);
+  test.skip(villages.length === 0, "表示できる村が無い DB のためスキップ");
+  const village = villages[villages.length - 1];
+
+  await page.goto(`village/${village.id}`);
+  await expect(page.locator(".message").first()).toBeVisible({ timeout: 15000 });
+
+  await page.getByRole("button", { name: "抽出", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "発言抽出" })).toBeVisible();
+
+  await page.getByPlaceholder("スペース区切り").fill("ようこそ");
+  await page.getByRole("button", { name: "抽出", exact: true }).last().click();
+
+  await expect(page).toHaveURL(/kwd=/);
+});

--- a/frontend/app/api/openapi.json
+++ b/frontend/app/api/openapi.json
@@ -1538,6 +1538,9 @@
           "name": {
             "type": "string"
           },
+          "notificationKeyword": {
+            "type": ["string", "null"]
+          },
           "shortName": {
             "type": "string"
           }
@@ -2601,6 +2604,33 @@
         },
         "required": ["days", "id", "name", "setting", "status"]
       },
+      "VillageFilterParticipantContent": {
+        "type": "object",
+        "properties": {
+          "deadStatus": {
+            "type": ["string", "null"]
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "imgHeight": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "imgUrl": {
+            "type": "string"
+          },
+          "imgWidth": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["id", "imgHeight", "imgUrl", "imgWidth", "name"]
+      },
       "VillageFootstepContent": {
         "type": "object",
         "properties": {
@@ -3129,6 +3159,12 @@
               "$ref": "#/components/schemas/VillageMemberContent"
             }
           },
+          "participantList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VillageFilterParticipantContent"
+            }
+          },
           "roomAssignedRowList": {
             "type": ["array", "null"],
             "items": {
@@ -3156,7 +3192,13 @@
             ]
           }
         },
-        "required": ["footstepList", "isViewableSpoilerContent", "memberList", "situationList"]
+        "required": [
+          "footstepList",
+          "isViewableSpoilerContent",
+          "memberList",
+          "participantList",
+          "situationList"
+        ]
       },
       "VillageStatus": {
         "type": "object",

--- a/frontend/app/api/types.ts
+++ b/frontend/app/api/types.ts
@@ -566,6 +566,7 @@ export interface components {
       isDead: boolean;
       isSpectator: boolean;
       name: string;
+      notificationKeyword?: string | null;
       shortName: string;
     };
     ParticipantSituationViewParticipate: {
@@ -868,6 +869,17 @@ export interface components {
       setting: components["schemas"]["VillageSettingView"];
       status: components["schemas"]["VillageStatus"];
     };
+    VillageFilterParticipantContent: {
+      deadStatus?: string | null;
+      /** Format: int32 */
+      id: number;
+      /** Format: int32 */
+      imgHeight: number;
+      imgUrl: string;
+      /** Format: int32 */
+      imgWidth: number;
+      name: string;
+    };
     VillageFootstepContent: {
       /** Format: int32 */
       day: number;
@@ -1027,6 +1039,7 @@ export interface components {
       footstepList: components["schemas"]["VillageFootstepContent"][];
       isViewableSpoilerContent: boolean;
       memberList: components["schemas"]["VillageMemberContent"][];
+      participantList: components["schemas"]["VillageFilterParticipantContent"][];
       roomAssignedRowList?: components["schemas"]["VillageRoomAssignedRow"][] | null;
       /** Format: int32 */
       roomWidth?: number | null;

--- a/frontend/app/components/ui/ButtonCheckboxGroup.tsx
+++ b/frontend/app/components/ui/ButtonCheckboxGroup.tsx
@@ -1,0 +1,48 @@
+/** ボタン型チェックボックスの選択肢。 */
+export type ButtonCheckboxOption<T> = {
+  value: T;
+  label: string;
+};
+
+const buttonClass = (selected: boolean) =>
+  `not-first:-ml-px flex-1 cursor-pointer border border-[#00bc8c] px-[9px] py-[5px] text-[13px] first:rounded-l-[3px] last:rounded-r-[3px] hover:opacity-90 ${
+    selected
+      ? "bg-[#00bc8c] text-white shadow-[inset_0_3px_5px_rgba(0,0,0,0.125)]"
+      : "bg-[#222222] text-[#00bc8c]"
+  }`;
+
+/**
+ * ボタンを横並びにした複数選択 (チェックボックス)。緑枠 + 選択時のみ緑地で、
+ * 単一選択の `ButtonRadioGroup` (outline) と同じ見た目にする。
+ */
+export function ButtonCheckboxGroup<T>({
+  options,
+  values,
+  onToggle,
+  ariaLabel,
+}: {
+  options: ButtonCheckboxOption<T>[];
+  values: T[];
+  onToggle: (value: T) => void;
+  ariaLabel?: string;
+}) {
+  return (
+    <div role="group" aria-label={ariaLabel} className="flex">
+      {options.map((opt) => {
+        const selected = values.includes(opt.value);
+        return (
+          <button
+            key={opt.label}
+            type="button"
+            role="checkbox"
+            aria-checked={selected}
+            onClick={() => onToggle(opt.value)}
+            className={buttonClass(selected)}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/app/components/ui/TextButton.tsx
+++ b/frontend/app/components/ui/TextButton.tsx
@@ -1,0 +1,18 @@
+import type { ButtonHTMLAttributes } from "react";
+
+/**
+ * 本文中のテキストリンク風アクションボタン。遷移を伴うものは `TextLink` を使う。
+ */
+export function TextButton({
+  className = "",
+  type = "button",
+  ...props
+}: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      type={type}
+      className={`text-wm-accent cursor-pointer hover:underline ${className}`}
+      {...props}
+    />
+  );
+}

--- a/frontend/app/features/village/api.ts
+++ b/frontend/app/features/village/api.ts
@@ -128,3 +128,7 @@ export function fetchAnchorMessages(
 export function fetchVillageParticipants(id: number): Promise<VillageParticipantsContent> {
   return apiFetch<VillageParticipantsContent>(`/api/v1/villages/${id}/participants`);
 }
+
+/** 発言抽出用の参加者ビュー (村状況 API の participantList)。 */
+export type VillageFilterParticipantContent =
+  components["schemas"]["VillageFilterParticipantContent"];

--- a/frontend/app/features/village/filter.ts
+++ b/frontend/app/features/village/filter.ts
@@ -1,0 +1,87 @@
+/**
+ * 発言抽出のフィルタ状態。URL の searchParams を正本にする (共有 URL で再現可能)。
+ * パラメータ名は既存 (`fpid`/`typ`/`kwd`/`tpid`/`spl`) を踏襲する。
+ */
+
+/** 抽出モーダルの発言種別 (チェックボックスの並び順)。 */
+export const FILTER_TYPES: { value: string; label: string }[] = [
+  { value: "NORMAL_SAY", label: "通常" },
+  { value: "GRAVE_SPECTATE_SAY", label: "墓下見学" },
+  { value: "MONOLOGUE_SAY", label: "独り言" },
+  { value: "CREATOR_SAY", label: "村建て発言" },
+  { value: "WEREWOLF_SAY", label: "囁き" },
+  { value: "MASON_SAY", label: "共鳴" },
+  { value: "LOVERS_SAY", label: "恋人" },
+  { value: "TELEPATHY", label: "念話" },
+  { value: "SECRET_SAY", label: "秘話" },
+  { value: "ACTION", label: "アクション" },
+  { value: "PUBLIC_SYSTEM", label: "公開シスメ" },
+  { value: "PRIVATE_SYSTEM", label: "非公開シスメ" },
+];
+
+export type MessageFilter = {
+  /** 発言者の参加者 ID。空 = 全員 */
+  participantIds: number[];
+  /** 宛先の参加者 ID。空 = 全員 */
+  toParticipantIds: number[];
+  /** 発言種別。空 = 全種別 */
+  types: string[];
+  /** キーワード (スペース区切りの原文)。空文字 = 指定なし */
+  keywords: string;
+  /** ネタバレ防止 (エピローグ前同等の表示にする) */
+  spoiled: boolean;
+};
+
+export const EMPTY_FILTER: MessageFilter = {
+  participantIds: [],
+  toParticipantIds: [],
+  types: [],
+  keywords: "",
+  spoiled: false,
+};
+
+export function parseFilter(params: URLSearchParams): MessageFilter {
+  const ids = (value: string | null): number[] =>
+    value == null || value === ""
+      ? []
+      : value
+          .split(",")
+          .map(Number)
+          .filter((n) => Number.isFinite(n));
+  return {
+    participantIds: ids(params.get("fpid")),
+    toParticipantIds: ids(params.get("tpid")),
+    types: (params.get("typ") ?? "").split(",").filter((t) => t !== ""),
+    keywords: params.get("kwd") ?? "",
+    spoiled: params.get("spl") === "true",
+  };
+}
+
+/** フィルタ状態を searchParams へ書き戻す (既存の他パラメータは保持)。 */
+export function applyFilterToParams(
+  params: URLSearchParams,
+  filter: MessageFilter,
+): URLSearchParams {
+  const next = new URLSearchParams(params);
+  const setOrDelete = (key: string, value: string) => {
+    if (value === "") next.delete(key);
+    else next.set(key, value);
+  };
+  setOrDelete("fpid", filter.participantIds.join(","));
+  setOrDelete("tpid", filter.toParticipantIds.join(","));
+  setOrDelete("typ", filter.types.join(","));
+  setOrDelete("kwd", filter.keywords);
+  setOrDelete("spl", filter.spoiled ? "true" : "");
+  return next;
+}
+
+/** 何らかの抽出条件が指定されているか (footer の「抽出中」表示用)。 */
+export function isFiltering(filter: MessageFilter): boolean {
+  return (
+    filter.participantIds.length > 0 ||
+    filter.toParticipantIds.length > 0 ||
+    filter.types.length > 0 ||
+    filter.keywords !== "" ||
+    filter.spoiled
+  );
+}

--- a/frontend/app/routes/village/DayList.tsx
+++ b/frontend/app/routes/village/DayList.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link, useLocation } from "react-router";
 
 import { dayLabel } from "./dayLabel";
 
@@ -17,6 +17,8 @@ export function DayList({
   currentDay: number;
   epilogueDay: number | null | undefined;
 }) {
+  // 抽出条件 (searchParams) は日付遷移後も引き継ぐ
+  const { search } = useLocation();
   return (
     <ul className="pl-0 text-[10.32px]">
       <li className="mr-[10px] inline list-none">
@@ -28,7 +30,7 @@ export function DayList({
             <span>{dayLabel(day, epilogueDay)}</span>
           ) : (
             <Link
-              to={`/village/${villageId}/day/${day}`}
+              to={`/village/${villageId}/day/${day}${search}`}
               className="text-wm-accent hover:underline"
             >
               {dayLabel(day, epilogueDay)}

--- a/frontend/app/routes/village/FilterModal.tsx
+++ b/frontend/app/routes/village/FilterModal.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from "react";
 
 import { Button } from "~/components/ui/Button";
-import { Modal } from "~/components/ui/Modal";
+import { ButtonCheckboxGroup } from "~/components/ui/ButtonCheckboxGroup";
 import { inputClass } from "~/components/ui/Input";
+import { Modal } from "~/components/ui/Modal";
+import { TextButton } from "~/components/ui/TextButton";
 import type { VillageFilterParticipantContent } from "~/features/village/api";
 import { EMPTY_FILTER, FILTER_TYPES, type MessageFilter } from "~/features/village/filter";
 
@@ -48,8 +50,6 @@ function toggle<T>(list: T[], value: T): T[] {
   return list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
 }
 
-const linkClass = "text-wm-accent cursor-pointer hover:underline";
-
 function ParticipantCheckList({
   participants,
   checked,
@@ -63,21 +63,13 @@ function ParticipantCheckList({
   return (
     <div>
       <div className="mb-[10px]">
-        <button type="button" className={linkClass} onClick={() => onChange(allIds)}>
-          全てON
-        </button>
+        <TextButton onClick={() => onChange(allIds)}>全てON</TextButton>
         &nbsp;/&nbsp;
-        <button type="button" className={linkClass} onClick={() => onChange([])}>
-          全てOFF
-        </button>
+        <TextButton onClick={() => onChange([])}>全てOFF</TextButton>
         &nbsp;/&nbsp;
-        <button
-          type="button"
-          className={linkClass}
-          onClick={() => onChange(allIds.filter((id) => !checked.includes(id)))}
-        >
+        <TextButton onClick={() => onChange(allIds.filter((id) => !checked.includes(id)))}>
           反転
-        </button>
+        </TextButton>
       </div>
       <div className="grid grid-cols-1 border-b border-[#ccc] min-[768px]:grid-cols-2 min-[1200px]:grid-cols-3">
         {participants.map((participant) => (
@@ -174,27 +166,17 @@ export function FilterModal({
         <div>
           <strong>ショートカット機能</strong>
           <div className="mt-[10px]">
-            <button type="button" className={linkClass} onClick={() => sayShortcut("WEREWOLF_SAY")}>
-              囁き
-            </button>
+            <TextButton onClick={() => sayShortcut("WEREWOLF_SAY")}>囁き</TextButton>
             &nbsp;/&nbsp;
-            <button type="button" className={linkClass} onClick={() => sayShortcut("MASON_SAY")}>
-              共鳴
-            </button>
+            <TextButton onClick={() => sayShortcut("MASON_SAY")}>共鳴</TextButton>
             &nbsp;/&nbsp;
-            <button type="button" className={linkClass} onClick={() => sayShortcut("LOVERS_SAY")}>
-              恋人
-            </button>
+            <TextButton onClick={() => sayShortcut("LOVERS_SAY")}>恋人</TextButton>
             &nbsp;/&nbsp;
-            <button type="button" className={linkClass} onClick={() => sayShortcut("TELEPATHY")}>
-              念話
-            </button>
+            <TextButton onClick={() => sayShortcut("TELEPATHY")}>念話</TextButton>
             {myselfId != null && (
               <>
                 &nbsp;/&nbsp;
-                <button
-                  type="button"
-                  className={linkClass}
+                <TextButton
                   onClick={() =>
                     apply({
                       ...toDraft(EMPTY_FILTER, allParticipantIds),
@@ -203,15 +185,13 @@ export function FilterModal({
                   }
                 >
                   自分宛
-                </button>
+                </TextButton>
               </>
             )}
             {notificationKeyword != null && notificationKeyword !== "" && (
               <>
                 &nbsp;/&nbsp;
-                <button
-                  type="button"
-                  className={linkClass}
+                <TextButton
                   onClick={() =>
                     apply({
                       ...toDraft(EMPTY_FILTER, allParticipantIds),
@@ -220,7 +200,7 @@ export function FilterModal({
                   }
                 >
                   通知キーワード
-                </button>
+                </TextButton>
               </>
             )}
           </div>
@@ -230,25 +210,13 @@ export function FilterModal({
         <div className="mt-[15px]">
           <strong>発言種別</strong>
           <div className="mt-[10px]">
-            <button
-              type="button"
-              className={linkClass}
-              onClick={() => setDraft({ ...draft, types: ALL_TYPE_VALUES })}
-            >
+            <TextButton onClick={() => setDraft({ ...draft, types: ALL_TYPE_VALUES })}>
               全てON
-            </button>
+            </TextButton>
             &nbsp;/&nbsp;
-            <button
-              type="button"
-              className={linkClass}
-              onClick={() => setDraft({ ...draft, types: [] })}
-            >
-              全てOFF
-            </button>
+            <TextButton onClick={() => setDraft({ ...draft, types: [] })}>全てOFF</TextButton>
             &nbsp;/&nbsp;
-            <button
-              type="button"
-              className={linkClass}
+            <TextButton
               onClick={() =>
                 setDraft({
                   ...draft,
@@ -257,31 +225,16 @@ export function FilterModal({
               }
             >
               反転
-            </button>
+            </TextButton>
           </div>
           {[0, 4, 8].map((start) => (
-            <div key={start} className="mt-[10px] flex">
-              {FILTER_TYPES.slice(start, start + 4).map((type) => {
-                const active = draft.types.includes(type.value);
-                return (
-                  <label
-                    key={type.value}
-                    className={`flex-1 cursor-pointer border border-[#00bc8c] px-[9px] py-[6px] text-center text-white first:rounded-l-[3px] last:rounded-r-[3px] ${
-                      active ? "bg-[#00bc8c]" : "bg-transparent"
-                    }`}
-                  >
-                    <input
-                      type="checkbox"
-                      className="hidden"
-                      checked={active}
-                      onChange={() =>
-                        setDraft({ ...draft, types: toggle(draft.types, type.value) })
-                      }
-                    />
-                    {type.label}
-                  </label>
-                );
-              })}
+            <div key={start} className="mt-[10px]">
+              <ButtonCheckboxGroup
+                options={FILTER_TYPES.slice(start, start + 4)}
+                values={draft.types}
+                onToggle={(value) => setDraft({ ...draft, types: toggle(draft.types, value) })}
+                ariaLabel="発言種別"
+              />
             </div>
           ))}
         </div>
@@ -310,13 +263,9 @@ export function FilterModal({
             value={draft.keywords}
             onChange={(e) => setDraft({ ...draft, keywords: e.target.value })}
           />
-          <button
-            type="button"
-            className={`${linkClass} mt-[10px]`}
-            onClick={() => setDraft({ ...draft, keywords: "" })}
-          >
+          <TextButton className="mt-[10px]" onClick={() => setDraft({ ...draft, keywords: "" })}>
             クリア
-          </button>
+          </TextButton>
         </div>
 
         <div className="mt-[40px]">
@@ -326,16 +275,14 @@ export function FilterModal({
               {myselfId != null && (
                 <>
                   &nbsp;
-                  <button
-                    type="button"
-                    className={linkClass}
+                  <TextButton
                     onClick={(e) => {
                       e.preventDefault();
                       setDraft({ ...draft, toParticipantIds: [myselfId] });
                     }}
                   >
                     自分宛
-                  </button>
+                  </TextButton>
                 </>
               )}
             </summary>

--- a/frontend/app/routes/village/FilterModal.tsx
+++ b/frontend/app/routes/village/FilterModal.tsx
@@ -1,0 +1,386 @@
+import { useEffect, useState } from "react";
+
+import { Button } from "~/components/ui/Button";
+import { Modal } from "~/components/ui/Modal";
+import { inputClass } from "~/components/ui/Input";
+import type { VillageFilterParticipantContent } from "~/features/village/api";
+import { EMPTY_FILTER, FILTER_TYPES, type MessageFilter } from "~/features/village/filter";
+
+const ALL_TYPE_VALUES = FILTER_TYPES.map((t) => t.value);
+
+/** チェック状態。フィルタの「空 = 全選択」と UI の「全チェック」を相互変換する。 */
+type Draft = {
+  types: string[];
+  participantIds: number[];
+  toParticipantIds: number[];
+  keywords: string;
+  spoiled: boolean;
+};
+
+function toDraft(filter: MessageFilter, allParticipantIds: number[]): Draft {
+  return {
+    types: filter.types.length === 0 ? ALL_TYPE_VALUES : filter.types,
+    participantIds: filter.participantIds.length === 0 ? allParticipantIds : filter.participantIds,
+    toParticipantIds:
+      filter.toParticipantIds.length === 0 ? allParticipantIds : filter.toParticipantIds,
+    keywords: filter.keywords,
+    spoiled: filter.spoiled,
+  };
+}
+
+function toFilter(draft: Draft, allParticipantIds: number[]): MessageFilter {
+  return {
+    types: draft.types.length === ALL_TYPE_VALUES.length ? [] : draft.types,
+    participantIds:
+      draft.participantIds.length === allParticipantIds.length
+        ? []
+        : [...draft.participantIds].sort((a, b) => a - b),
+    toParticipantIds:
+      draft.toParticipantIds.length === allParticipantIds.length
+        ? []
+        : [...draft.toParticipantIds].sort((a, b) => a - b),
+    keywords: draft.keywords.replace(/　/g, " ").trim(),
+    spoiled: draft.spoiled,
+  };
+}
+
+function toggle<T>(list: T[], value: T): T[] {
+  return list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
+}
+
+const linkClass = "text-wm-accent cursor-pointer hover:underline";
+
+function ParticipantCheckList({
+  participants,
+  checked,
+  onChange,
+}: {
+  participants: VillageFilterParticipantContent[];
+  checked: number[];
+  onChange: (ids: number[]) => void;
+}) {
+  const allIds = participants.map((p) => p.id);
+  return (
+    <div>
+      <div className="mb-[10px]">
+        <button type="button" className={linkClass} onClick={() => onChange(allIds)}>
+          全てON
+        </button>
+        &nbsp;/&nbsp;
+        <button type="button" className={linkClass} onClick={() => onChange([])}>
+          全てOFF
+        </button>
+        &nbsp;/&nbsp;
+        <button
+          type="button"
+          className={linkClass}
+          onClick={() => onChange(allIds.filter((id) => !checked.includes(id)))}
+        >
+          反転
+        </button>
+      </div>
+      <div className="grid grid-cols-1 border-b border-[#ccc] min-[768px]:grid-cols-2 min-[1200px]:grid-cols-3">
+        {participants.map((participant) => (
+          <label
+            key={participant.id}
+            className="flex cursor-pointer items-center border-t border-[#ccc] px-[10px] py-[5px]"
+          >
+            <input
+              type="checkbox"
+              checked={checked.includes(participant.id)}
+              onChange={() => onChange(toggle(checked, participant.id))}
+            />
+            <div className="px-[10px]">
+              {participant.imgUrl != null && (
+                <img
+                  src={participant.imgUrl}
+                  width={(participant.imgWidth ?? 0) / 2}
+                  height={(participant.imgHeight ?? 0) / 2}
+                  alt={participant.name ?? ""}
+                />
+              )}
+            </div>
+            <div className="flex-1 font-normal">
+              <p>{participant.name}</p>
+              <p
+                className={
+                  participant.deadStatus !== "生存" && participant.deadStatus !== "見学"
+                    ? "text-[#e74c3c]"
+                    : ""
+                }
+              >
+                {participant.deadStatus}
+              </p>
+            </div>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * 発言抽出モーダル。種別 / 発言者 / 宛先 / キーワード / ショートカットで絞り込み、
+ * 「抽出」で確定する (確定するまで表示には反映しない)。
+ */
+export function FilterModal({
+  open,
+  onClose,
+  filter,
+  participants,
+  myselfId,
+  notificationKeyword,
+  onApply,
+  onApplyNewTab,
+}: {
+  open: boolean;
+  onClose: () => void;
+  filter: MessageFilter;
+  participants: VillageFilterParticipantContent[];
+  /** 参加中の自分の参加者 ID (自分宛ショートカット用、未参加は null) */
+  myselfId: number | null;
+  /** Discord 通知キーワード (未設定は null) */
+  notificationKeyword: string | null;
+  onApply: (filter: MessageFilter) => void;
+  onApplyNewTab: (filter: MessageFilter) => void;
+}) {
+  const allParticipantIds = participants.map((p) => p.id);
+  const [draft, setDraft] = useState<Draft>(() => toDraft(filter, allParticipantIds));
+
+  // モーダルを開くたびに現在の適用状態から編集を始める
+  useEffect(() => {
+    if (open)
+      setDraft(
+        toDraft(
+          filter,
+          participants.map((p) => p.id),
+        ),
+      );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const apply = (next: Draft) => {
+    onApply(toFilter(next, allParticipantIds));
+    onClose();
+  };
+
+  const sayShortcut = (type: string) => {
+    apply({ ...toDraft(EMPTY_FILTER, allParticipantIds), types: [type] });
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} title="発言抽出" size="wide">
+      <div className="max-h-[70vh] overflow-x-hidden overflow-y-auto text-[12px]">
+        <div>
+          <strong>ショートカット機能</strong>
+          <div className="mt-[10px]">
+            <button type="button" className={linkClass} onClick={() => sayShortcut("WEREWOLF_SAY")}>
+              囁き
+            </button>
+            &nbsp;/&nbsp;
+            <button type="button" className={linkClass} onClick={() => sayShortcut("MASON_SAY")}>
+              共鳴
+            </button>
+            &nbsp;/&nbsp;
+            <button type="button" className={linkClass} onClick={() => sayShortcut("LOVERS_SAY")}>
+              恋人
+            </button>
+            &nbsp;/&nbsp;
+            <button type="button" className={linkClass} onClick={() => sayShortcut("TELEPATHY")}>
+              念話
+            </button>
+            {myselfId != null && (
+              <>
+                &nbsp;/&nbsp;
+                <button
+                  type="button"
+                  className={linkClass}
+                  onClick={() =>
+                    apply({
+                      ...toDraft(EMPTY_FILTER, allParticipantIds),
+                      toParticipantIds: [myselfId],
+                    })
+                  }
+                >
+                  自分宛
+                </button>
+              </>
+            )}
+            {notificationKeyword != null && notificationKeyword !== "" && (
+              <>
+                &nbsp;/&nbsp;
+                <button
+                  type="button"
+                  className={linkClass}
+                  onClick={() =>
+                    apply({
+                      ...toDraft(EMPTY_FILTER, allParticipantIds),
+                      keywords: notificationKeyword,
+                    })
+                  }
+                >
+                  通知キーワード
+                </button>
+              </>
+            )}
+          </div>
+          <hr className="my-[15px] border-[#464545]" />
+        </div>
+
+        <div className="mt-[15px]">
+          <strong>発言種別</strong>
+          <div className="mt-[10px]">
+            <button
+              type="button"
+              className={linkClass}
+              onClick={() => setDraft({ ...draft, types: ALL_TYPE_VALUES })}
+            >
+              全てON
+            </button>
+            &nbsp;/&nbsp;
+            <button
+              type="button"
+              className={linkClass}
+              onClick={() => setDraft({ ...draft, types: [] })}
+            >
+              全てOFF
+            </button>
+            &nbsp;/&nbsp;
+            <button
+              type="button"
+              className={linkClass}
+              onClick={() =>
+                setDraft({
+                  ...draft,
+                  types: ALL_TYPE_VALUES.filter((t) => !draft.types.includes(t)),
+                })
+              }
+            >
+              反転
+            </button>
+          </div>
+          {[0, 4, 8].map((start) => (
+            <div key={start} className="mt-[10px] flex">
+              {FILTER_TYPES.slice(start, start + 4).map((type) => {
+                const active = draft.types.includes(type.value);
+                return (
+                  <label
+                    key={type.value}
+                    className={`flex-1 cursor-pointer border border-[#00bc8c] px-[9px] py-[6px] text-center text-white first:rounded-l-[3px] last:rounded-r-[3px] ${
+                      active ? "bg-[#00bc8c]" : "bg-transparent"
+                    }`}
+                  >
+                    <input
+                      type="checkbox"
+                      className="hidden"
+                      checked={active}
+                      onChange={() =>
+                        setDraft({ ...draft, types: toggle(draft.types, type.value) })
+                      }
+                    />
+                    {type.label}
+                  </label>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-[40px]">
+          <details open>
+            <summary className="cursor-pointer">
+              <strong>発言者（クリックで開閉）</strong>
+            </summary>
+            <div className="mt-[10px]">
+              <ParticipantCheckList
+                participants={participants}
+                checked={draft.participantIds}
+                onChange={(ids) => setDraft({ ...draft, participantIds: ids })}
+              />
+            </div>
+          </details>
+        </div>
+
+        <div className="mt-[40px]">
+          <strong>キーワード</strong>
+          <input
+            type="text"
+            className={`${inputClass} mt-[5px] w-full`}
+            placeholder="スペース区切り"
+            value={draft.keywords}
+            onChange={(e) => setDraft({ ...draft, keywords: e.target.value })}
+          />
+          <button
+            type="button"
+            className={`${linkClass} mt-[10px]`}
+            onClick={() => setDraft({ ...draft, keywords: "" })}
+          >
+            クリア
+          </button>
+        </div>
+
+        <div className="mt-[40px]">
+          <details open>
+            <summary className="cursor-pointer">
+              <strong>宛先（クリックで開閉）</strong>
+              {myselfId != null && (
+                <>
+                  &nbsp;
+                  <button
+                    type="button"
+                    className={linkClass}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      setDraft({ ...draft, toParticipantIds: [myselfId] });
+                    }}
+                  >
+                    自分宛
+                  </button>
+                </>
+              )}
+            </summary>
+            <div className="mt-[10px]">
+              <ParticipantCheckList
+                participants={participants}
+                checked={draft.toParticipantIds}
+                onChange={(ids) => setDraft({ ...draft, toParticipantIds: ids })}
+              />
+            </div>
+          </details>
+        </div>
+
+        <div className="mt-[40px] mb-[20px]">
+          <label className="flex cursor-pointer items-center gap-[5px]">
+            <input
+              type="checkbox"
+              checked={draft.spoiled}
+              onChange={() => setDraft({ ...draft, spoiled: !draft.spoiled })}
+            />
+            エピローグ前同等の表示にする
+          </label>
+        </div>
+      </div>
+
+      <div className="mt-[20px] flex justify-end gap-[10px] text-[12px]">
+        <Button variant="default" onClick={onClose}>
+          閉じる
+        </Button>
+        <Button
+          variant="default"
+          onClick={() => setDraft(toDraft(EMPTY_FILTER, allParticipantIds))}
+        >
+          リセット
+        </Button>
+        <Button
+          onClick={() => {
+            onApplyNewTab(toFilter(draft, allParticipantIds));
+            onClose();
+          }}
+        >
+          別タブ
+        </Button>
+        <Button onClick={() => apply(draft)}>抽出</Button>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/app/routes/village/FooterMenu.tsx
+++ b/frontend/app/routes/village/FooterMenu.tsx
@@ -16,18 +16,21 @@ function MenuButton({
   label,
   onClick,
   disabled = false,
+  active = false,
 }: {
   icon: ReactNode;
   label: string;
   onClick?: () => void;
   disabled?: boolean;
+  /** 適用中の状態表示 (塗りつぶし)。 */
+  active?: boolean;
 }) {
   return (
     <button
       type="button"
       className={`${buttonBaseClass} ${
         disabled ? "opacity-50" : "cursor-pointer hover:bg-[#00bc8c] hover:text-white"
-      }`}
+      } ${active ? "bg-[#00bc8c] text-white" : ""}`}
       onClick={onClick}
       disabled={disabled}
     >
@@ -44,9 +47,15 @@ function MenuButton({
 export function FooterMenu({
   onRefresh,
   hasNewMessage = false,
+  onFilter,
+  filtering = false,
 }: {
   onRefresh: () => void;
   hasNewMessage?: boolean;
+  /** 抽出モーダルを開く。 */
+  onFilter?: () => void;
+  /** 抽出条件が適用中か (ボタンを「抽出中」のアクティブ表示にする) */
+  filtering?: boolean;
 }) {
   const iconClass = "h-[14px] w-[14px]";
   const gotoTop = () => window.scrollTo({ top: 0 });
@@ -73,7 +82,13 @@ export function FooterMenu({
           label="更新"
           onClick={onRefresh}
         />
-        <MenuButton icon={<FunnelIcon className={iconClass} />} label="抽出" disabled />
+        <MenuButton
+          icon={<FunnelIcon className={iconClass} />}
+          label={filtering ? "抽出中" : "抽出"}
+          onClick={onFilter}
+          disabled={onFilter == null}
+          active={filtering}
+        />
         <MenuButton icon={<InformationCircleIcon className={iconClass} />} label="情報" disabled />
         <MenuButton icon={<Cog6ToothIcon className={iconClass} />} label="設定" disabled />
       </div>

--- a/frontend/app/routes/village/FootstepTab.tsx
+++ b/frontend/app/routes/village/FootstepTab.tsx
@@ -7,9 +7,12 @@ const cellBorderClass = "border border-[#464545]";
 export function FootstepTab({
   footstepList,
   roomAssignedRows,
+  spoiled = false,
 }: {
   footstepList: VillageFootstepContent[];
   roomAssignedRows: VillageRoomAssignedRow[] | null | undefined;
+  /** ネタバレ防止 (足音の詳細を代替文言にする) */
+  spoiled?: boolean;
 }) {
   return (
     <div className="pt-[10px] pb-[10px]">
@@ -27,7 +30,7 @@ export function FootstepTab({
               <tr key={footstep.day}>
                 <td className={`${cellBorderClass} p-[5px] text-center`}>{footstep.day}d</td>
                 <td className={`${cellBorderClass} p-[5px] whitespace-pre-line`}>
-                  {footstep.footstep}
+                  {spoiled ? "ネタバレ防止のため非表示にしています。" : footstep.footstep}
                 </td>
               </tr>
             ))}

--- a/frontend/app/routes/village/MessageArea.tsx
+++ b/frontend/app/routes/village/MessageArea.tsx
@@ -48,9 +48,12 @@ export function MessageArea({
     d == null ? { pageNum: 1, isDispLatest: true } : { pageNum: 1, isDispLatest: false };
   const [page, setPage] = useState<PageState>(() => initialPage(day));
 
+  // 日付遷移・抽出条件の変更で先頭ページに戻す (絞り込み後に存在しないページを引かないため)
+  const filterKey = JSON.stringify(filter);
   useEffect(() => {
     setPage(initialPage(day));
-  }, [day]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [day, filterKey]);
 
   const { data, isLoading } = useVillageMessages(villageId, {
     day,

--- a/frontend/app/routes/village/MessageArea.tsx
+++ b/frontend/app/routes/village/MessageArea.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 
 import { MESSAGE_STYLES } from "~/components/ui/messageStyles";
 import type { VillageMessageListContent } from "~/features/village/api";
+import { EMPTY_FILTER, type MessageFilter } from "~/features/village/filter";
 import { useVillageMessages } from "~/features/village/useMessages";
 import { MessageCard } from "./MessageCard";
 import { MessagePagination, type PageState } from "./MessagePagination";
@@ -29,11 +30,16 @@ export function MessageArea({
   villageId,
   day,
   randomKeywords,
+  filter = EMPTY_FILTER,
+  onHashtagClick,
   onLoaded,
 }: {
   villageId: number;
   day: number | undefined;
   randomKeywords: string[];
+  /** 発言抽出の条件 (URL searchParams 由来)。 */
+  filter?: MessageFilter;
+  onHashtagClick?: (tag: string) => void;
   /** 一覧取得のたびに呼ぶ (新着検知の基準更新用)。 */
   onLoaded: (content: VillageMessageListContent) => void;
 }) {
@@ -52,6 +58,10 @@ export function MessageArea({
     pageNum: page.isDispLatest ? undefined : page.pageNum,
     isPaging: true,
     isDispLatest: page.isDispLatest,
+    participantIds: filter.participantIds.length > 0 ? filter.participantIds : undefined,
+    toParticipantIds: filter.toParticipantIds.length > 0 ? filter.toParticipantIds : undefined,
+    types: filter.types.length > 0 ? filter.types : undefined,
+    keywords: filter.keywords !== "" ? filter.keywords : undefined,
   });
 
   useEffect(() => {
@@ -71,6 +81,8 @@ export function MessageArea({
           villageId={villageId}
           message={message}
           randomKeywords={randomKeywords}
+          spoiled={filter.spoiled}
+          onHashtagClick={onHashtagClick}
         />
       ))}
       {data.suddenlyDeathMessage != null && <Announce text={data.suddenlyDeathMessage} />}

--- a/frontend/app/routes/village/MessageCard.tsx
+++ b/frontend/app/routes/village/MessageCard.tsx
@@ -38,6 +38,29 @@ const SYSTEM_VARIANTS: Record<string, string> = {
   PRIVATE_ABILITY: "message-private-ability",
 };
 
+/** ネタバレ防止の対象種別 (エピローグ前は見えなかったもの)。 */
+const SPOILED_TYPES = new Set([
+  "WEREWOLF_SAY",
+  "MONOLOGUE_SAY",
+  "SECRET_SAY",
+  "MASON_SAY",
+  "LOVERS_SAY",
+  "TELEPATHY",
+  "GRAVE_SAY",
+  "SPECTATE_SAY",
+  "PRIVATE_SYSTEM",
+  "PRIVATE_SEER",
+  "PRIVATE_WISE",
+  "PRIVATE_PSYCHIC",
+  "PRIVATE_GURU",
+  "PRIVATE_CORONER",
+  "PRIVATE_INVESTIGATE",
+  "PRIVATE_WEREWOLF",
+  "PRIVATE_LOVER",
+  "PRIVATE_FOX",
+  "PRIVATE_ABILITY",
+]);
+
 const bubbleBaseClass = "message rounded-[5px] border p-[9px] break-words";
 
 // 種別クラス (message-normal 等) も付ける。本文内リンクの色分け CSS が参照する
@@ -72,10 +95,15 @@ export function MessageCard({
   villageId,
   message,
   randomKeywords,
+  spoiled = false,
+  onHashtagClick,
 }: {
   villageId: number;
   message: VillageMessageContent;
   randomKeywords: string[];
+  /** ネタバレ防止 (エピローグ前同等の表示)。対象種別の発言とプレイヤー名を隠す */
+  spoiled?: boolean;
+  onHashtagClick?: (tag: string) => void;
 }) {
   const [expandedAnchors, setExpandedAnchors] = useState<ExpandedAnchor[]>([]);
 
@@ -107,7 +135,7 @@ export function MessageCard({
     }
   };
 
-  // 生成 HTML 内のリンク/装飾はイベント委譲で扱う (アンカー展開・伏せ字解除)
+  // 生成 HTML 内のリンク/装飾はイベント委譲で扱う (アンカー展開・ハッシュタグ抽出・伏せ字解除)
   const onContentClick = (e: MouseEvent<HTMLDivElement>) => {
     const target = e.target as HTMLElement;
     const anchor = target.closest("[data-anchor-type]") as HTMLElement | null;
@@ -115,6 +143,12 @@ export function MessageCard({
       const type = anchor.dataset.anchorType;
       const number = Number(anchor.dataset.anchorNumber);
       if (type != null && Number.isFinite(number)) toggleAnchor(type, number);
+      return;
+    }
+    const hashtag = target.closest("[data-message-hashtag]") as HTMLElement | null;
+    if (hashtag != null) {
+      const tag = hashtag.dataset.messageHashtag ?? "";
+      if (tag !== "" && onHashtagClick != null) onHashtagClick(tag);
       return;
     }
     if (target.classList.contains("netabare")) {
@@ -130,7 +164,12 @@ export function MessageCard({
     navigator.clipboard.writeText(text).then(() => alert(`コピーしました： ${text}`));
   };
 
-  const body = renderBody(message, html, onContentClick, copyAnchor, villageId);
+  // ネタバレ防止中はスポイラー対象の発言そのものを出さない
+  if (spoiled && (message.isBigEars || SPOILED_TYPES.has(message.messageType))) {
+    return null;
+  }
+
+  const body = renderBody(message, html, onContentClick, copyAnchor, villageId, spoiled);
 
   return (
     <div className="mb-[20px]">
@@ -170,6 +209,7 @@ function renderBody(
   onContentClick: (e: MouseEvent<HTMLDivElement>) => void,
   copyAnchor: (text: string) => void,
   villageId: number,
+  spoiled: boolean,
 ) {
   const type = message.messageType;
 
@@ -217,7 +257,7 @@ function renderBody(
             )}
             {message.characterName}
             {type === "SECRET_SAY" && ` → ${message.targetCharacterName ?? ""}`}
-            {message.playerName != null && (
+            {message.playerName != null && !spoiled && (
               <span>
                 &nbsp;[
                 <UserPageLink name={message.playerName} />]
@@ -300,7 +340,7 @@ function renderBody(
                 .
               </>
             )}
-            {message.playerName != null && (
+            {message.playerName != null && !spoiled && (
               <span>
                 &nbsp;[
                 <UserPageLink name={message.playerName} />]

--- a/frontend/app/routes/village/RoomAssignedTab.tsx
+++ b/frontend/app/routes/village/RoomAssignedTab.tsx
@@ -13,10 +13,13 @@ export function RoomAssignedTab({
   rows,
   situationList,
   isViewableSpoilerContent,
+  spoiled = false,
 }: {
   rows: VillageRoomAssignedRow[];
   situationList: VillageSituationContent[];
   isViewableSpoilerContent: boolean;
+  /** ネタバレ防止 (役職名を隠す) */
+  spoiled?: boolean;
 }) {
   return (
     <div className="pt-[10px] pb-[10px]">
@@ -67,7 +70,7 @@ export function RoomAssignedTab({
                           ダミー
                         </span>
                       )}
-                      {room.skillName != null && (
+                      {room.skillName != null && !spoiled && (
                         <span className="bg-wm-base whitespace-nowrap">
                           <br />
                           {shortenSkillName(room.skillName)}

--- a/frontend/app/routes/village/SituationPanel.tsx
+++ b/frontend/app/routes/village/SituationPanel.tsx
@@ -15,9 +15,12 @@ type TabKey = "room" | "member" | "vote" | "footstep";
 export function SituationPanel({
   situation,
   day,
+  spoiled = false,
 }: {
   situation: VillageSituationView;
   day: number;
+  /** ネタバレ防止 (役職名・能力欄・足音詳細を隠す) */
+  spoiled?: boolean;
 }) {
   const hasRoomTab = situation.roomWidth != null && day > 0;
   const hasVoteTab = situation.vote != null;
@@ -70,7 +73,8 @@ export function SituationPanel({
             <RoomAssignedTab
               rows={situation.roomAssignedRowList ?? []}
               situationList={situation.situationList ?? []}
-              isViewableSpoilerContent={situation.isViewableSpoilerContent ?? false}
+              isViewableSpoilerContent={(situation.isViewableSpoilerContent ?? false) && !spoiled}
+              spoiled={spoiled}
             />
           )}
           {activeTab === "member" && <MemberListTab memberList={situation.memberList ?? []} />}
@@ -81,6 +85,7 @@ export function SituationPanel({
             <FootstepTab
               footstepList={situation.footstepList ?? []}
               roomAssignedRows={situation.roomAssignedRowList}
+              spoiled={spoiled}
             />
           )}
         </div>

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -1,11 +1,18 @@
 import { useCallback, useEffect, useState } from "react";
-import { Link } from "react-router";
+import { Link, useSearchParams } from "react-router";
 
 import { PageLayout } from "~/components/layout/PageLayout";
 import { LinkButton } from "~/components/ui/Button";
 import { useMe } from "~/features/auth/useMe";
 import { useRandomKeywords } from "~/features/random-keywords/useRandomKeywords";
 import type { VillageDetailView, VillageMessageListContent } from "~/features/village/api";
+import {
+  applyFilterToParams,
+  EMPTY_FILTER,
+  isFiltering,
+  parseFilter,
+  type MessageFilter,
+} from "~/features/village/filter";
 import { useNewMessageDetector } from "~/features/village/useMessages";
 import {
   useInvalidateVillage,
@@ -18,6 +25,7 @@ import { ApiError } from "~/lib/api";
 import { siteMeta } from "~/lib/meta";
 import { AgeLimitModal } from "./AgeLimitModal";
 import { DayList } from "./DayList";
+import { FilterModal } from "./FilterModal";
 import { FooterMenu } from "./FooterMenu";
 import { MessageArea } from "./MessageArea";
 import { SituationPanel } from "./SituationPanel";
@@ -74,9 +82,27 @@ export default function Village({ params }: Route.ComponentProps) {
   const { me } = useMe();
   const { data: village, error: villageError } = useVillage(villageId);
   const { data: situation } = useVillageSituation(villageId, dayParam, me?.name ?? null);
-  const { error: mySituationError } = useMyVillageSituation(villageId, dayParam);
+  const { data: mySituation, error: mySituationError } = useMyVillageSituation(villageId, dayParam);
   const { data: randomKeywords } = useRandomKeywords();
   const invalidate = useInvalidateVillage(villageId);
+
+  // 発言抽出。URL searchParams が正本 (共有 URL で再現できる)
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filter = parseFilter(searchParams);
+  const [filterOpen, setFilterOpen] = useState(false);
+  const applyFilter = (next: MessageFilter) =>
+    setSearchParams(applyFilterToParams(searchParams, next));
+  const applyFilterNewTab = (next: MessageFilter) => {
+    const params = applyFilterToParams(searchParams, next);
+    const query = params.toString();
+    window.open(`${window.location.pathname}${query !== "" ? `?${query}` : ""}`);
+  };
+  const onHashtagClick = useCallback(
+    (tag: string) => {
+      setSearchParams((prev) => applyFilterToParams(prev, { ...EMPTY_FILTER, keywords: tag }));
+    },
+    [setSearchParams],
+  );
 
   const latestDay = village != null ? latestDayOf(village) : undefined;
   const currentDay = dayParam ?? latestDay ?? 0;
@@ -154,6 +180,8 @@ export default function Village({ params }: Route.ComponentProps) {
           villageId={villageId}
           day={dayParam}
           randomKeywords={(randomKeywords ?? []).map((k) => k.keyword ?? "").filter(Boolean)}
+          filter={filter}
+          onHashtagClick={onHashtagClick}
           onLoaded={onMessagesLoaded}
         />
         {!noAd && (
@@ -166,7 +194,9 @@ export default function Village({ params }: Route.ComponentProps) {
         {/* 最下部への移動先 (発言後のスクロール先) */}
         <div id="bottom" />
 
-        {situation != null && <SituationPanel situation={situation} day={currentDay} />}
+        {situation != null && (
+          <SituationPanel situation={situation} day={currentDay} spoiled={filter.spoiled} />
+        )}
 
         <DayList
           villageId={villageId}
@@ -190,7 +220,22 @@ export default function Village({ params }: Route.ComponentProps) {
         </div>
       </div>
 
-      <FooterMenu onRefresh={() => invalidate()} hasNewMessage={hasNewMessage} />
+      <FooterMenu
+        onRefresh={() => invalidate()}
+        hasNewMessage={hasNewMessage}
+        onFilter={() => setFilterOpen(true)}
+        filtering={isFiltering(filter)}
+      />
+      <FilterModal
+        open={filterOpen}
+        onClose={() => setFilterOpen(false)}
+        filter={filter}
+        participants={situation?.participantList ?? []}
+        myselfId={mySituation?.myself?.id ?? null}
+        notificationKeyword={mySituation?.myself?.notificationKeyword ?? null}
+        onApply={applyFilter}
+        onApplyNewTab={applyFilterNewTab}
+      />
       {ageLimit != null && <AgeLimitModal villageId={villageId} ageLimit={ageLimit} />}
 
       {/* 通知系のオーバーレイ */}


### PR DESCRIPTION
closes .issues/step-8.3-village-message-filter.md

## 概要

発言抽出 (modal-filter) を React 化する (step-8.3)。base は `feature/monorepo-step8`。

## backend

- `VillageSituationView` に **発言抽出用の `participantList`** を追加 (既存 `VillageFilterParticipantContent` を流用、`VillageContent.participantList` が正本)
- `ParticipantSituationView.MyselfView` に **`notificationKeyword`** を追加 (通知キーワードショートカットの素材。未設定は null)
- 絞り込み自体は 8.2 の `VillageMessageSearchRequest` をそのまま使用 (検索ロジック変更なし)

## frontend

- **`FilterModal`**: ショートカット (囁き/共鳴/恋人/念話/自分宛/通知キーワード) / 発言種別 12 種 (全ON/OFF/反転、GRAVE_SPECTATE_SAY 合成種別含む) / 発言者・宛先の参加者チェックリスト (全ON/OFF/反転、死亡ステータス赤表示) / キーワード / ネタバレ防止チェック / 抽出・別タブ・リセット・閉じる。**「空 = 全選択」の正規化** (全チェック時は条件なし扱い) は legacy `doFilter` と同じ
- **フィルタ状態は URL searchParams が正本** (`fpid`/`typ`/`kwd`/`tpid`/`spl`、legacy と同名)。共有 URL で再現でき、**日付ナビ遷移でも引き継ぐ** (legacy `addFilterParameterToDayLink` 相当)
- **ハッシュタグクリック → 全種別/全員 + キーワード=タグで抽出** (8.2 で no-op だった `data-message-hashtag` を接続)
- **ネタバレ防止 (`spl=true`)**: スポイラー対象種別の発言と地獄耳・playerName を非表示、部屋割りの役職名と日別状況の能力欄を非表示、足音は「ネタバレ防止のため非表示にしています。」へ差し替え
- footer の「抽出」ボタンを有効化。適用中は塗りつぶし + 「抽出中」表示 (legacy `#filter-button.active` 相当)

## 検証

- 村 5 で実測: 囁きショートカット → `?typ=WEREWOLF_SAY` で囁きのみ表示 + 「抽出中」 / `#テストタグ` クリック → `?kwd=%23テストタグ` で該当発言のみ表示
- backend: ktlintCheck / test green。frontend: typecheck / lint / format / build green。`pnpm gen:api` 差分込みでコミット
- e2e 2 件追加 (全 **56 件** green)

## 申し送り

- 表示設定モーダル (ページサイズ/自動リロード等) はユーザー設定のサブ step。返信/秘話は発言投稿のサブ step

🤖 Generated with [Claude Code](https://claude.com/claude-code)