### PR TITLE
feat: 村画面の発言投稿を REST + React 化 (step-8.4)

### DIFF
--- a/.issues/README.md
+++ b/.issues/README.md
@@ -24,7 +24,7 @@ monorepo 移行作業中につき **階層番号方式** (`step-<N>(.M)-<slug>.m
 
 | # | タイトル | type | status |
 | --- | --- | --- | --- |
-| (現在 open な Issue なし) | | | |
+| step-8.4 | 村画面 発言投稿 (種別/表情/装飾/制限 + 確認フロー + 返信) | enhancement | open |
 
 > **Step 8 は統合ブランチ方式 (ユーザー指示 2026-06-12)**: `feature/monorepo-step8` を base にサブ step PR を積み、同ブランチへの squash merge は Claude 単独で可。`feature/monorepo` への merge は最終 PR でユーザー承認。8.1 ✅ #71 / 8.2 ✅ #72 / 8.3 ✅ #73。
 

--- a/backend/src/main/kotlin/com/ort/app/api/village/VillageSayRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/VillageSayRestController.kt
@@ -1,0 +1,136 @@
+package com.ort.app.api.village
+
+import com.ort.app.api.request.validator.SayFormValidator
+import com.ort.app.api.view.VillageSayConfirmContent
+import com.ort.app.api.village.request.VillageSayRequest
+import com.ort.app.application.coordinator.MessageCoordinator
+import com.ort.app.application.service.CharaService
+import com.ort.app.application.service.PlayerService
+import com.ort.app.application.service.RandomKeywordService
+import com.ort.app.application.service.VillageService
+import com.ort.app.domain.model.village.Village
+import com.ort.app.domain.model.village.participant.VillageParticipant
+import com.ort.app.fw.exception.WolfMansionAuthException
+import com.ort.app.fw.exception.WolfMansionBusinessException
+import com.ort.app.fw.exception.WolfMansionValidationException
+import com.ort.app.fw.exception.WolfMansionValidationException.FieldErrorItem
+import com.ort.app.fw.interceptor.getIpAddress
+import com.ort.app.fw.security.jwt.JwtPrincipal
+import io.swagger.v3.oas.annotations.Operation
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.context.MessageSource
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.validation.BeanPropertyBindingResult
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+import java.util.Locale
+
+/**
+ * 発言の REST。確認 (プレビュー) → 投稿の 2 段フロー。いずれも要認証で、
+ * 発言可否・種別の妥当性は既存 MessageCoordinator (domain) が検証する。
+ */
+@RestController
+@RequestMapping("/api/v1/villages/{id}")
+class VillageSayRestController(
+    private val villageService: VillageService,
+    private val playerService: PlayerService,
+    private val charaService: CharaService,
+    private val randomKeywordService: RandomKeywordService,
+    private val messageCoordinator: MessageCoordinator,
+    private val sayFormValidator: SayFormValidator,
+    private val messageSource: MessageSource,
+    private val httpServletRequest: HttpServletRequest,
+) {
+    /** 発言確認 (プレビュー)。表示用に整形済みの発言を返す (まだ保存しない)。 */
+    @Operation(operationId = "confirmVillageSay")
+    @PostMapping("/say-confirm")
+    fun confirm(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+        @RequestBody @Validated request: VillageSayRequest,
+    ): VillageSayConfirmContent {
+        val (village, myself) = resolveSayer(principal, id)
+        validate(request)
+        val message =
+            messageCoordinator.confirmToSay(
+                village,
+                myself,
+                request.message!!,
+                request.messageType!!,
+                request.faceType!!,
+                request.convertDisable,
+                request.secretSayTargetCharaId,
+            )
+        val player = playerService.findPlayer(myself.playerId)
+        val charas =
+            village.setting.chara.let {
+                charaService.findCharachips(it.charachipIds, it.isOriginalCharachip).charas()
+            }
+        return VillageSayConfirmContent(
+            village = village,
+            message = message,
+            fromParticipant = myself,
+            player = player,
+            charas = charas,
+            keywords = randomKeywordService.findRandomKeywords(),
+        )
+    }
+
+    /** 発言する。IP アドレスの記録は SSR と同じ (不正対策)。 */
+    @Operation(operationId = "sayVillage")
+    @PostMapping("/say")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun say(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+        @RequestBody @Validated request: VillageSayRequest,
+    ) {
+        val (village, myself) = resolveSayer(principal, id)
+        validate(request)
+        messageCoordinator.say(
+            village,
+            myself,
+            request.message!!,
+            request.messageType!!,
+            request.faceType,
+            request.convertDisable,
+            request.secretSayTargetCharaId,
+            httpServletRequest.getIpAddress(),
+        )
+    }
+
+    private fun resolveSayer(
+        principal: JwtPrincipal?,
+        villageId: Int,
+    ): Pair<Village, VillageParticipant> {
+        // principal は filter chain の authenticated() で保証済み (到達時は非 null)。防御的に確認する
+        principal ?: throw WolfMansionAuthException("ログインしてください")
+        val village =
+            villageService.findVillage(villageId)
+                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "village not found")
+        val myself =
+            villageService.findVillageParticipant(village.id, principal.name)
+                ?: throw WolfMansionBusinessException("村に参加していません")
+        return village to myself
+    }
+
+    private fun validate(request: VillageSayRequest) {
+        val form = request.toForm()
+        val errors = BeanPropertyBindingResult(form, "sayForm")
+        sayFormValidator.validate(form, errors)
+        if (errors.hasErrors()) {
+            throw WolfMansionValidationException(
+                errors.fieldErrors.map {
+                    FieldErrorItem(it.field, messageSource.getMessage(it, Locale.JAPAN))
+                },
+            )
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/village/request/VillageSayRequest.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/request/VillageSayRequest.kt
@@ -1,0 +1,31 @@
+package com.ort.app.api.village.request
+
+import com.ort.app.api.request.VillageSayForm
+import jakarta.validation.constraints.NotNull
+
+/**
+ * 発言の確認/投稿。検証は SSR と共通の SayFormValidator を [toForm] 変換後に流用する。
+ */
+data class VillageSayRequest(
+    @field:NotNull
+    val message: String? = null,
+    /** 発言種別コード */
+    @field:NotNull
+    val messageType: String? = null,
+    /** 表情種別コード */
+    @field:NotNull
+    val faceType: String? = null,
+    /** 装飾・変換を無効にするか */
+    val convertDisable: Boolean? = null,
+    /** 秘話の宛先キャラ ID (秘話のみ必須) */
+    val secretSayTargetCharaId: Int? = null,
+) {
+    fun toForm(): VillageSayForm =
+        VillageSayForm(
+            message = message,
+            messageType = messageType,
+            secretSayTargetCharaId = secretSayTargetCharaId,
+            convertDisable = convertDisable,
+            faceType = faceType,
+        )
+}

--- a/backend/src/main/kotlin/com/ort/app/api/village/response/ParticipantSituationView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/response/ParticipantSituationView.kt
@@ -1,6 +1,10 @@
 package com.ort.app.api.village.response
 
+import com.ort.app.domain.model.chara.CharaImage
 import com.ort.app.domain.model.situation.ParticipantSituation
+import com.ort.app.domain.model.situation.participant.ParticipantSayMessageTypeSituation
+import com.ort.app.domain.model.situation.participant.ParticipantSayRestrictSituation
+import com.ort.app.domain.model.situation.participant.ParticipantSaySituation
 import com.ort.app.domain.model.village.participant.VillageParticipant
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -34,7 +38,7 @@ data class ParticipantSituationView(
                 isAvailableCommit = situation.commit.isAvailableCommit,
                 isCommitting = situation.commit.isCommitting,
             ),
-        say = SayView(isAvailableSay = situation.say.isAvailableSay),
+        say = SayView(situation.say),
         rp =
             RpView(
                 isAvailableChangeName = situation.rp.isAvailableChangeName,
@@ -106,7 +110,78 @@ data class ParticipantSituationView(
     @Schema(name = "ParticipantSituationViewSay")
     data class SayView(
         val isAvailableSay: Boolean,
-    )
+        /** 既定で選択する発言種別コード */
+        val defaultMessageTypeCode: String?,
+        /** 選択できる発言種別 (種別別の制限・秘話の宛先候補付き) */
+        val selectableMessageTypeList: List<SayMessageTypeView>,
+        /** 選択できる表情 (表示中の差分のみ) */
+        val selectableCharaImageList: List<SayCharaImageView>,
+    ) {
+        constructor(say: ParticipantSaySituation) : this(
+            isAvailableSay = say.isAvailableSay,
+            defaultMessageTypeCode = say.defaultMessageType?.code,
+            selectableMessageTypeList = say.selectableMessageTypeList.map { SayMessageTypeView(it) },
+            selectableCharaImageList =
+                say.selectableCharaImageList
+                    .filter { it.isDisplay }
+                    .map { SayCharaImageView(it) },
+        )
+    }
+
+    @Schema(name = "ParticipantSituationViewSayMessageType")
+    data class SayMessageTypeView(
+        val messageTypeCode: String,
+        val restrict: SayRestrictView,
+        /** 宛先の候補 (秘話のみ非空) */
+        val targetList: List<SayTargetView>,
+    ) {
+        constructor(situation: ParticipantSayMessageTypeSituation) : this(
+            messageTypeCode = situation.messageType.code,
+            restrict = SayRestrictView(situation.restrict),
+            targetList = situation.targetList.map { SayTargetView(it) },
+        )
+    }
+
+    @Schema(name = "ParticipantSituationViewSayRestrict")
+    data class SayRestrictView(
+        val isRestricted: Boolean,
+        val maxCount: Int?,
+        val remainingCount: Int?,
+        val maxLength: Int,
+        val maxLine: Int,
+    ) {
+        constructor(restrict: ParticipantSayRestrictSituation) : this(
+            isRestricted = restrict.isRestricted,
+            maxCount = restrict.maxCount,
+            remainingCount = restrict.remainingCount,
+            maxLength = restrict.maxLength,
+            maxLine = restrict.maxLine,
+        )
+    }
+
+    @Schema(name = "ParticipantSituationViewSayTarget")
+    data class SayTargetView(
+        val charaId: Int,
+        val name: String,
+    ) {
+        constructor(participant: VillageParticipant) : this(
+            charaId = participant.charaId,
+            name = participant.name(),
+        )
+    }
+
+    @Schema(name = "ParticipantSituationViewSayCharaImage")
+    data class SayCharaImageView(
+        val faceTypeCode: String,
+        val faceTypeName: String,
+        val url: String,
+    ) {
+        constructor(image: CharaImage) : this(
+            faceTypeCode = image.faceType.code,
+            faceTypeName = image.faceType.name,
+            url = image.url,
+        )
+    }
 
     @Schema(name = "ParticipantSituationViewRp")
     data class RpView(

--- a/e2e/tests/village-say.spec.ts
+++ b/e2e/tests/village-say.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * 村画面の発言投稿 e2e。ローカル DB の master (testuser) でログインし、
+ * 発言できる村があれば 確認 → 投稿 → ログ反映 を通す。
+ */
+
+type SimpleVillage = { id: number; name: string };
+
+async function findVillages(page: Page, statuses: string[]): Promise<SimpleVillage[]> {
+  const query = statuses.map((s) => `status=${s}`).join("&");
+  const res = await page.request.get(`/wolf-mansion-api/api/v1/villages?${query}`);
+  expect(res.ok()).toBeTruthy();
+  const body = (await res.json()) as { villages: SimpleVillage[] };
+  return body.villages;
+}
+
+async function loginAsMaster(page: Page) {
+  await page.goto("login");
+  await page.waitForLoadState("networkidle");
+  await page.fill("#userId", "master");
+  await page.fill("#password", "testuser");
+  await page.getByRole("button", { name: "ログイン" }).click();
+  await expect(page).toHaveURL(/\/wolf-mansion$/);
+}
+
+test("発言: 入力 → 確認 → 投稿 → ログ反映", async ({ page }) => {
+  const villages = await findVillages(page, ["IN_PROGRESS"]);
+  test.skip(villages.length === 0, "進行中の村が無い DB のためスキップ");
+  const village = villages[0];
+
+  await loginAsMaster(page);
+  await page.goto(`village/${village.id}`);
+
+  const sayPanel = page.locator("#say-panel");
+  await expect(page.locator(".message").first()).toBeVisible({ timeout: 15000 });
+  test.skip((await sayPanel.count()) === 0, "発言できない状態のためスキップ");
+
+  // 独り言で投稿する (種別が無ければスキップ)
+  const monologue = sayPanel.getByRole("button", { name: "独り言" });
+  test.skip((await monologue.count()) === 0, "独り言が選択できないためスキップ");
+  await monologue.click();
+
+  const text = `e2e 発言テスト ${Date.now()}`;
+  await sayPanel.locator("textarea").fill(text);
+  // 文字数カウントが入力に追従する
+  await expect(sayPanel.getByText(/文字数: \d+\/\d+/)).toBeVisible();
+
+  await sayPanel.getByRole("button", { name: "確認画面へ" }).click();
+
+  // 確認プレビュー (まだ投稿されていない)
+  const confirmArea = page.locator("#message-confirm-area");
+  await expect(confirmArea).toBeVisible();
+  await expect(confirmArea).toContainText(text);
+
+  await confirmArea.getByRole("button", { name: "発言する（独り言）" }).click();
+
+  // プレビューが消え、ログに反映される
+  await expect(confirmArea).toHaveCount(0);
+  await expect(page.locator(".message-monologue").filter({ hasText: text })).toBeVisible({
+    timeout: 15000,
+  });
+});
+
+test("空入力では確認ボタンが無効", async ({ page }) => {
+  const villages = await findVillages(page, ["IN_PROGRESS"]);
+  test.skip(villages.length === 0, "進行中の村が無い DB のためスキップ");
+  const village = villages[0];
+
+  await loginAsMaster(page);
+  await page.goto(`village/${village.id}`);
+  const sayPanel = page.locator("#say-panel");
+  await expect(page.locator(".message").first()).toBeVisible({ timeout: 15000 });
+  test.skip((await sayPanel.count()) === 0, "発言できない状態のためスキップ");
+
+  await expect(sayPanel.getByRole("button", { name: "確認画面へ" })).toBeDisabled();
+});

--- a/frontend/app/api/openapi.json
+++ b/frontend/app/api/openapi.json
@@ -903,6 +903,77 @@
         "tags": ["village-message-rest-controller"]
       }
     },
+    "/api/v1/villages/{id}/say": {
+      "post": {
+        "operationId": "sayVillage",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VillageSayRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": ["village-say-rest-controller"]
+      }
+    },
+    "/api/v1/villages/{id}/say-confirm": {
+      "post": {
+        "operationId": "confirmVillageSay",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VillageSayRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/VillageSayConfirmContent"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": ["village-say-rest-controller"]
+      }
+    },
     "/api/v1/villages/{id}/setting": {
       "get": {
         "operationId": "setting",
@@ -1592,11 +1663,97 @@
       "ParticipantSituationViewSay": {
         "type": "object",
         "properties": {
+          "defaultMessageTypeCode": {
+            "type": ["string", "null"]
+          },
           "isAvailableSay": {
             "type": "boolean"
+          },
+          "selectableCharaImageList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParticipantSituationViewSayCharaImage"
+            }
+          },
+          "selectableMessageTypeList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParticipantSituationViewSayMessageType"
+            }
           }
         },
-        "required": ["isAvailableSay"]
+        "required": ["isAvailableSay", "selectableCharaImageList", "selectableMessageTypeList"]
+      },
+      "ParticipantSituationViewSayCharaImage": {
+        "type": "object",
+        "properties": {
+          "faceTypeCode": {
+            "type": "string"
+          },
+          "faceTypeName": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": ["faceTypeCode", "faceTypeName", "url"]
+      },
+      "ParticipantSituationViewSayMessageType": {
+        "type": "object",
+        "properties": {
+          "messageTypeCode": {
+            "type": "string"
+          },
+          "restrict": {
+            "$ref": "#/components/schemas/ParticipantSituationViewSayRestrict"
+          },
+          "targetList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParticipantSituationViewSayTarget"
+            }
+          }
+        },
+        "required": ["messageTypeCode", "restrict", "targetList"]
+      },
+      "ParticipantSituationViewSayRestrict": {
+        "type": "object",
+        "properties": {
+          "isRestricted": {
+            "type": "boolean"
+          },
+          "maxCount": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          },
+          "maxLength": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxLine": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "remainingCount": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          }
+        },
+        "required": ["isRestricted", "maxLength", "maxLine"]
+      },
+      "ParticipantSituationViewSayTarget": {
+        "type": "object",
+        "properties": {
+          "charaId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["charaId", "name"]
       },
       "ParticipantSituationViewSkillRequest": {
         "type": "object",
@@ -3057,6 +3214,40 @@
           "isVisibleGraveSpectateMessage",
           "secretSayRange"
         ]
+      },
+      "VillageSayConfirmContent": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "$ref": "#/components/schemas/VillageMessageContent"
+          },
+          "randomKeywords": {
+            "type": "string"
+          }
+        },
+        "required": ["message", "randomKeywords"]
+      },
+      "VillageSayRequest": {
+        "type": "object",
+        "properties": {
+          "convertDisable": {
+            "type": ["boolean", "null"]
+          },
+          "faceType": {
+            "type": ["string", "null"]
+          },
+          "message": {
+            "type": ["string", "null"]
+          },
+          "messageType": {
+            "type": ["string", "null"]
+          },
+          "secretSayTargetCharaId": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          }
+        },
+        "required": ["faceType", "message", "messageType"]
       },
       "VillageSettingView": {
         "type": "object",

--- a/frontend/app/api/types.ts
+++ b/frontend/app/api/types.ts
@@ -339,6 +339,38 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/villages/{id}/say": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["sayVillage"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/villages/{id}/say-confirm": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["confirmVillageSay"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/villages/{id}/setting": {
     parameters: {
       query?: never;
@@ -582,7 +614,36 @@ export interface components {
       isAvailableMemo: boolean;
     };
     ParticipantSituationViewSay: {
+      defaultMessageTypeCode?: string | null;
       isAvailableSay: boolean;
+      selectableCharaImageList: components["schemas"]["ParticipantSituationViewSayCharaImage"][];
+      selectableMessageTypeList: components["schemas"]["ParticipantSituationViewSayMessageType"][];
+    };
+    ParticipantSituationViewSayCharaImage: {
+      faceTypeCode: string;
+      faceTypeName: string;
+      url: string;
+    };
+    ParticipantSituationViewSayMessageType: {
+      messageTypeCode: string;
+      restrict: components["schemas"]["ParticipantSituationViewSayRestrict"];
+      targetList: components["schemas"]["ParticipantSituationViewSayTarget"][];
+    };
+    ParticipantSituationViewSayRestrict: {
+      isRestricted: boolean;
+      /** Format: int32 */
+      maxCount?: number | null;
+      /** Format: int32 */
+      maxLength: number;
+      /** Format: int32 */
+      maxLine: number;
+      /** Format: int32 */
+      remainingCount?: number | null;
+    };
+    ParticipantSituationViewSayTarget: {
+      /** Format: int32 */
+      charaId: number;
+      name: string;
     };
     ParticipantSituationViewSkillRequest: {
       isAvailableSkillRequest: boolean;
@@ -1009,6 +1070,18 @@ export interface components {
       isReincarnationSkillAll: boolean;
       isVisibleGraveSpectateMessage: boolean;
       secretSayRange: components["schemas"]["SecretSayRange"];
+    };
+    VillageSayConfirmContent: {
+      message: components["schemas"]["VillageMessageContent"];
+      randomKeywords: string;
+    };
+    VillageSayRequest: {
+      convertDisable?: boolean | null;
+      faceType: string | null;
+      message: string | null;
+      messageType: string | null;
+      /** Format: int32 */
+      secretSayTargetCharaId?: number | null;
     };
     VillageSettingView: {
       chara: components["schemas"]["VillageCharaSetting"];
@@ -1668,6 +1741,56 @@ export interface operations {
         };
         content: {
           "*/*": components["schemas"]["VillageParticipantsContent"];
+        };
+      };
+    };
+  };
+  sayVillage: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["VillageSayRequest"];
+      };
+    };
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  confirmVillageSay: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["VillageSayRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["VillageSayConfirmContent"];
         };
       };
     };

--- a/frontend/app/features/village/api.ts
+++ b/frontend/app/features/village/api.ts
@@ -132,3 +132,27 @@ export function fetchVillageParticipants(id: number): Promise<VillageParticipant
 /** 発言抽出用の参加者ビュー (村状況 API の participantList)。 */
 export type VillageFilterParticipantContent =
   components["schemas"]["VillageFilterParticipantContent"];
+
+/** 発言の確認/投稿のリクエスト。 */
+export type VillageSayRequest = components["schemas"]["VillageSayRequest"];
+/** 発言確認 (プレビュー) の応答。 */
+export type VillageSayConfirmContent = components["schemas"]["VillageSayConfirmContent"];
+/** 発言種別ごとの選択肢 (制限・宛先候補)。 */
+export type SayMessageTypeView = components["schemas"]["ParticipantSituationViewSayMessageType"];
+export type SayCharaImageView = components["schemas"]["ParticipantSituationViewSayCharaImage"];
+
+/** 発言を確認する (プレビュー。まだ保存されない)。要認証。 */
+export function confirmVillageSay(
+  id: number,
+  request: VillageSayRequest,
+): Promise<VillageSayConfirmContent> {
+  return apiFetch<VillageSayConfirmContent>(`/api/v1/villages/${id}/say-confirm`, {
+    method: "POST",
+    body: request,
+  });
+}
+
+/** 発言する。要認証 → 204。 */
+export function sayVillage(id: number, request: VillageSayRequest): Promise<void> {
+  return apiFetch<void>(`/api/v1/villages/${id}/say`, { method: "POST", body: request });
+}

--- a/frontend/app/routes/village/MessageArea.tsx
+++ b/frontend/app/routes/village/MessageArea.tsx
@@ -4,7 +4,7 @@ import { MESSAGE_STYLES } from "~/components/ui/messageStyles";
 import type { VillageMessageListContent } from "~/features/village/api";
 import { EMPTY_FILTER, type MessageFilter } from "~/features/village/filter";
 import { useVillageMessages } from "~/features/village/useMessages";
-import { MessageCard } from "./MessageCard";
+import { MessageCard, type ReplyDraft } from "./MessageCard";
 import { MessagePagination, type PageState } from "./MessagePagination";
 
 function Announce({ text }: { text: string }) {
@@ -32,6 +32,8 @@ export function MessageArea({
   randomKeywords,
   filter = EMPTY_FILTER,
   onHashtagClick,
+  onReply,
+  onSecret,
   onLoaded,
 }: {
   villageId: number;
@@ -40,6 +42,8 @@ export function MessageArea({
   /** 発言抽出の条件 (URL searchParams 由来)。 */
   filter?: MessageFilter;
   onHashtagClick?: (tag: string) => void;
+  onReply?: (reply: ReplyDraft) => void;
+  onSecret?: (reply: ReplyDraft) => void;
   /** 一覧取得のたびに呼ぶ (新着検知の基準更新用)。 */
   onLoaded: (content: VillageMessageListContent) => void;
 }) {
@@ -86,6 +90,8 @@ export function MessageArea({
           randomKeywords={randomKeywords}
           spoiled={filter.spoiled}
           onHashtagClick={onHashtagClick}
+          onReply={onReply}
+          onSecret={onSecret}
         />
       ))}
       {data.suddenlyDeathMessage != null && <Announce text={data.suddenlyDeathMessage} />}

--- a/frontend/app/routes/village/MessageCard.tsx
+++ b/frontend/app/routes/village/MessageCard.tsx
@@ -74,6 +74,16 @@ type ExpandedAnchor = {
   visible: boolean;
 };
 
+/** 返信・秘話返信で発言フォームへ引き継ぐ内容。 */
+export type ReplyDraft = {
+  /** 本文へ挿入するアンカー (秘話返信は null) */
+  anchorText: string | null;
+  /** 秘話返信なら宛先のキャラ ID */
+  secretTargetCharaId: number | null;
+  /** 引用表示する元発言 */
+  message: VillageMessageContent;
+};
+
 /** プレイヤーのプロフィールページへの別タブリンク。 */
 export function UserPageLink({ name }: { name: string }) {
   return (
@@ -97,6 +107,8 @@ export function MessageCard({
   randomKeywords,
   spoiled = false,
   onHashtagClick,
+  onReply,
+  onSecret,
 }: {
   villageId: number;
   message: VillageMessageContent;
@@ -104,6 +116,10 @@ export function MessageCard({
   /** ネタバレ防止 (エピローグ前同等の表示)。対象種別の発言とプレイヤー名を隠す */
   spoiled?: boolean;
   onHashtagClick?: (tag: string) => void;
+  /** 返信 (アンカー挿入 + 引用)。未指定なら返信リンクを出さない */
+  onReply?: (reply: ReplyDraft) => void;
+  /** 秘話返信 (宛先セット + 引用)。未指定なら秘話リンクを出さない */
+  onSecret?: (reply: ReplyDraft) => void;
 }) {
   const [expandedAnchors, setExpandedAnchors] = useState<ExpandedAnchor[]>([]);
 
@@ -169,7 +185,16 @@ export function MessageCard({
     return null;
   }
 
-  const body = renderBody(message, html, onContentClick, copyAnchor, villageId, spoiled);
+  const body = renderBody(
+    message,
+    html,
+    onContentClick,
+    copyAnchor,
+    villageId,
+    spoiled,
+    onReply,
+    onSecret,
+  );
 
   return (
     <div className="mb-[20px]">
@@ -210,6 +235,8 @@ function renderBody(
   copyAnchor: (text: string) => void,
   villageId: number,
   spoiled: boolean,
+  onReply?: (reply: ReplyDraft) => void,
+  onSecret?: (reply: ReplyDraft) => void,
 ) {
   const type = message.messageType;
 
@@ -289,6 +316,44 @@ function renderBody(
             )}
           </div>
         </div>
+        {(message.canReply || message.canSecret) && (onReply != null || onSecret != null) && (
+          <div className="-mt-[18px] flex justify-end gap-[10px] text-[10.32px]">
+            {message.canReply && onReply != null && (
+              <button
+                type="button"
+                className="text-wm-accent cursor-pointer hover:underline"
+                onClick={() =>
+                  onReply(
+                    type === "SECRET_SAY"
+                      ? {
+                          anchorText: null,
+                          secretTargetCharaId: message.characterId ?? null,
+                          message,
+                        }
+                      : { anchorText: anchorText ?? "", secretTargetCharaId: null, message },
+                  )
+                }
+              >
+                &gt;&gt;返信
+              </button>
+            )}
+            {message.canSecret && onSecret != null && message.characterId != null && (
+              <button
+                type="button"
+                className="text-wm-accent cursor-pointer hover:underline"
+                onClick={() =>
+                  onSecret({
+                    anchorText: null,
+                    secretTargetCharaId: message.characterId ?? null,
+                    message,
+                  })
+                }
+              >
+                &gt;&gt;秘話
+              </button>
+            )}
+          </div>
+        )}
       </div>
     );
   }

--- a/frontend/app/routes/village/SayPanel.tsx
+++ b/frontend/app/routes/village/SayPanel.tsx
@@ -1,0 +1,394 @@
+import { useEffect, useRef, useState } from "react";
+
+import { Button } from "~/components/ui/Button";
+import { selectClass } from "~/components/ui/Input";
+import { MESSAGE_STYLES } from "~/components/ui/messageStyles";
+import type {
+  ParticipantSituationView,
+  VillageDetailView,
+  VillageSayRequest,
+} from "~/features/village/api";
+import { MessageCard, type ReplyDraft } from "./MessageCard";
+export type { ReplyDraft };
+
+/** 発言種別ラジオの表示順とラベル (フォーム上の並び)。 */
+const SAY_TYPE_ORDER: { code: string; label: string }[] = [
+  { code: "WEREWOLF_SAY", label: "囁き" },
+  { code: "MASON_SAY", label: "共鳴" },
+  { code: "LOVERS_SAY", label: "恋人" },
+  { code: "TELEPATHY", label: "念話" },
+  { code: "NORMAL_SAY", label: "通常" },
+  { code: "GRAVE_SAY", label: "呻き" },
+  { code: "SPECTATE_SAY", label: "見学" },
+  { code: "MONOLOGUE_SAY", label: "独り言" },
+  { code: "SECRET_SAY", label: "秘話" },
+];
+
+/** 発言種別 → textarea の背景色 (吹き出しと同じ配色)。 */
+const TYPE_TO_STYLE_KEY: Record<string, string> = {
+  WEREWOLF_SAY: "message-werewolf",
+  MASON_SAY: "message-mason",
+  LOVERS_SAY: "message-lover",
+  TELEPATHY: "message-telepathy",
+  MONOLOGUE_SAY: "message-monologue",
+  SECRET_SAY: "message-secret",
+  GRAVE_SAY: "message-grave",
+  SPECTATE_SAY: "message-spectate",
+};
+
+/** 発言種別 → 既定の表情種別コード。 */
+const TYPE_TO_FACE: Record<string, string> = {
+  NORMAL_SAY: "NORMAL",
+  WEREWOLF_SAY: "WEREWOLF",
+  MASON_SAY: "MASON",
+  LOVERS_SAY: "LOVER",
+  TELEPATHY: "SECRET",
+  MONOLOGUE_SAY: "MONOLOGUE",
+  SECRET_SAY: "SECRET",
+  GRAVE_SAY: "GRAVE",
+  SPECTATE_SAY: "NORMAL",
+};
+
+/** 装飾タグ (選択範囲を囲む)。 */
+const DECORATION_TAGS: { name: string; label: string; color?: string }[] = [
+  { name: "b", label: "B" },
+  { name: "s", label: "S" },
+  { name: "large", label: "大" },
+  { name: "small", label: "小" },
+  { name: "ruby", label: "rb" },
+  { name: "cw", label: "隠" },
+  { name: "tp", label: "透" },
+  { name: "#ff0000", label: "■", color: "#ff0000" },
+  { name: "#ff8800", label: "■", color: "#ff8800" },
+  { name: "#dddd00", label: "■", color: "#dddd00" },
+  { name: "#00dd00", label: "■", color: "#00dd00" },
+  { name: "#00dddd", label: "■", color: "#00dddd" },
+  { name: "#0000ff", label: "■", color: "#0000ff" },
+  { name: "#ee00ee", label: "■", color: "#ee00ee" },
+];
+
+const RANDOM_TAGS = ["fortune", "1d6", "or", "who", "allwho", "gwho"];
+
+/**
+ * 発言フォーム。種別選択 / 表情 / 装飾 / 文字数・行数・残数のリアルタイム表示 / 確認フロー。
+ * 制限超過でも入力はできるが確認ボタンを無効にする。
+ */
+export function SayPanel({
+  village,
+  mySituation,
+  randomKeywords,
+  reply,
+  onClearReply,
+  onConfirm,
+}: {
+  village: VillageDetailView;
+  mySituation: ParticipantSituationView;
+  randomKeywords: string[];
+  reply: ReplyDraft | null;
+  onClearReply: () => void;
+  /** 確認画面へ (リクエスト内容を親へ渡し、プレビュー取得は親が行う) */
+  onConfirm: (request: VillageSayRequest) => void;
+}) {
+  const say = mySituation.say;
+  const myself = mySituation.myself;
+  const selectable = say.selectableMessageTypeList ?? [];
+  const images = say.selectableCharaImageList ?? [];
+
+  const defaultType = say.defaultMessageTypeCode ?? selectable[0]?.messageTypeCode ?? "NORMAL_SAY";
+  const [messageType, setMessageType] = useState(defaultType);
+  const [message, setMessage] = useState("");
+  const [faceType, setFaceType] = useState<string>(
+    () =>
+      faceTypeFor(
+        defaultType,
+        images.map((i) => i.faceTypeCode),
+      ) ??
+      images[0]?.faceTypeCode ??
+      "NORMAL",
+  );
+  const [convertDisable, setConvertDisable] = useState(false);
+  const [secretTargetCharaId, setSecretTargetCharaId] = useState<string>("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // 返信・秘話返信からの引き継ぎ (アンカー挿入 / 種別・宛先の切替)
+  useEffect(() => {
+    if (reply == null) return;
+    if (reply.secretTargetCharaId != null) {
+      changeType("SECRET_SAY");
+      setSecretTargetCharaId(String(reply.secretTargetCharaId));
+    } else if (reply.anchorText != null) {
+      insertAtCursor(`${reply.anchorText}\n`);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reply]);
+
+  const current = selectable.find((t) => t.messageTypeCode === messageType);
+  const restrict = current?.restrict;
+  const secretTargets =
+    selectable.find((t) => t.messageTypeCode === "SECRET_SAY")?.targetList ?? [];
+
+  const length = message.length;
+  const lineCount = message.split("\n").length;
+  const maxLength = restrict?.maxLength ?? 400;
+  const maxLine = restrict?.maxLine ?? 20;
+  const leftCount = restrict?.remainingCount ?? null;
+  const maxCount = restrict?.maxCount ?? null;
+
+  const overLimit =
+    length > maxLength || lineCount > maxLine || (leftCount != null && leftCount <= 0);
+  const submitDisabled =
+    overLimit ||
+    message.trim().length === 0 ||
+    (messageType === "SECRET_SAY" && secretTargetCharaId === "");
+
+  function faceTypeFor(type: string, codes: string[]): string | null {
+    const candidate = TYPE_TO_FACE[type];
+    return candidate != null && codes.includes(candidate) ? candidate : null;
+  }
+
+  const changeType = (type: string) => {
+    setMessageType(type);
+    const face = faceTypeFor(
+      type,
+      images.map((i) => i.faceTypeCode),
+    );
+    if (face != null) setFaceType(face);
+  };
+
+  const insertAtCursor = (text: string, wrap?: { close: string }) => {
+    const textarea = textareaRef.current;
+    if (textarea == null) {
+      setMessage((prev) => prev + text);
+      return;
+    }
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const value = textarea.value;
+    const selected = value.slice(start, end);
+    const inserted = wrap == null ? text : `${text}${selected}${wrap.close}`;
+    const next = value.slice(0, start) + inserted + value.slice(wrap == null ? start : end);
+    setMessage(next);
+    requestAnimationFrame(() => {
+      textarea.focus();
+      const cursor = start + inserted.length;
+      textarea.setSelectionRange(cursor, cursor);
+    });
+  };
+
+  const addDecoration = (name: string) => {
+    if (name === "ruby") {
+      insertAtCursor("[[ruby]]", { close: "[[rt]][[/rt]][[/ruby]]" });
+    } else if (name.startsWith("#")) {
+      insertAtCursor(`[[${name}]]`, { close: "[[/#]]" });
+    } else {
+      insertAtCursor(`[[${name}]]`, { close: `[[/${name}]]` });
+    }
+  };
+
+  const faceImage = images.find((i) => i.faceTypeCode === faceType) ?? images[0];
+  const styleKey = TYPE_TO_STYLE_KEY[messageType];
+  const textareaStyle = styleKey != null ? MESSAGE_STYLES[styleKey] : "bg-white text-[#555]";
+
+  const submit = () => {
+    onConfirm({
+      message,
+      messageType,
+      faceType,
+      convertDisable,
+      secretSayTargetCharaId:
+        messageType === "SECRET_SAY" && secretTargetCharaId !== ""
+          ? Number(secretTargetCharaId)
+          : null,
+    });
+  };
+
+  return (
+    <div className="mb-[20px] rounded border border-[#464545] bg-[#303030]">
+      <div className="rounded-t bg-[#464545] px-[15px] py-[10px]">
+        <span className="text-[15px] text-white">発言</span>
+      </div>
+      <div className="p-[15px]">
+        {myself?.isDead && (
+          <div className="mb-[10px] rounded border border-[#e74c3c] p-[9px] text-[#e74c3c]">
+            あなたは死亡しました。現世の思い出を語り合いましょう。
+          </div>
+        )}
+        {village.status.isProgress && (
+          <div className="mb-[10px] rounded border border-[#f39c12] p-[9px] text-[#f39c12]">
+            {village.setting.rule.isVisibleGraveSpectateMessage
+              ? "この村は、墓下や見学発言を生存者が参照できます。進行中は、推理、まとめ、および推理に繋がる内容は生存者全員が見られる発言種別で発言しないでください。"
+              : "進行中は、推理、まとめ、および推理に繋がる内容は通常発言で発言しないでください。"}
+            <br />
+            COおよび能力行使結果の発表は生存中の導師と探偵のみ行うことができます。騙りCOも禁止です。
+          </div>
+        )}
+
+        {/* 発言種別 */}
+        <div className="flex flex-wrap">
+          {SAY_TYPE_ORDER.filter((t) => selectable.some((s) => s.messageTypeCode === t.code)).map(
+            (t) => {
+              const active = messageType === t.code;
+              return (
+                <button
+                  key={t.code}
+                  type="button"
+                  className={`not-first:-ml-px cursor-pointer border border-[#00bc8c] px-[9px] py-[5px] text-[13px] first:rounded-l-[3px] last:rounded-r-[3px] hover:opacity-90 ${
+                    active
+                      ? "bg-[#00bc8c] text-white shadow-[inset_0_3px_5px_rgba(0,0,0,0.125)]"
+                      : "bg-[#222222] text-[#00bc8c]"
+                  }`}
+                  onClick={() => changeType(t.code)}
+                >
+                  {t.label}
+                </button>
+              );
+            },
+          )}
+        </div>
+
+        {/* 秘話相手 */}
+        {messageType === "SECRET_SAY" && (
+          <div className="mt-[10px]">
+            <select
+              className={selectClass}
+              value={secretTargetCharaId}
+              onChange={(e) => setSecretTargetCharaId(e.target.value)}
+              aria-label="秘話相手"
+            >
+              <option value="">選択してください</option>
+              {secretTargets.map((target) => (
+                <option key={target.charaId} value={target.charaId}>
+                  {target.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {/* 装飾タグ・ランダム機能 */}
+        <div className="mt-[10px] flex flex-wrap items-center gap-[5px]">
+          {DECORATION_TAGS.map((tag) => (
+            <button
+              key={tag.name}
+              type="button"
+              className="cursor-pointer rounded-[3px] border border-[#464545] bg-[#464545] px-[8px] py-[2px] text-[12px] text-white hover:opacity-90"
+              style={tag.color != null ? { color: tag.color } : undefined}
+              onClick={() => addDecoration(tag.name)}
+            >
+              {tag.name === "s" ? <s>あ</s> : tag.label}
+            </button>
+          ))}
+          <button
+            type="button"
+            className="cursor-pointer rounded-[3px] border border-[#464545] bg-[#464545] px-[8px] py-[2px] text-[12px] text-white hover:opacity-90"
+            onClick={() => insertAtCursor("[[]]")}
+          >
+            [[]]
+          </button>
+          <RandomTagSelect
+            keywords={randomKeywords}
+            onAdd={(tag) => insertAtCursor(`[[${tag}]]`)}
+          />
+        </div>
+
+        {/* 表情 + 本文 */}
+        <div className="mt-[10px] flex">
+          <div>
+            {faceImage != null && (
+              <img src={faceImage.url} alt={faceImage.faceTypeName} width={60} height={77} />
+            )}
+            <select
+              className={`${selectClass} mt-[5px] max-w-[80px]`}
+              value={faceType}
+              onChange={(e) => setFaceType(e.target.value)}
+              aria-label="表情"
+            >
+              {images.map((image) => (
+                <option key={image.faceTypeCode} value={image.faceTypeCode}>
+                  {image.faceTypeName}
+                </option>
+              ))}
+            </select>
+          </div>
+          <textarea
+            ref={textareaRef}
+            className={`ml-[5px] min-h-[150px] flex-1 rounded border border-[#464545] p-[9px] text-[12px] ${textareaStyle}`}
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            aria-label="発言"
+          />
+        </div>
+
+        {/* 文字数・行数・残数 */}
+        <div className={`mt-[5px] ml-[55px] text-[12px] ${overLimit ? "text-[#e74c3c]" : ""}`}>
+          {leftCount != null && maxCount != null && `残り${leftCount}/${maxCount}回, `}
+          文字数: {length}/{maxLength}, 行数: {lineCount}/{maxLine}
+        </div>
+
+        <div className="mt-[10px] flex items-center justify-between">
+          <label className="flex cursor-pointer items-center gap-[5px] text-[12px]">
+            <input
+              type="checkbox"
+              checked={convertDisable}
+              onChange={() => setConvertDisable(!convertDisable)}
+            />
+            装飾・変換無効
+          </label>
+          <Button onClick={submit} disabled={submitDisabled}>
+            確認画面へ
+          </Button>
+        </div>
+
+        {/* 返信元の引用 */}
+        {reply != null && (
+          <div className="mt-[5px] rounded border border-[#ffff00] bg-[#303030] p-[10px]">
+            <div className="mb-[5px] flex justify-end">
+              <Button variant="default" size="xs" onClick={onClearReply}>
+                ×
+              </Button>
+            </div>
+            <MessageCard
+              villageId={village.id}
+              message={reply.message}
+              randomKeywords={randomKeywords}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RandomTagSelect({
+  keywords,
+  onAdd,
+}: {
+  keywords: string[];
+  onAdd: (tag: string) => void;
+}) {
+  const [selected, setSelected] = useState(RANDOM_TAGS[0]);
+  return (
+    <span className="inline-flex items-center gap-[5px]">
+      <select
+        className={selectClass}
+        value={selected}
+        onChange={(e) => setSelected(e.target.value)}
+        aria-label="ランダム機能"
+      >
+        {RANDOM_TAGS.map((tag) => (
+          <option key={tag} value={tag}>
+            {tag}
+          </option>
+        ))}
+        {keywords.map((keyword) => (
+          <option key={keyword} value={keyword}>
+            {keyword}
+          </option>
+        ))}
+      </select>
+      <Button variant="info" size="xs" onClick={() => onAdd(selected)}>
+        追加
+      </Button>
+    </span>
+  );
+}

--- a/frontend/app/routes/village/messageHtml.ts
+++ b/frontend/app/routes/village/messageHtml.ts
@@ -131,7 +131,7 @@ export function replaceIdLink(messageType: string, html: string): string {
   return html;
 }
 
-/** ISO 日時 → `yyyy/MM/dd HH:mm:ss` 表示。 */
+/** ISO 日時 → `yyyy/MM/dd HH:mm:ss` 表示 (小数秒は落とす)。 */
 export function formatMessageTime(iso: string): string {
-  return iso.replace("T", " ").replace(/-/g, "/");
+  return iso.split(".")[0].replace("T", " ").replace(/-/g, "/");
 }

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -2,10 +2,17 @@ import { useCallback, useEffect, useState } from "react";
 import { Link, useSearchParams } from "react-router";
 
 import { PageLayout } from "~/components/layout/PageLayout";
-import { LinkButton } from "~/components/ui/Button";
+import { Button, LinkButton } from "~/components/ui/Button";
 import { useMe } from "~/features/auth/useMe";
 import { useRandomKeywords } from "~/features/random-keywords/useRandomKeywords";
-import type { VillageDetailView, VillageMessageListContent } from "~/features/village/api";
+import {
+  confirmVillageSay,
+  sayVillage,
+  type VillageDetailView,
+  type VillageMessageContent,
+  type VillageMessageListContent,
+  type VillageSayRequest,
+} from "~/features/village/api";
 import {
   applyFilterToParams,
   EMPTY_FILTER,
@@ -28,6 +35,9 @@ import { DayList } from "./DayList";
 import { FilterModal } from "./FilterModal";
 import { FooterMenu } from "./FooterMenu";
 import { MessageArea } from "./MessageArea";
+import { type ReplyDraft } from "./MessageCard";
+import { MessageCard } from "./MessageCard";
+import { SayPanel } from "./SayPanel";
 import { SituationPanel } from "./SituationPanel";
 import { useCountdown } from "./useCountdown";
 import type { Route } from "./+types/route";
@@ -45,6 +55,28 @@ function latestDayOf(village: VillageDetailView): number {
 /** 村番号は 4 桁 0 埋めで表示する。 */
 function villageNumber(id: number): string {
   return String(id).padStart(4, "0");
+}
+
+/** 確認画面の投稿ボタンのラベル (発言種別ごと)。 */
+function sayLabel(messageType: string | null | undefined): string {
+  switch (messageType) {
+    case "WEREWOLF_SAY":
+      return "発言する（囁き）";
+    case "MASON_SAY":
+      return "発言する（共鳴）";
+    case "LOVERS_SAY":
+      return "発言する（恋人）";
+    case "TELEPATHY":
+      return "発言する（念話）";
+    case "MONOLOGUE_SAY":
+      return "発言する（独り言）";
+    case "SECRET_SAY":
+      return "発言する（秘話）";
+    case "GRAVE_SAY":
+      return "呻く";
+    default:
+      return "発言する";
+  }
 }
 
 function formatStartDatetime(iso: string): string {
@@ -85,6 +117,10 @@ export default function Village({ params }: Route.ComponentProps) {
   const { data: mySituation, error: mySituationError } = useMyVillageSituation(villageId, dayParam);
   const { data: randomKeywords } = useRandomKeywords();
   const invalidate = useInvalidateVillage(villageId);
+  const keywordList = (randomKeywords ?? []).map((k) => k.keyword ?? "").filter(Boolean);
+  const canSecretReply =
+    mySituation?.say.selectableMessageTypeList?.some((t) => t.messageTypeCode === "SECRET_SAY") ??
+    false;
 
   // 発言抽出。URL searchParams が正本 (共有 URL で再現できる)
   const [searchParams, setSearchParams] = useSearchParams();
@@ -103,6 +139,48 @@ export default function Village({ params }: Route.ComponentProps) {
     },
     [setSearchParams],
   );
+
+  // 発言: 返信引き継ぎと確認 (プレビュー) → 投稿の 2 段フロー
+  const [reply, setReply] = useState<ReplyDraft | null>(null);
+  const [sayPreview, setSayPreview] = useState<{
+    message: VillageMessageContent;
+    request: VillageSayRequest;
+  } | null>(null);
+  const [sayError, setSayError] = useState<string | null>(null);
+  const onReply = useCallback((draft: ReplyDraft) => {
+    setReply(draft);
+    document.getElementById("say-panel")?.scrollIntoView();
+  }, []);
+  const onSayConfirm = async (request: VillageSayRequest) => {
+    setSayError(null);
+    try {
+      const response = await confirmVillageSay(villageId, request);
+      if (response.message == null) return;
+      setSayPreview({ message: response.message, request });
+      requestAnimationFrame(() =>
+        document.getElementById("message-confirm-area")?.scrollIntoView(),
+      );
+    } catch (e) {
+      setSayError(e instanceof ApiError ? e.detail : "発言の確認に失敗しました");
+    }
+  };
+  const onSayDetermine = async () => {
+    if (sayPreview == null) return;
+    setSayError(null);
+    try {
+      await sayVillage(villageId, sayPreview.request);
+      setSayPreview(null);
+      setReply(null);
+      await invalidate();
+      requestAnimationFrame(() => document.getElementById("bottom")?.scrollIntoView());
+    } catch (e) {
+      setSayError(e instanceof ApiError ? e.detail : "発言に失敗しました");
+    }
+  };
+  const onSayCancel = () => {
+    setSayPreview(null);
+    document.getElementById("say-panel")?.scrollIntoView();
+  };
 
   const latestDay = village != null ? latestDayOf(village) : undefined;
   const currentDay = dayParam ?? latestDay ?? 0;
@@ -179,11 +257,34 @@ export default function Village({ params }: Route.ComponentProps) {
         <MessageArea
           villageId={villageId}
           day={dayParam}
-          randomKeywords={(randomKeywords ?? []).map((k) => k.keyword ?? "").filter(Boolean)}
+          randomKeywords={keywordList}
           filter={filter}
           onHashtagClick={onHashtagClick}
+          onReply={mySituation?.say.isAvailableSay ? onReply : undefined}
+          onSecret={canSecretReply ? onReply : undefined}
           onLoaded={onMessagesLoaded}
         />
+        {sayPreview != null && (
+          <div
+            id="message-confirm-area"
+            className="mb-[20px] rounded border border-[#ffff00] bg-[#303030] p-[10px]"
+          >
+            <p className="mb-[10px]">
+              以下の内容で発言してよろしいですか？（まだ発言されていません）
+            </p>
+            <MessageCard
+              villageId={villageId}
+              message={sayPreview.message}
+              randomKeywords={keywordList}
+            />
+            <div className="flex justify-end gap-[10px]">
+              <Button variant="default" onClick={onSayCancel}>
+                キャンセル
+              </Button>
+              <Button onClick={onSayDetermine}>{sayLabel(sayPreview.request.messageType)}</Button>
+            </div>
+          </div>
+        )}
         {!noAd && (
           <div className="mt-[15px] min-h-[90px] border border-dashed border-gray-600 p-2 text-center text-gray-400">
             広告（移行中はプレースホルダー）
@@ -196,6 +297,20 @@ export default function Village({ params }: Route.ComponentProps) {
 
         {situation != null && (
           <SituationPanel situation={situation} day={currentDay} spoiled={filter.spoiled} />
+        )}
+
+        {mySituation?.say.isAvailableSay && (
+          <div id="say-panel">
+            {sayError != null && <p className="mb-[5px] text-[#e74c3c]">{sayError}</p>}
+            <SayPanel
+              village={village}
+              mySituation={mySituation}
+              randomKeywords={keywordList}
+              reply={reply}
+              onClearReply={() => setReply(null)}
+              onConfirm={onSayConfirm}
+            />
+          </div>
         )}
 
         <DayList

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -147,6 +147,7 @@ export default function Village({ params }: Route.ComponentProps) {
     request: VillageSayRequest;
   } | null>(null);
   const [sayError, setSayError] = useState<string | null>(null);
+  const [saySubmitting, setSaySubmitting] = useState(false);
   const onReply = useCallback((draft: ReplyDraft) => {
     setReply(draft);
     document.getElementById("say-panel")?.scrollIntoView();
@@ -155,7 +156,10 @@ export default function Village({ params }: Route.ComponentProps) {
     setSayError(null);
     try {
       const response = await confirmVillageSay(villageId, request);
-      if (response.message == null) return;
+      if (response.message == null) {
+        setSayError("発言の確認に失敗しました");
+        return;
+      }
       setSayPreview({ message: response.message, request });
       requestAnimationFrame(() =>
         document.getElementById("message-confirm-area")?.scrollIntoView(),
@@ -165,7 +169,9 @@ export default function Village({ params }: Route.ComponentProps) {
     }
   };
   const onSayDetermine = async () => {
-    if (sayPreview == null) return;
+    // 非冪等な投稿のため連打をガードする
+    if (sayPreview == null || saySubmitting) return;
+    setSaySubmitting(true);
     setSayError(null);
     try {
       await sayVillage(villageId, sayPreview.request);
@@ -175,6 +181,8 @@ export default function Village({ params }: Route.ComponentProps) {
       requestAnimationFrame(() => document.getElementById("bottom")?.scrollIntoView());
     } catch (e) {
       setSayError(e instanceof ApiError ? e.detail : "発言に失敗しました");
+    } finally {
+      setSaySubmitting(false);
     }
   };
   const onSayCancel = () => {
@@ -281,7 +289,9 @@ export default function Village({ params }: Route.ComponentProps) {
               <Button variant="default" onClick={onSayCancel}>
                 キャンセル
               </Button>
-              <Button onClick={onSayDetermine}>{sayLabel(sayPreview.request.messageType)}</Button>
+              <Button onClick={onSayDetermine} disabled={saySubmitting}>
+                {sayLabel(sayPreview.request.messageType)}
+              </Button>
             </div>
           </div>
         )}


### PR DESCRIPTION
closes .issues/step-8.4-village-say.md

## 概要

発言投稿を REST + React 化する (step-8.4)。種別選択 / 表情 / 装飾 / 種別別制限の出し分け / **確認 → 投稿の 2 段フロー** (確定方針どおり「実際に発言が表示される位置でプレビュー」) / 返信・秘話返信。base は `feature/monorepo-step8`。

## backend

- **situation/me の say を拡張** (additive): `selectableMessageTypeList` (種別コード + restrict {maxCount/remainingCount/maxLength/maxLine} + 秘話の宛先候補 {charaId, name}) / `selectableCharaImageList` (表示中の表情差分 code/name/url) / `defaultMessageTypeCode`。ネスト DTO は `@Schema` 命名
- **`POST /api/v1/villages/{id}/say-confirm`** (要認証): プレビュー。検証は SSR と共通の `SayFormValidator` を `VillageSayRequest.toForm()` 後に流用 → fieldErrors。整形は既存 `VillageSayConfirmContent` を直接返す。発言可否・種別妥当性は既存 `MessageCoordinator.confirmToSay` (domain) が検証
- **`POST /api/v1/villages/{id}/say`** (要認証) → 204。**IP アドレス記録は SSR と同じ** (`getIpAddress`、不正対策)。`MessageCoordinator.say` 流用 (通知・ランダム展開も既存どおり)

## frontend

- **`SayPanel`**: 死亡時/進行中の注意アラート → 種別ラジオ (selectable のみ表示、種別→textarea 背景色/既定表情の自動切替) → 秘話相手 select → 装飾ツールバー (B/S/大/小/ruby/隠/透/色 7 種/[[]]/ランダム機能 select、選択範囲を [[tag]] で囲んでカーソル位置に挿入) → 表情 select + プレビュー → textarea → **残り回数/文字数/行数のリアルタイム表示** (超過で赤字 + 確認ボタン無効。**入力自体は可能**の挙動を維持) → 変換無効 → 確認画面へ
- **確認フロー**: 確認 → メッセージ一覧末尾相当の位置に黄枠プレビュー (「以下の内容で発言してよろしいですか？（まだ発言されていません）」+ `MessageCard` 描画) へスクロール → 「発言する（種別）」(種別別ラベル) で投稿 → 一覧無効化 + `#bottom` へ / キャンセルでフォームへ戻る
- **返信・秘話返信**: 8.2 で未接続だったログ上の `>>返信` / `>>秘話` リンクを接続。返信はアンカーを本文へ挿入 + 元発言を黄枠引用、秘話返信は種別を秘話 + 宛先セット
- 確認プレビューの日時は小数秒を落として表示 (`formatMessageTime`)

## 検証

- 村 5 で実測: REST 単体 (confirm → say 204 → 一覧反映、装飾 [[b]] とアンカー入り)。UI 一連 (種別切替 独り言 → 入力 → カウント追従 → 確認プレビュー → 発言する（独り言） → プレビュー消滅 + ログ反映) を Playwright で確認。空入力時の確認ボタン無効も確認
- backend: ktlintCheck / test green。frontend: typecheck / lint / format / build green。gen:api 差分込み
- e2e 2 件追加 (発言一連フロー / 空入力無効。master + 進行中村で動的 skip)

## 申し送り

- 装飾ツールバーは legacy では表示設定 `is_disp_random_tag_area` で既定非表示 → ユーザー設定のサブ step で設定に接続するまで**常時表示** (意図的な暫定差異)
- アクション発言 (別パネル) は次サブ step。表情画像クリックでの画像選択モーダル・秘話相手の画像選択モーダルは select で代替 (legacy にあるモーダルは後続で検討)
- 確認中の自動更新抑止 (`canAutoRefresh`) は自動リロード自体がユーザー設定サブ step のため、その実装時に対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)
