### PR TITLE
feat: 村画面のアクション発言を REST + React 化 (step-8.5)

### DIFF
--- a/.issues/README.md
+++ b/.issues/README.md
@@ -24,7 +24,7 @@ monorepo 移行作業中につき **階層番号方式** (`step-<N>(.M)-<slug>.m
 
 | # | タイトル | type | status |
 | --- | --- | --- | --- |
-| (現在 open な Issue なし) | | | |
+| step-8.5 | 村画面 アクション発言 (別パネル + 確認フロー) | enhancement | open |
 
 > **Step 8 は統合ブランチ方式 (ユーザー指示 2026-06-12)**: `feature/monorepo-step8` を base にサブ step PR を積み、同ブランチへの squash merge は Claude 単独で可。`feature/monorepo` への merge は最終 PR でユーザー承認。8.1 ✅ #71 / 8.2 ✅ #72 / 8.3 ✅ #73 / 8.4 ✅ #74。
 

--- a/backend/src/main/kotlin/com/ort/app/api/village/VillageSayRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/VillageSayRestController.kt
@@ -1,7 +1,9 @@
 package com.ort.app.api.village
 
+import com.ort.app.api.request.validator.ActionFormValidator
 import com.ort.app.api.request.validator.SayFormValidator
 import com.ort.app.api.view.VillageSayConfirmContent
+import com.ort.app.api.village.request.VillageActionRequest
 import com.ort.app.api.village.request.VillageSayRequest
 import com.ort.app.application.coordinator.MessageCoordinator
 import com.ort.app.application.service.CharaService
@@ -16,6 +18,7 @@ import com.ort.app.fw.exception.WolfMansionValidationException
 import com.ort.app.fw.exception.WolfMansionValidationException.FieldErrorItem
 import com.ort.app.fw.interceptor.getIpAddress
 import com.ort.app.fw.security.jwt.JwtPrincipal
+import com.ort.dbflute.allcommon.CDef
 import io.swagger.v3.oas.annotations.Operation
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.context.MessageSource
@@ -45,6 +48,7 @@ class VillageSayRestController(
     private val randomKeywordService: RandomKeywordService,
     private val messageCoordinator: MessageCoordinator,
     private val sayFormValidator: SayFormValidator,
+    private val actionFormValidator: ActionFormValidator,
     private val messageSource: MessageSource,
     private val httpServletRequest: HttpServletRequest,
 ) {
@@ -104,6 +108,79 @@ class VillageSayRestController(
             request.secretSayTargetCharaId,
             httpServletRequest.getIpAddress(),
         )
+    }
+
+    /** アクション発言の確認 (プレビュー)。「{自分}は、{対象}{本文}」を結合して表示用に整形する。 */
+    @Operation(operationId = "confirmVillageAction")
+    @PostMapping("/action-confirm")
+    fun actionConfirm(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+        @RequestBody @Validated request: VillageActionRequest,
+    ): VillageSayConfirmContent {
+        val (village, myself) = resolveSayer(principal, id)
+        validateAction(request)
+        val message =
+            messageCoordinator.confirmToSay(
+                village,
+                myself,
+                composeActionText(request),
+                CDef.MessageType.アクション.code(),
+                null,
+                request.convertDisable,
+                null,
+            )
+        val player = playerService.findPlayer(myself.playerId)
+        val charas =
+            village.setting.chara.let {
+                charaService.findCharachips(it.charachipIds, it.isOriginalCharachip).charas()
+            }
+        return VillageSayConfirmContent(
+            village = village,
+            message = message,
+            fromParticipant = myself,
+            player = player,
+            charas = charas,
+            keywords = randomKeywordService.findRandomKeywords(),
+        )
+    }
+
+    /** アクション発言する。 */
+    @Operation(operationId = "actionVillage")
+    @PostMapping("/action")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun action(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+        @RequestBody @Validated request: VillageActionRequest,
+    ) {
+        val (village, myself) = resolveSayer(principal, id)
+        validateAction(request)
+        messageCoordinator.say(
+            village,
+            myself,
+            composeActionText(request),
+            CDef.MessageType.アクション.code(),
+            null,
+            request.convertDisable,
+            null,
+            httpServletRequest.getIpAddress(),
+        )
+    }
+
+    private fun composeActionText(request: VillageActionRequest): String = "${request.myself!!}${request.target ?: ""}${request.message!!}"
+
+    private fun validateAction(request: VillageActionRequest) {
+        val form = request.toForm()
+        val errors = BeanPropertyBindingResult(form, "actionForm")
+        actionFormValidator.validate(form, errors)
+        if (errors.hasErrors()) {
+            throw WolfMansionValidationException(
+                errors.fieldErrors.map {
+                    FieldErrorItem(it.field, messageSource.getMessage(it, Locale.JAPAN))
+                },
+            )
+        }
     }
 
     private fun resolveSayer(

--- a/backend/src/main/kotlin/com/ort/app/api/village/request/VillageActionRequest.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/request/VillageActionRequest.kt
@@ -1,0 +1,28 @@
+package com.ort.app.api.village.request
+
+import com.ort.app.api.request.VillageActionForm
+import jakarta.validation.constraints.NotNull
+
+/**
+ * アクション発言の確認/投稿。「{自分}は、{対象}{本文}」を結合してアクション種別で投稿する。
+ * 検証は SSR と共通の ActionFormValidator を [toForm] 変換後に流用する。
+ */
+data class VillageActionRequest(
+    /** 「〜は、」の prefix (表示名由来) */
+    @field:NotNull
+    val myself: String? = null,
+    /** 対象 (選択しない場合は null) */
+    val target: String? = null,
+    @field:NotNull
+    val message: String? = null,
+    /** 装飾・変換を無効にするか */
+    val convertDisable: Boolean? = null,
+) {
+    fun toForm(): VillageActionForm =
+        VillageActionForm(
+            myself = myself,
+            target = target,
+            message = message,
+            convertDisable = convertDisable,
+        )
+}

--- a/e2e/tests/village-say.spec.ts
+++ b/e2e/tests/village-say.spec.ts
@@ -75,3 +75,36 @@ test("空入力では確認ボタンが無効", async ({ page }) => {
 
   await expect(sayPanel.getByRole("button", { name: "確認画面へ" })).toBeDisabled();
 });
+
+test("アクション: 対象選択 + 本文 → 確認 → 投稿 → ログ反映", async ({ page }) => {
+  const villages = await findVillages(page, ["IN_PROGRESS"]);
+  test.skip(villages.length === 0, "進行中の村が無い DB のためスキップ");
+  const village = villages[0];
+
+  await loginAsMaster(page);
+  await page.goto(`village/${village.id}`);
+  await expect(page.locator(".message").first()).toBeVisible({ timeout: 15000 });
+
+  const actionPanel = page.locator("div").filter({ hasText: /^アクション$/ }).first();
+  const actionInput = page.getByLabel("アクション本文");
+  test.skip((await actionInput.count()) === 0, "アクションできない状態のためスキップ");
+
+  const text = `に e2e アクション ${Date.now()}`;
+  await page.getByLabel("アクションの対象").selectOption("全員");
+  await actionInput.fill(text);
+  await actionPanel
+    .locator("..")
+    .getByRole("button", { name: "確認画面へ" })
+    .last()
+    .click();
+
+  const confirmArea = page.locator("#message-confirm-area");
+  await expect(confirmArea).toBeVisible();
+  await expect(confirmArea).toContainText(text);
+
+  await confirmArea.getByRole("button", { name: "アクション" }).click();
+  await expect(confirmArea).toHaveCount(0);
+  await expect(page.locator(".message-action").filter({ hasText: text })).toBeVisible({
+    timeout: 15000,
+  });
+});

--- a/frontend/app/api/openapi.json
+++ b/frontend/app/api/openapi.json
@@ -593,6 +593,77 @@
         "tags": ["village-rest-controller"]
       }
     },
+    "/api/v1/villages/{id}/action": {
+      "post": {
+        "operationId": "actionVillage",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VillageActionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": ["village-say-rest-controller"]
+      }
+    },
+    "/api/v1/villages/{id}/action-confirm": {
+      "post": {
+        "operationId": "confirmVillageAction",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VillageActionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/VillageSayConfirmContent"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": ["village-say-rest-controller"]
+      }
+    },
     "/api/v1/villages/{id}/messages": {
       "get": {
         "operationId": "getVillageMessages",
@@ -2315,6 +2386,24 @@
           }
         },
         "required": ["skillCodes"]
+      },
+      "VillageActionRequest": {
+        "type": "object",
+        "properties": {
+          "convertDisable": {
+            "type": ["boolean", "null"]
+          },
+          "message": {
+            "type": ["string", "null"]
+          },
+          "myself": {
+            "type": ["string", "null"]
+          },
+          "target": {
+            "type": ["string", "null"]
+          }
+        },
+        "required": ["message", "myself"]
       },
       "VillageAnchorMessageContent": {
         "type": "object",

--- a/frontend/app/api/types.ts
+++ b/frontend/app/api/types.ts
@@ -259,6 +259,38 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/villages/{id}/action": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["actionVillage"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/villages/{id}/action-confirm": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["confirmVillageAction"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/villages/{id}/messages": {
     parameters: {
       query?: never;
@@ -809,6 +841,12 @@ export interface components {
     };
     SkillSearchResponse: {
       skillCodes: string[];
+    };
+    VillageActionRequest: {
+      convertDisable?: boolean | null;
+      message: string | null;
+      myself: string | null;
+      target?: string | null;
     };
     VillageAnchorMessageContent: {
       message?: components["schemas"]["VillageMessageContent"] | null;
@@ -1610,6 +1648,56 @@ export interface operations {
         };
         content: {
           "*/*": components["schemas"]["VillageDetailView"];
+        };
+      };
+    };
+  };
+  actionVillage: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["VillageActionRequest"];
+      };
+    };
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  confirmVillageAction: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["VillageActionRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["VillageSayConfirmContent"];
         };
       };
     };

--- a/frontend/app/features/village/api.ts
+++ b/frontend/app/features/village/api.ts
@@ -156,3 +156,22 @@ export function confirmVillageSay(
 export function sayVillage(id: number, request: VillageSayRequest): Promise<void> {
   return apiFetch<void>(`/api/v1/villages/${id}/say`, { method: "POST", body: request });
 }
+
+/** アクション発言のリクエスト。 */
+export type VillageActionRequest = components["schemas"]["VillageActionRequest"];
+
+/** アクション発言を確認する (プレビュー)。要認証。 */
+export function confirmVillageAction(
+  id: number,
+  request: VillageActionRequest,
+): Promise<VillageSayConfirmContent> {
+  return apiFetch<VillageSayConfirmContent>(`/api/v1/villages/${id}/action-confirm`, {
+    method: "POST",
+    body: request,
+  });
+}
+
+/** アクション発言する。要認証 → 204。 */
+export function actionVillage(id: number, request: VillageActionRequest): Promise<void> {
+  return apiFetch<void>(`/api/v1/villages/${id}/action`, { method: "POST", body: request });
+}

--- a/frontend/app/routes/village/ActionPanel.tsx
+++ b/frontend/app/routes/village/ActionPanel.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react";
+
+import { Button } from "~/components/ui/Button";
+import { selectClass } from "~/components/ui/Input";
+import type {
+  ParticipantSituationView,
+  VillageActionRequest,
+  VillageFilterParticipantContent,
+} from "~/features/village/api";
+
+/**
+ * アクション発言フォーム (発言とは別パネル)。「{自分}は、{対象}{本文}」を結合して投稿する。
+ * 制限超過でも入力はできるが確認ボタンを無効にする。
+ */
+export function ActionPanel({
+  mySituation,
+  participants,
+  onConfirm,
+}: {
+  mySituation: ParticipantSituationView;
+  participants: VillageFilterParticipantContent[];
+  onConfirm: (request: VillageActionRequest) => void;
+}) {
+  const myself = mySituation.myself;
+  const restrict = mySituation.say.selectableMessageTypeList?.find(
+    (t) => t.messageTypeCode === "ACTION",
+  )?.restrict;
+
+  const [target, setTarget] = useState("");
+  const [message, setMessage] = useState("");
+  const [convertDisable, setConvertDisable] = useState(false);
+
+  if (myself == null) return null;
+  const prefix = `${myself.name}は、`;
+  // 対象は自分以外の参加者を表示名で指定する
+  const targets = participants.filter((p) => p.id !== myself.id).map((p) => p.name ?? "");
+
+  const totalLength = (prefix + target + message).length;
+  const maxLength = restrict?.maxLength ?? 400;
+  const leftCount = restrict?.remainingCount ?? null;
+  const maxCount = restrict?.maxCount ?? null;
+  const overLimit = totalLength > maxLength || (leftCount != null && leftCount <= 0);
+  const submitDisabled = overLimit || message.trim().length === 0;
+
+  return (
+    <div className="mb-[20px] rounded border border-[#464545] bg-[#303030]">
+      <div className="rounded-t bg-[#464545] px-[15px] py-[10px]">
+        <span className="text-[15px] text-white">アクション</span>
+      </div>
+      <div className="p-[15px]">
+        <div className="mb-[10px] rounded border border-[#f39c12] p-[9px] text-[#f39c12]">
+          推理、まとめ、および推理に繋がる内容のアクションは禁止です。
+        </div>
+        <div className="flex flex-wrap items-center gap-[5px]">
+          <span>{prefix}</span>
+          <select
+            className={`${selectClass} max-w-[200px]`}
+            value={target}
+            onChange={(e) => setTarget(e.target.value)}
+            aria-label="アクションの対象"
+          >
+            <option value="">選択しない</option>
+            <option value="全員">全員</option>
+            {targets.map((name) => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+          </select>
+          <input
+            type="text"
+            className="h-[30px] min-w-[200px] flex-1 rounded border border-[#464545] bg-white p-[6px] text-[12px] text-[#555]"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            aria-label="アクション本文"
+          />
+        </div>
+        <div className={`mt-[5px] text-[12px] ${overLimit ? "text-[#e74c3c]" : ""}`}>
+          {leftCount != null && maxCount != null && `残り${leftCount}/${maxCount}回, `}
+          文字数: {totalLength}/{maxLength}
+        </div>
+        <div className="mt-[10px] flex items-center justify-between">
+          <label className="flex cursor-pointer items-center gap-[5px] text-[12px]">
+            <input
+              type="checkbox"
+              checked={convertDisable}
+              onChange={() => setConvertDisable(!convertDisable)}
+            />
+            装飾・変換無効
+          </label>
+          <Button
+            onClick={() =>
+              onConfirm({
+                myself: prefix,
+                target: target === "" ? null : target,
+                message,
+                convertDisable,
+              })
+            }
+            disabled={submitDisabled}
+          >
+            確認画面へ
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -6,8 +6,11 @@ import { Button, LinkButton } from "~/components/ui/Button";
 import { useMe } from "~/features/auth/useMe";
 import { useRandomKeywords } from "~/features/random-keywords/useRandomKeywords";
 import {
+  actionVillage,
+  confirmVillageAction,
   confirmVillageSay,
   sayVillage,
+  type VillageActionRequest,
   type VillageDetailView,
   type VillageMessageContent,
   type VillageMessageListContent,
@@ -30,6 +33,7 @@ import {
 } from "~/features/village/useVillage";
 import { ApiError } from "~/lib/api";
 import { siteMeta } from "~/lib/meta";
+import { ActionPanel } from "./ActionPanel";
 import { AgeLimitModal } from "./AgeLimitModal";
 import { DayList } from "./DayList";
 import { FilterModal } from "./FilterModal";
@@ -118,6 +122,9 @@ export default function Village({ params }: Route.ComponentProps) {
   const { data: randomKeywords } = useRandomKeywords();
   const invalidate = useInvalidateVillage(villageId);
   const keywordList = (randomKeywords ?? []).map((k) => k.keyword ?? "").filter(Boolean);
+  const canAction =
+    mySituation?.say.selectableMessageTypeList?.some((t) => t.messageTypeCode === "ACTION") ??
+    false;
   const canSecretReply =
     mySituation?.say.selectableMessageTypeList?.some((t) => t.messageTypeCode === "SECRET_SAY") ??
     false;
@@ -142,10 +149,11 @@ export default function Village({ params }: Route.ComponentProps) {
 
   // 発言: 返信引き継ぎと確認 (プレビュー) → 投稿の 2 段フロー
   const [reply, setReply] = useState<ReplyDraft | null>(null);
-  const [sayPreview, setSayPreview] = useState<{
-    message: VillageMessageContent;
-    request: VillageSayRequest;
-  } | null>(null);
+  const [sayPreview, setSayPreview] = useState<
+    | { kind: "say"; message: VillageMessageContent; request: VillageSayRequest }
+    | { kind: "action"; message: VillageMessageContent; request: VillageActionRequest }
+    | null
+  >(null);
   const [sayError, setSayError] = useState<string | null>(null);
   const [saySubmitting, setSaySubmitting] = useState(false);
   const onReply = useCallback((draft: ReplyDraft) => {
@@ -160,12 +168,28 @@ export default function Village({ params }: Route.ComponentProps) {
         setSayError("発言の確認に失敗しました");
         return;
       }
-      setSayPreview({ message: response.message, request });
+      setSayPreview({ kind: "say", message: response.message, request });
       requestAnimationFrame(() =>
         document.getElementById("message-confirm-area")?.scrollIntoView(),
       );
     } catch (e) {
       setSayError(e instanceof ApiError ? e.detail : "発言の確認に失敗しました");
+    }
+  };
+  const onActionConfirm = async (request: VillageActionRequest) => {
+    setSayError(null);
+    try {
+      const response = await confirmVillageAction(villageId, request);
+      if (response.message == null) {
+        setSayError("アクションの確認に失敗しました");
+        return;
+      }
+      setSayPreview({ kind: "action", message: response.message, request });
+      requestAnimationFrame(() =>
+        document.getElementById("message-confirm-area")?.scrollIntoView(),
+      );
+    } catch (e) {
+      setSayError(e instanceof ApiError ? e.detail : "アクションの確認に失敗しました");
     }
   };
   const onSayDetermine = async () => {
@@ -174,7 +198,11 @@ export default function Village({ params }: Route.ComponentProps) {
     setSaySubmitting(true);
     setSayError(null);
     try {
-      await sayVillage(villageId, sayPreview.request);
+      if (sayPreview.kind === "say") {
+        await sayVillage(villageId, sayPreview.request);
+      } else {
+        await actionVillage(villageId, sayPreview.request);
+      }
       setSayPreview(null);
       setReply(null);
       await invalidate();
@@ -290,7 +318,9 @@ export default function Village({ params }: Route.ComponentProps) {
                 キャンセル
               </Button>
               <Button onClick={onSayDetermine} disabled={saySubmitting}>
-                {sayLabel(sayPreview.request.messageType)}
+                {sayPreview.kind === "action"
+                  ? "アクション"
+                  : sayLabel(sayPreview.request.messageType)}
               </Button>
             </div>
           </div>
@@ -321,6 +351,14 @@ export default function Village({ params }: Route.ComponentProps) {
               onConfirm={onSayConfirm}
             />
           </div>
+        )}
+
+        {mySituation != null && canAction && (
+          <ActionPanel
+            mySituation={mySituation}
+            participants={situation?.participantList ?? []}
+            onConfirm={onActionConfirm}
+          />
         )}
 
         <DayList


### PR DESCRIPTION
closes .issues/step-8.5-village-action.md

## 概要

アクション発言 (別パネル、「{自分}は、{対象}{本文}」) を REST + React 化 (step-8.5)。base は `feature/monorepo-step8`。

## backend

- `POST /api/v1/villages/{id}/action-confirm` / `POST .../action` (要認証 → 204)。`VillageActionRequest.toForm()` で SSR と共通の `ActionFormValidator` を流用し、結合テキストを `MessageCoordinator.confirmToSay/say` (アクション種別) へ委譲。IP 記録維持。SSR の action 系だけ CSRF 必須だった非対称は v1 チェーン (CSRF 無効 + JWT) で解消

## frontend

- **`ActionPanel`**: 「{表示名}は、」prefix + 対象 select (選択しない/全員/自分以外の参加者 = situation.participantList 由来) + 本文 + 文字数/残数 (ACTION の restrict は situation/me の say.selectableMessageTypeList から) + 変換無効。超過は入力可・確認のみ無効
- 確認 → 投稿フローは発言と共用 (プレビュー state に kind を導入、確定ボタンは「アクション」ラベル)

## 検証

- REST 実測 (confirm 200 / action 204 / ACTION 種別で一覧反映「[10楽] 楽天家 ゲルトは、全員に手を振った。」)
- backend ktlintCheck/test green。frontend typecheck/lint/format/build green。gen:api 差分込み
- e2e 1 件追加 (アクション一連フロー、全 59 件 green 想定 — say spec 単体 3/3 green 確認済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)