### PR TITLE
feat: 村画面の入村を REST + React 化 (step-8.6)

### DIFF
--- a/.issues/README.md
+++ b/.issues/README.md
@@ -24,7 +24,7 @@ monorepo 移行作業中につき **階層番号方式** (`step-<N>(.M)-<slug>.m
 
 | # | タイトル | type | status |
 | --- | --- | --- | --- |
-| (現在 open な Issue なし) | | | |
+| step-8.6 | 村画面 入村 (キャラ選択 + 入村発言 + 希望役職 + 確認) | enhancement | open |
 
 > **Step 8 は統合ブランチ方式 (ユーザー指示 2026-06-12)**: `feature/monorepo-step8` を base にサブ step PR を積み、同ブランチへの squash merge は Claude 単独で可。`feature/monorepo` への merge は最終 PR でユーザー承認。8.1 ✅ #71 / 8.2 ✅ #72 / 8.3 ✅ #73 / 8.4 ✅ #74 / 8.5 ✅ #75。
 

--- a/backend/src/main/kotlin/com/ort/app/api/village/VillageParticipateRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/VillageParticipateRestController.kt
@@ -1,0 +1,143 @@
+package com.ort.app.api.village
+
+import com.ort.app.api.request.validator.VillageParticipateFormValidator
+import com.ort.app.api.village.request.VillageParticipateRequest
+import com.ort.app.application.coordinator.VillageCoordinator
+import com.ort.app.application.service.PlayerService
+import com.ort.app.application.service.VillageService
+import com.ort.app.domain.model.player.Player
+import com.ort.app.domain.model.skill.Skill
+import com.ort.app.domain.model.skill.toModel
+import com.ort.app.domain.model.village.Village
+import com.ort.app.fw.exception.WolfMansionAuthException
+import com.ort.app.fw.exception.WolfMansionBusinessException
+import com.ort.app.fw.exception.WolfMansionValidationException
+import com.ort.app.fw.exception.WolfMansionValidationException.FieldErrorItem
+import com.ort.app.fw.interceptor.getIpAddress
+import com.ort.app.fw.security.jwt.JwtPrincipal
+import com.ort.dbflute.allcommon.CDef
+import io.swagger.v3.oas.annotations.Operation
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.context.MessageSource
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.validation.BeanPropertyBindingResult
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+import org.springframework.web.server.ResponseStatusException
+import java.util.Locale
+
+/**
+ * 入村の REST。確認 (検証のみ) → 入村の 2 段フロー。入村可否 (人数・パスワード・キャラ重複など) は
+ * 既存 VillageCoordinator.assertParticipate (domain) が検証する。
+ */
+@RestController
+@RequestMapping("/api/v1/villages/{id}")
+class VillageParticipateRestController(
+    private val villageService: VillageService,
+    private val playerService: PlayerService,
+    private val villageCoordinator: VillageCoordinator,
+    private val villageParticipateFormValidator: VillageParticipateFormValidator,
+    private val messageSource: MessageSource,
+    private val httpServletRequest: HttpServletRequest,
+) {
+    /** 入村確認。検証だけ行い、通れば 204 (フロントは確認画面へ進む)。 */
+    @Operation(operationId = "confirmVillageParticipate")
+    @PostMapping("/participate-confirm")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun confirm(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+        @RequestBody @Validated request: VillageParticipateRequest,
+    ) {
+        val (village, player) = resolvePlayer(principal, id)
+        validate(request, null)
+        villageCoordinator.assertParticipate(
+            village,
+            player,
+            request.charaId,
+            request.charaName,
+            request.charaShortName,
+            null,
+            request.joinPassword,
+            request.spectator == true,
+        )
+    }
+
+    /**
+     * 入村する。multipart/form-data で JSON part (`request`) + オリジナル画像 part
+     * (`charaImage`、原画村のみ必須) を受ける。IP アドレスの記録は SSR と同じ。
+     */
+    @Operation(operationId = "participateVillage")
+    @PostMapping("/participate", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun participate(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+        @RequestPart @Validated request: VillageParticipateRequest,
+        @RequestPart(required = false) charaImage: MultipartFile?,
+    ) {
+        val (village, player) = resolvePlayer(principal, id)
+        validate(request, charaImage)
+        if (village.setting.chara.isOriginalCharachip && charaImage == null) {
+            throw WolfMansionBusinessException("キャラクター画像は必須です")
+        }
+        val first = request.requestedSkill?.let { code -> CDef.Skill.codeOf(code)?.toModel() } ?: Skill(CDef.Skill.おまかせ)
+        val second =
+            request.secondRequestedSkill?.let { code -> CDef.Skill.codeOf(code)?.toModel() }
+                ?: Skill(CDef.Skill.おまかせ)
+        villageCoordinator.participate(
+            village,
+            player,
+            request.charaId,
+            request.charaName!!,
+            request.charaShortName!!,
+            charaImage,
+            first,
+            second,
+            request.joinMessage!!,
+            request.joinPassword,
+            request.spectator == true,
+            httpServletRequest.getIpAddress(),
+        )
+    }
+
+    private fun resolvePlayer(
+        principal: JwtPrincipal?,
+        villageId: Int,
+    ): Pair<Village, Player> {
+        // principal は filter chain の authenticated() で保証済み (到達時は非 null)。防御的に確認する
+        principal ?: throw WolfMansionAuthException("ログインしてください")
+        val village =
+            villageService.findVillage(villageId)
+                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "village not found")
+        val player =
+            playerService.findPlayer(principal.name)
+                ?: throw WolfMansionAuthException("ログインしてください")
+        return village to player
+    }
+
+    private fun validate(
+        request: VillageParticipateRequest,
+        charaImage: MultipartFile?,
+    ) {
+        val form = request.toForm(charaImage)
+        val errors = BeanPropertyBindingResult(form, "participateForm")
+        villageParticipateFormValidator.validate(form, errors)
+        if (errors.hasErrors()) {
+            throw WolfMansionValidationException(
+                errors.fieldErrors.map {
+                    FieldErrorItem(it.field, messageSource.getMessage(it, Locale.JAPAN))
+                },
+            )
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/village/request/VillageParticipateRequest.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/request/VillageParticipateRequest.kt
@@ -1,0 +1,40 @@
+package com.ort.app.api.village.request
+
+import com.ort.app.api.request.VillageParticipateForm
+import jakarta.validation.constraints.NotNull
+import org.springframework.web.multipart.MultipartFile
+
+/**
+ * 入村の確認/実行。検証は SSR と共通の VillageParticipateFormValidator を [toForm] 変換後に流用する。
+ * オリジナル画像 (原画村) は multipart の別パートで受ける。
+ */
+data class VillageParticipateRequest(
+    /** 選択キャラ (キャラチップ制のみ) */
+    val charaId: Int? = null,
+    @field:NotNull
+    val charaName: String? = null,
+    @field:NotNull
+    val charaShortName: String? = null,
+    /** 第 1 希望役職コード (省略はおまかせ) */
+    val requestedSkill: String? = null,
+    /** 第 2 希望役職コード (省略はおまかせ) */
+    val secondRequestedSkill: String? = null,
+    @field:NotNull
+    val joinMessage: String? = null,
+    val joinPassword: String? = null,
+    /** 見学者として入村するか */
+    val spectator: Boolean? = null,
+) {
+    fun toForm(charaImageFile: MultipartFile? = null): VillageParticipateForm =
+        VillageParticipateForm(
+            charaId = charaId,
+            charaImageFile = charaImageFile,
+            charaName = charaName,
+            charaShortName = charaShortName,
+            requestedSkill = requestedSkill,
+            secondRequestedSkill = secondRequestedSkill,
+            joinMessage = joinMessage,
+            joinPassword = joinPassword,
+            spectator = spectator,
+        )
+}

--- a/backend/src/main/kotlin/com/ort/app/api/village/response/ParticipantSituationView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/response/ParticipantSituationView.kt
@@ -1,6 +1,8 @@
 package com.ort.app.api.village.response
 
+import com.ort.app.domain.model.chara.Chara
 import com.ort.app.domain.model.chara.CharaImage
+import com.ort.app.domain.model.chara.Charachip
 import com.ort.app.domain.model.situation.ParticipantSituation
 import com.ort.app.domain.model.situation.participant.ParticipantSayMessageTypeSituation
 import com.ort.app.domain.model.situation.participant.ParticipantSayRestrictSituation
@@ -32,7 +34,7 @@ data class ParticipantSituationView(
     constructor(situation: ParticipantSituation) : this(
         myself = situation.participate.myself?.let { MyselfView(it) },
         participate = ParticipateView(situation),
-        skillRequest = SkillRequestView(isAvailableSkillRequest = situation.skillRequest.isAvailableSkillRequest),
+        skillRequest = SkillRequestView(situation),
         commit =
             CommitView(
                 isAvailableCommit = situation.commit.isAvailableCommit,
@@ -86,6 +88,8 @@ data class ParticipantSituationView(
         val isAvailableSpectate: Boolean,
         val isAvailableSwitchParticipate: Boolean,
         val isAvailableLeave: Boolean,
+        /** 入村フォームで選択できるキャラセット (空きキャラのみ) */
+        val selectableCharachipList: List<ParticipateCharachipView>,
     ) {
         constructor(situation: ParticipantSituation) : this(
             isParticipating = situation.participate.isParticipating,
@@ -93,12 +97,80 @@ data class ParticipantSituationView(
             isAvailableSpectate = situation.participate.isAvailableSpectate,
             isAvailableSwitchParticipate = situation.participate.isAvailableSwitchParticipate,
             isAvailableLeave = situation.participate.isAvailableLeave,
+            selectableCharachipList =
+                situation.participate.selectableCharachipList.map { charachip ->
+                    ParticipateCharachipView(charachip, situation.participate.selectableCharaList)
+                },
+        )
+    }
+
+    @Schema(name = "ParticipantSituationViewParticipateCharachip")
+    data class ParticipateCharachipView(
+        val id: Int,
+        val name: String,
+        /** このキャラセットのうち選択できる (未使用の) キャラ */
+        val charas: List<ParticipateCharaView>,
+    ) {
+        constructor(charachip: Charachip, selectableCharas: List<Chara>) : this(
+            id = charachip.id,
+            name = charachip.name,
+            charas =
+                charachip.charas.list
+                    .filter { chara -> selectableCharas.any { it.id == chara.id } }
+                    .map { ParticipateCharaView(it) },
+        )
+    }
+
+    @Schema(name = "ParticipantSituationViewParticipateChara")
+    data class ParticipateCharaView(
+        val id: Int,
+        val name: String,
+        val shortName: String,
+        val imageUrl: String,
+        val imageWidth: Int,
+        val imageHeight: Int,
+    ) {
+        constructor(chara: Chara) : this(
+            id = chara.id,
+            name = chara.name,
+            shortName = chara.shortName,
+            imageUrl = chara.defaultImage().url,
+            imageWidth = chara.size.width,
+            imageHeight = chara.size.height,
         )
     }
 
     @Schema(name = "ParticipantSituationViewSkillRequest")
     data class SkillRequestView(
         val isAvailableSkillRequest: Boolean,
+        /** 希望できる役職 */
+        val selectableSkillList: List<SkillRequestSkillView>,
+        /** 現在の第 1 希望 (未参加は null) */
+        val requestedSkillCode: String?,
+        /** 現在の第 2 希望 (未参加は null) */
+        val secondRequestedSkillCode: String?,
+    ) {
+        constructor(situation: ParticipantSituation) : this(
+            isAvailableSkillRequest = situation.skillRequest.isAvailableSkillRequest,
+            selectableSkillList =
+                situation.skillRequest.selectableSkillList.map {
+                    SkillRequestSkillView(code = it.code, name = it.name)
+                },
+            requestedSkillCode =
+                situation.skillRequest.skillRequest
+                    ?.first
+                    ?.code,
+            secondRequestedSkillCode =
+                situation.skillRequest.skillRequest
+                    ?.second
+                    ?.code,
+        )
+    }
+
+    @Schema(name = "ParticipantSituationViewSkillRequestSkill")
+    data class SkillRequestSkillView(
+        val code: String,
+        val name: String,
     )
 
     @Schema(name = "ParticipantSituationViewCommit")

--- a/e2e/tests/village-participate.spec.ts
+++ b/e2e/tests/village-participate.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * 村画面の入村フォーム e2e。新規ユーザーで確認画面 (サーバ検証 204) まで進み、
+ * 実際の入村はしない (共有 DB を汚さない)。
+ */
+
+type SimpleVillage = { id: number; name: string };
+
+async function findVillages(page: Page, statuses: string[]): Promise<SimpleVillage[]> {
+  const query = statuses.map((s) => `status=${s}`).join("&");
+  const res = await page.request.get(`/wolf-mansion-api/api/v1/villages?${query}`);
+  expect(res.ok()).toBeTruthy();
+  const body = (await res.json()) as { villages: SimpleVillage[] };
+  return body.villages;
+}
+
+function uniqueUserId(): string {
+  const stamp = Date.now().toString(36).slice(-6);
+  const rand = Math.floor(Math.random() * 36 ** 2)
+    .toString(36)
+    .padStart(2, "0");
+  return `e${stamp}${rand}`;
+}
+
+test("入村: キャラ選択 → 確認画面 (同意チェックで活性化) まで", async ({ page }) => {
+  const villages = await findVillages(page, ["IN_PREPARATION"]);
+  test.skip(villages.length === 0, "募集中の村が無い DB のためスキップ");
+  const village = villages[villages.length - 1];
+
+  // 新規ユーザー (終了村参加なし = 村作成不可だが入村は可能)
+  await page.goto("signup");
+  await page.waitForLoadState("networkidle");
+  await page.fill("#userId", uniqueUserId());
+  await page.fill("#password", "test1234!");
+  await page.getByRole("button", { name: "作成" }).click();
+  await expect(page).toHaveURL(/\/wolf-mansion$/);
+
+  await page.goto(`village/${village.id}`);
+  await expect(page.getByText("入村", { exact: true })).toBeVisible({ timeout: 15000 });
+
+  // キャラ選択で名前・略称が自動補完される
+  const charaSelect = page.getByLabel("キャラクター", { exact: true });
+  await charaSelect.selectOption({ index: 1 });
+  await expect(page.getByLabel("キャラクター名")).not.toHaveValue("");
+  await expect(page.getByLabel("略称")).not.toHaveValue("");
+
+  await page.getByLabel("入村発言").fill("e2e の入村確認テストです。");
+  await page.getByRole("button", { name: "確認画面へ" }).click();
+
+  // サーバ検証 (assertParticipate) を通って確認画面へ
+  await expect(page.getByText("入村確認")).toBeVisible();
+  const submit = page.getByRole("button", { name: "入村する" });
+  await expect(submit).toBeDisabled();
+
+  // 2 つの同意チェックで活性化する (実際の入村はしない)
+  await page.getByText("ルールを確認し、同意します").click();
+  await page.getByText("他の参加者への礼節を守り、迷惑をかけないことに同意します").click();
+  await expect(submit).toBeEnabled();
+});

--- a/frontend/app/api/openapi.json
+++ b/frontend/app/api/openapi.json
@@ -974,6 +974,79 @@
         "tags": ["village-message-rest-controller"]
       }
     },
+    "/api/v1/villages/{id}/participate": {
+      "post": {
+        "operationId": "participateVillage",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "charaImage": {
+                    "type": "string",
+                    "format": "binary"
+                  },
+                  "request": {
+                    "$ref": "#/components/schemas/VillageParticipateRequest"
+                  }
+                },
+                "required": ["request"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": ["village-participate-rest-controller"]
+      }
+    },
+    "/api/v1/villages/{id}/participate-confirm": {
+      "post": {
+        "operationId": "confirmVillageParticipate",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VillageParticipateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": ["village-participate-rest-controller"]
+      }
+    },
     "/api/v1/villages/{id}/say": {
       "post": {
         "operationId": "sayVillage",
@@ -1706,6 +1779,12 @@
           },
           "isParticipating": {
             "type": "boolean"
+          },
+          "selectableCharachipList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParticipantSituationViewParticipateCharachip"
+            }
           }
         },
         "required": [
@@ -1713,8 +1792,55 @@
           "isAvailableParticipate",
           "isAvailableSpectate",
           "isAvailableSwitchParticipate",
-          "isParticipating"
+          "isParticipating",
+          "selectableCharachipList"
         ]
+      },
+      "ParticipantSituationViewParticipateChara": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "imageHeight": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "imageUrl": {
+            "type": "string"
+          },
+          "imageWidth": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string"
+          },
+          "shortName": {
+            "type": "string"
+          }
+        },
+        "required": ["id", "imageHeight", "imageUrl", "imageWidth", "name", "shortName"]
+      },
+      "ParticipantSituationViewParticipateCharachip": {
+        "type": "object",
+        "properties": {
+          "charas": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParticipantSituationViewParticipateChara"
+            }
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["charas", "id", "name"]
       },
       "ParticipantSituationViewRp": {
         "type": "object",
@@ -1831,9 +1957,33 @@
         "properties": {
           "isAvailableSkillRequest": {
             "type": "boolean"
+          },
+          "requestedSkillCode": {
+            "type": ["string", "null"]
+          },
+          "secondRequestedSkillCode": {
+            "type": ["string", "null"]
+          },
+          "selectableSkillList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParticipantSituationViewSkillRequestSkill"
+            }
           }
         },
-        "required": ["isAvailableSkillRequest"]
+        "required": ["isAvailableSkillRequest", "selectableSkillList"]
+      },
+      "ParticipantSituationViewSkillRequestSkill": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["code", "name"]
       },
       "ParticipantSituationViewVote": {
         "type": "object",
@@ -3146,6 +3296,37 @@
           }
         },
         "required": ["list"]
+      },
+      "VillageParticipateRequest": {
+        "type": "object",
+        "properties": {
+          "charaId": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          },
+          "charaName": {
+            "type": ["string", "null"]
+          },
+          "charaShortName": {
+            "type": ["string", "null"]
+          },
+          "joinMessage": {
+            "type": ["string", "null"]
+          },
+          "joinPassword": {
+            "type": ["string", "null"]
+          },
+          "requestedSkill": {
+            "type": ["string", "null"]
+          },
+          "secondRequestedSkill": {
+            "type": ["string", "null"]
+          },
+          "spectator": {
+            "type": ["boolean", "null"]
+          }
+        },
+        "required": ["charaName", "charaShortName", "joinMessage"]
       },
       "VillageRandomOrganize": {
         "type": "object",

--- a/frontend/app/api/types.ts
+++ b/frontend/app/api/types.ts
@@ -371,6 +371,38 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/villages/{id}/participate": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["participateVillage"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/villages/{id}/participate-confirm": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["confirmVillageParticipate"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/villages/{id}/say": {
     parameters: {
       query?: never;
@@ -639,6 +671,24 @@ export interface components {
       isAvailableSpectate: boolean;
       isAvailableSwitchParticipate: boolean;
       isParticipating: boolean;
+      selectableCharachipList: components["schemas"]["ParticipantSituationViewParticipateCharachip"][];
+    };
+    ParticipantSituationViewParticipateChara: {
+      /** Format: int32 */
+      id: number;
+      /** Format: int32 */
+      imageHeight: number;
+      imageUrl: string;
+      /** Format: int32 */
+      imageWidth: number;
+      name: string;
+      shortName: string;
+    };
+    ParticipantSituationViewParticipateCharachip: {
+      charas: components["schemas"]["ParticipantSituationViewParticipateChara"][];
+      /** Format: int32 */
+      id: number;
+      name: string;
     };
     ParticipantSituationViewRp: {
       canAddImage: boolean;
@@ -679,6 +729,13 @@ export interface components {
     };
     ParticipantSituationViewSkillRequest: {
       isAvailableSkillRequest: boolean;
+      requestedSkillCode?: string | null;
+      secondRequestedSkillCode?: string | null;
+      selectableSkillList: components["schemas"]["ParticipantSituationViewSkillRequestSkill"][];
+    };
+    ParticipantSituationViewSkillRequestSkill: {
+      code: string;
+      name: string;
     };
     ParticipantSituationViewVote: {
       canVote: boolean;
@@ -1062,6 +1119,17 @@ export interface components {
     };
     VillageParticipantsContent: {
       list: components["schemas"]["VillageParticipantContent"][];
+    };
+    VillageParticipateRequest: {
+      /** Format: int32 */
+      charaId?: number | null;
+      charaName: string | null;
+      charaShortName: string | null;
+      joinMessage: string | null;
+      joinPassword?: string | null;
+      requestedSkill?: string | null;
+      secondRequestedSkill?: string | null;
+      spectator?: boolean | null;
     };
     VillageRandomOrganize: {
       campAllocation: components["schemas"]["CampAllocation"][];
@@ -1830,6 +1898,58 @@ export interface operations {
         content: {
           "*/*": components["schemas"]["VillageParticipantsContent"];
         };
+      };
+    };
+  };
+  participateVillage: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "multipart/form-data": {
+          /** Format: binary */
+          charaImage?: string;
+          request: components["schemas"]["VillageParticipateRequest"];
+        };
+      };
+    };
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  confirmVillageParticipate: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["VillageParticipateRequest"];
+      };
+    };
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
     };
   };

--- a/frontend/app/features/village/api.ts
+++ b/frontend/app/features/village/api.ts
@@ -175,3 +175,35 @@ export function confirmVillageAction(
 export function actionVillage(id: number, request: VillageActionRequest): Promise<void> {
   return apiFetch<void>(`/api/v1/villages/${id}/action`, { method: "POST", body: request });
 }
+
+/** 入村のリクエスト (JSON part)。 */
+export type VillageParticipateRequest = components["schemas"]["VillageParticipateRequest"];
+
+/** 入村確認 (サーバ検証のみ)。通れば 204。要認証。 */
+export function confirmVillageParticipate(
+  id: number,
+  request: VillageParticipateRequest,
+): Promise<void> {
+  return apiFetch<void>(`/api/v1/villages/${id}/participate-confirm`, {
+    method: "POST",
+    body: request,
+  });
+}
+
+/**
+ * 入村する。multipart/form-data で JSON part (`request`) + オリジナル画像 (`charaImage`、
+ * 原画村のみ必須) を送る。要認証 → 204。
+ */
+export function participateVillage(
+  id: number,
+  request: VillageParticipateRequest,
+  charaImage: File | null,
+): Promise<void> {
+  const formData = new FormData();
+  formData.append("request", new Blob([JSON.stringify(request)], { type: "application/json" }));
+  if (charaImage != null) formData.append("charaImage", charaImage);
+  return apiFetch<void>(`/api/v1/villages/${id}/participate`, {
+    method: "POST",
+    body: formData,
+  });
+}

--- a/frontend/app/routes/village/ParticipatePanel.tsx
+++ b/frontend/app/routes/village/ParticipatePanel.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useState } from "react";
 
 import { Button } from "~/components/ui/Button";
-import { selectClass } from "~/components/ui/Input";
+import { inlineInputClass, inputClass, selectClass, textareaClass } from "~/components/ui/Input";
 import {
   confirmVillageParticipate,
   type ParticipantSituationView,
@@ -240,7 +240,7 @@ export function ParticipatePanel({
             キャラクター名 (1〜40 字)
             <input
               type="text"
-              className="mt-[5px] h-[30px] w-full rounded border border-[#464545] bg-white p-[6px] text-[#555]"
+              className={`${inputClass} mt-[5px]`}
               value={charaName}
               onChange={(e) => setCharaName(e.target.value)}
               aria-label="キャラクター名"
@@ -250,7 +250,7 @@ export function ParticipatePanel({
             略称 (1 字)
             <input
               type="text"
-              className="mt-[5px] h-[30px] w-full rounded border border-[#464545] bg-white p-[6px] text-[#555]"
+              className={`${inlineInputClass} mt-[5px] w-full`}
               value={charaShortName}
               onChange={(e) => setCharaShortName(e.target.value)}
               aria-label="略称"
@@ -294,7 +294,7 @@ export function ParticipatePanel({
         <label className="block">
           入村発言 (1〜400 字)
           <textarea
-            className="mt-[5px] min-h-[100px] w-full rounded border border-[#464545] bg-white p-[9px] text-[#555]"
+            className={`${textareaClass} mt-[5px] min-h-[100px]`}
             value={joinMessage}
             onChange={(e) => setJoinMessage(e.target.value)}
             aria-label="入村発言"
@@ -307,7 +307,7 @@ export function ParticipatePanel({
           入村パスワード (設定されている村のみ)
           <input
             type="text"
-            className="mt-[5px] h-[30px] w-full rounded border border-[#464545] bg-white p-[6px] text-[#555]"
+            className={`${inputClass} mt-[5px]`}
             value={joinPassword}
             onChange={(e) => setJoinPassword(e.target.value)}
             aria-label="入村パスワード"

--- a/frontend/app/routes/village/ParticipatePanel.tsx
+++ b/frontend/app/routes/village/ParticipatePanel.tsx
@@ -1,0 +1,330 @@
+import { useMemo, useRef, useState } from "react";
+
+import { Button } from "~/components/ui/Button";
+import { selectClass } from "~/components/ui/Input";
+import {
+  confirmVillageParticipate,
+  type ParticipantSituationView,
+  type VillageDetailView,
+  type VillageParticipateRequest,
+} from "~/features/village/api";
+import { ApiError } from "~/lib/api";
+import { toMessageHtml } from "./messageHtml";
+
+const OMAKASE = "LEFTOVER";
+
+type Step = "input" | "confirm";
+
+/**
+ * 入村フォーム。キャラ選択 → 名前/略称 (キャラから自動補完) → 希望役職 → 入村発言 →
+ * 確認 (ルール/礼節の 2 つの同意チェックで「入村する」が活性化) → 入村。
+ */
+export function ParticipatePanel({
+  village,
+  mySituation,
+  onParticipated,
+  onError,
+}: {
+  village: VillageDetailView;
+  mySituation: ParticipantSituationView;
+  onParticipated: (request: VillageParticipateRequest, charaImage: File | null) => Promise<void>;
+  /** 確認 (サーバ検証) のエラーメッセージ表示用 */
+  onError: (message: string | null) => void;
+}) {
+  const participate = mySituation.participate;
+  const skillRequest = mySituation.skillRequest;
+  const isOriginal = village.setting.chara.isOriginalCharachip;
+  const charachips = participate.selectableCharachipList ?? [];
+
+  const [step, setStep] = useState<Step>("input");
+  const [charachipId, setCharachipId] = useState<number | null>(charachips[0]?.id ?? null);
+  const [charaId, setCharaId] = useState<number | null>(null);
+  const [charaName, setCharaName] = useState("");
+  const [charaShortName, setCharaShortName] = useState("");
+  const [requestedSkill, setRequestedSkill] = useState(OMAKASE);
+  const [secondRequestedSkill, setSecondRequestedSkill] = useState(OMAKASE);
+  const [joinMessage, setJoinMessage] = useState("");
+  const [joinPassword, setJoinPassword] = useState("");
+  const [spectator, setSpectator] = useState(false);
+  const [agreeRule, setAgreeRule] = useState(false);
+  const [agreeMind, setAgreeMind] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const currentChip = charachips.find((c) => c.id === charachipId) ?? charachips[0];
+  const charas = currentChip?.charas ?? [];
+  const chara = charas.find((c) => c.id === charaId) ?? null;
+
+  const selectChara = (id: number | null) => {
+    setCharaId(id);
+    const selected = charas.find((c) => c.id === id);
+    if (selected != null) {
+      setCharaName(selected.name);
+      setCharaShortName(selected.shortName);
+    }
+  };
+
+  const length = joinMessage.length;
+  const lineCount = joinMessage.split("\n").length;
+  const overLimit = length > 400 || lineCount > 20;
+  const confirmDisabled =
+    overLimit ||
+    joinMessage.trim().length === 0 ||
+    charaName.trim().length === 0 ||
+    charaShortName.trim().length !== 1 ||
+    (!isOriginal && charaId == null);
+
+  const request: VillageParticipateRequest = {
+    charaId,
+    charaName,
+    charaShortName,
+    requestedSkill,
+    secondRequestedSkill,
+    joinMessage,
+    joinPassword: joinPassword === "" ? null : joinPassword,
+    spectator,
+  };
+
+  const previewHtml = useMemo(() => toMessageHtml(joinMessage, false, []), [joinMessage]);
+
+  const toConfirm = async () => {
+    onError(null);
+    try {
+      await confirmVillageParticipate(village.id, request);
+      setAgreeRule(false);
+      setAgreeMind(false);
+      setStep("confirm");
+    } catch (e) {
+      onError(e instanceof ApiError ? e.detail : "入村の確認に失敗しました");
+    }
+  };
+
+  const submit = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    onError(null);
+    try {
+      await onParticipated(request, fileRef.current?.files?.[0] ?? null);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (step === "confirm") {
+    return (
+      <div className="mb-[20px] rounded border border-[#464545] bg-[#303030]">
+        <div className="rounded-t bg-[#464545] px-[15px] py-[10px]">
+          <span className="text-[15px] text-white">入村確認</span>
+        </div>
+        <div className="p-[15px]">
+          <p className="mb-[10px]">以下の内容で入村してよろしいですか？</p>
+          <div className="flex">
+            <div>
+              {chara != null && (
+                <img
+                  src={chara.imageUrl}
+                  width={chara.imageWidth}
+                  height={chara.imageHeight}
+                  alt={charaName}
+                />
+              )}
+            </div>
+            <div
+              className="message message-normal ml-[5px] flex-1 rounded-[5px] border bg-white p-[9px] break-words text-[#555]"
+              dangerouslySetInnerHTML={{ __html: previewHtml }}
+            />
+          </div>
+          <div className="mt-[10px] text-[12px]">
+            <p>
+              キャラクター: {charaName} ({charaShortName}){spectator && " / 見学者として入村"}
+            </p>
+          </div>
+          {isOriginal && (
+            <div className="mt-[10px]">
+              <label className="block text-[12px]">
+                キャラクター画像 (必須、100KB まで)
+                <input ref={fileRef} type="file" accept="image/*" className="mt-[5px] block" />
+              </label>
+            </div>
+          )}
+          <div className="mt-[15px] space-y-[5px] text-[12px]">
+            <label className="flex cursor-pointer items-center gap-[5px]">
+              <input
+                type="checkbox"
+                checked={agreeRule}
+                onChange={() => setAgreeRule(!agreeRule)}
+              />
+              ルールを確認し、同意します
+            </label>
+            <label className="flex cursor-pointer items-center gap-[5px]">
+              <input
+                type="checkbox"
+                checked={agreeMind}
+                onChange={() => setAgreeMind(!agreeMind)}
+              />
+              他の参加者への礼節を守り、迷惑をかけないことに同意します
+            </label>
+          </div>
+          <div className="mt-[15px] flex justify-end gap-[10px]">
+            <Button variant="default" onClick={() => setStep("input")}>
+              戻る
+            </Button>
+            <Button onClick={submit} disabled={!agreeRule || !agreeMind || submitting}>
+              入村する
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-[20px] rounded border border-[#464545] bg-[#303030]">
+      <div className="rounded-t bg-[#464545] px-[15px] py-[10px]">
+        <span className="text-[15px] text-white">入村</span>
+      </div>
+      <div className="space-y-[10px] p-[15px] text-[12px]">
+        {!isOriginal && (
+          <>
+            {charachips.length > 1 && (
+              <div>
+                <label className="mb-[5px] block">キャラセット</label>
+                <select
+                  className={selectClass}
+                  value={charachipId ?? ""}
+                  onChange={(e) => {
+                    setCharachipId(Number(e.target.value));
+                    setCharaId(null);
+                  }}
+                  aria-label="キャラセット"
+                >
+                  {charachips.map((chip) => (
+                    <option key={chip.id} value={chip.id}>
+                      {chip.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+            <div>
+              <label className="mb-[5px] block">キャラクター</label>
+              <select
+                className={selectClass}
+                value={charaId ?? ""}
+                onChange={(e) => selectChara(e.target.value === "" ? null : Number(e.target.value))}
+                aria-label="キャラクター"
+              >
+                <option value="">選択してください</option>
+                {charas.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            {chara != null && (
+              <img
+                src={chara.imageUrl}
+                width={chara.imageWidth}
+                height={chara.imageHeight}
+                alt={chara.name}
+              />
+            )}
+          </>
+        )}
+        {isOriginal && (
+          <p>この村はオリジナルキャラクター制です。キャラクター画像は確認画面で選択します。</p>
+        )}
+        <div className="flex gap-[10px]">
+          <label className="flex-1">
+            キャラクター名 (1〜40 字)
+            <input
+              type="text"
+              className="mt-[5px] h-[30px] w-full rounded border border-[#464545] bg-white p-[6px] text-[#555]"
+              value={charaName}
+              onChange={(e) => setCharaName(e.target.value)}
+              aria-label="キャラクター名"
+            />
+          </label>
+          <label className="w-[120px]">
+            略称 (1 字)
+            <input
+              type="text"
+              className="mt-[5px] h-[30px] w-full rounded border border-[#464545] bg-white p-[6px] text-[#555]"
+              value={charaShortName}
+              onChange={(e) => setCharaShortName(e.target.value)}
+              aria-label="略称"
+            />
+          </label>
+        </div>
+        {skillRequest.isAvailableSkillRequest && (
+          <div className="flex gap-[10px]">
+            <label className="flex-1">
+              第 1 希望役職
+              <select
+                className={`${selectClass} mt-[5px]`}
+                value={requestedSkill}
+                onChange={(e) => setRequestedSkill(e.target.value)}
+                aria-label="第1希望役職"
+              >
+                {(skillRequest.selectableSkillList ?? []).map((skill) => (
+                  <option key={skill.code} value={skill.code}>
+                    {skill.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex-1">
+              第 2 希望役職
+              <select
+                className={`${selectClass} mt-[5px]`}
+                value={secondRequestedSkill}
+                onChange={(e) => setSecondRequestedSkill(e.target.value)}
+                aria-label="第2希望役職"
+              >
+                {(skillRequest.selectableSkillList ?? []).map((skill) => (
+                  <option key={skill.code} value={skill.code}>
+                    {skill.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        )}
+        <label className="block">
+          入村発言 (1〜400 字)
+          <textarea
+            className="mt-[5px] min-h-[100px] w-full rounded border border-[#464545] bg-white p-[9px] text-[#555]"
+            value={joinMessage}
+            onChange={(e) => setJoinMessage(e.target.value)}
+            aria-label="入村発言"
+          />
+        </label>
+        <div className={overLimit ? "text-[#e74c3c]" : ""}>
+          文字数: {length}/400, 行数: {lineCount}/20
+        </div>
+        <label className="block">
+          入村パスワード (設定されている村のみ)
+          <input
+            type="text"
+            className="mt-[5px] h-[30px] w-full rounded border border-[#464545] bg-white p-[6px] text-[#555]"
+            value={joinPassword}
+            onChange={(e) => setJoinPassword(e.target.value)}
+            aria-label="入村パスワード"
+          />
+        </label>
+        {participate.isAvailableSpectate && (
+          <label className="flex cursor-pointer items-center gap-[5px]">
+            <input type="checkbox" checked={spectator} onChange={() => setSpectator(!spectator)} />
+            見学者として入村
+          </label>
+        )}
+        <div className="flex justify-end">
+          <Button onClick={toConfirm} disabled={confirmDisabled}>
+            確認画面へ
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -9,11 +9,13 @@ import {
   actionVillage,
   confirmVillageAction,
   confirmVillageSay,
+  participateVillage,
   sayVillage,
   type VillageActionRequest,
   type VillageDetailView,
   type VillageMessageContent,
   type VillageMessageListContent,
+  type VillageParticipateRequest,
   type VillageSayRequest,
 } from "~/features/village/api";
 import {
@@ -39,6 +41,7 @@ import { DayList } from "./DayList";
 import { FilterModal } from "./FilterModal";
 import { FooterMenu } from "./FooterMenu";
 import { MessageArea } from "./MessageArea";
+import { ParticipatePanel } from "./ParticipatePanel";
 import { type ReplyDraft } from "./MessageCard";
 import { MessageCard } from "./MessageCard";
 import { SayPanel } from "./SayPanel";
@@ -217,6 +220,17 @@ export default function Village({ params }: Route.ComponentProps) {
     setSayPreview(null);
     document.getElementById("say-panel")?.scrollIntoView();
   };
+  const [participateError, setParticipateError] = useState<string | null>(null);
+  const onParticipated = async (request: VillageParticipateRequest, charaImage: File | null) => {
+    try {
+      await participateVillage(villageId, request, charaImage);
+      await invalidate();
+      requestAnimationFrame(() => document.getElementById("bottom")?.scrollIntoView());
+    } catch (e) {
+      setParticipateError(e instanceof ApiError ? e.detail : "入村に失敗しました");
+      throw e;
+    }
+  };
 
   const latestDay = village != null ? latestDayOf(village) : undefined;
   const currentDay = dayParam ?? latestDay ?? 0;
@@ -360,6 +374,23 @@ export default function Village({ params }: Route.ComponentProps) {
             onConfirm={onActionConfirm}
           />
         )}
+
+        {mySituation != null &&
+          !mySituation.participate.isParticipating &&
+          (mySituation.participate.isAvailableParticipate ||
+            mySituation.participate.isAvailableSpectate) && (
+            <div>
+              {participateError != null && (
+                <p className="mb-[5px] text-[#e74c3c]">{participateError}</p>
+              )}
+              <ParticipatePanel
+                village={village}
+                mySituation={mySituation}
+                onParticipated={onParticipated}
+                onError={setParticipateError}
+              />
+            </div>
+          )}
 
         <DayList
           villageId={villageId}


### PR DESCRIPTION
closes .issues/step-8.6-village-participate.md

## 概要

入村フローの REST + React 化 (step-8.6)。base は `feature/monorepo-step8`。見学切替/希望変更/退村は後続サブ step。

## backend

- **situation/me 拡張** (additive): `participate.selectableCharachipList` (キャラセットごとの**空きキャラのみ**: id/name/shortName/画像) / `skillRequest.selectableSkillList` (+ 現在の第1/第2希望コード)
- **`POST /api/v1/villages/{id}/participate-confirm`** (要認証、JSON): `VillageParticipateFormValidator` (SSR 共通) + `VillageCoordinator.assertParticipate` の検証のみ → 204
- **`POST /api/v1/villages/{id}/participate`** (要認証、multipart): JSON part + `charaImage` (原画村のみ必須、サイズ 0/100KB 検証は validator 共通)。`VillageCoordinator.participate` 流用、**IP 記録維持**。希望役職の既定はおまかせ (LEFTOVER)

## frontend

- **`ParticipatePanel`** (input → confirm の 2 段): キャラセット/キャラ select (選択で名前・略称を自動補完) + 画像プレビュー → 希望役職 第1/第2 (希望可の村のみ) → 入村発言 (1〜400 字/20 行、超過は確認無効) → パスワード → 見学チェック (可の村のみ)
- **確認画面**: キャラ画像 + 入村発言プレビュー (toMessageHtml のエスケープ済み出力) + 原画村のファイル入力 + **ルール/礼節の 2 つの同意チェックで「入村する」活性化** + 連打ガード。入村後は村系クエリ無効化
- 入村パスワード入力は常時表示 (村設定の `joinPassword` はマスク済みで有無を露出しないため。legacy は SSR が有無を知っていた点との意図的差異)

## 検証

- REST 一連を実測: 新規ユーザーで村 2 に confirm 204 → participate 204 → 生存一覧に反映 (**ユーザー `e2ejoin01` を村 2 に参加させたまま残置** — 退村実装後に外せます)
- e2e 1 件追加: 新規 signup → キャラ選択 (自動補完) → 確認画面 (サーバ検証 204) → 同意チェックで活性化まで (**実入村はせず DB 非汚染**)
- backend ktlintCheck/test green。frontend typecheck/lint/format/build green。gen:api 差分込み

🤖 Generated with [Claude Code](https://claude.com/claude-code)