### PR TITLE
feat: 参加見学切替・希望役職変更・退村を REST + React 化 (step-8.7/8.8)

### DIFF
--- a/.issues/README.md
+++ b/.issues/README.md
@@ -24,7 +24,7 @@ monorepo 移行作業中につき **階層番号方式** (`step-<N>(.M)-<slug>.m
 
 | # | タイトル | type | status |
 | --- | --- | --- | --- |
-| (現在 open な Issue なし) | | | |
+| step-8.7-8.8 | 村画面 参加見学切替・希望役職変更・退村 | enhancement | open |
 
 > **Step 8 は統合ブランチ方式 (ユーザー指示 2026-06-12)**: `feature/monorepo-step8` を base にサブ step PR を積み、同ブランチへの squash merge は Claude 単独で可。`feature/monorepo` への merge は最終 PR でユーザー承認。8.1 ✅ #71 / 8.2 ✅ #72 / 8.3 ✅ #73 / 8.4 ✅ #74 / 8.5 ✅ #75 / 8.6 ✅ #76。
 

--- a/backend/src/main/kotlin/com/ort/app/api/village/VillageParticipateRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/VillageParticipateRestController.kt
@@ -1,6 +1,7 @@
 package com.ort.app.api.village
 
 import com.ort.app.api.request.validator.VillageParticipateFormValidator
+import com.ort.app.api.village.request.VillageChangeSkillRequest
 import com.ort.app.api.village.request.VillageParticipateRequest
 import com.ort.app.application.coordinator.VillageCoordinator
 import com.ort.app.application.service.PlayerService
@@ -9,6 +10,7 @@ import com.ort.app.domain.model.player.Player
 import com.ort.app.domain.model.skill.Skill
 import com.ort.app.domain.model.skill.toModel
 import com.ort.app.domain.model.village.Village
+import com.ort.app.domain.model.village.participant.VillageParticipant
 import com.ort.app.fw.exception.WolfMansionAuthException
 import com.ort.app.fw.exception.WolfMansionBusinessException
 import com.ort.app.fw.exception.WolfMansionValidationException
@@ -108,6 +110,63 @@ class VillageParticipateRestController(
             request.spectator == true,
             httpServletRequest.getIpAddress(),
         )
+    }
+
+    /** 参加 ⇄ 見学の切替。可否は domain (switchParticipate) が検証する。 */
+    @Operation(operationId = "switchVillageParticipate")
+    @PostMapping("/switch-participate")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun switchParticipate(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+    ) {
+        val (village, myself) = resolveParticipant(principal, id)
+        villageCoordinator.switchParticipate(village, myself)
+    }
+
+    /** 希望役職 (第 1/第 2) の変更。 */
+    @Operation(operationId = "changeVillageRequestSkill")
+    @PostMapping("/change-skill")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun changeSkill(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+        @RequestBody @Validated request: VillageChangeSkillRequest,
+    ) {
+        val (village, myself) = resolveParticipant(principal, id)
+        val first =
+            CDef.Skill.codeOf(request.requestedSkill!!)?.toModel()
+                ?: throw WolfMansionBusinessException("skill not found.")
+        val second =
+            CDef.Skill.codeOf(request.secondRequestedSkill!!)?.toModel()
+                ?: throw WolfMansionBusinessException("skill not found.")
+        villageCoordinator.changeRequestSkill(village, myself, first, second)
+    }
+
+    /** 退村。可否は domain (leave) が検証する。 */
+    @Operation(operationId = "leaveVillage")
+    @PostMapping("/leave")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun leave(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+    ) {
+        val (village, myself) = resolveParticipant(principal, id)
+        villageCoordinator.leave(village, myself)
+    }
+
+    private fun resolveParticipant(
+        principal: JwtPrincipal?,
+        villageId: Int,
+    ): Pair<Village, VillageParticipant> {
+        principal ?: throw WolfMansionAuthException("ログインしてください")
+        val village =
+            villageService.findVillage(villageId)
+                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "village not found")
+        val myself =
+            villageService.findVillageParticipant(village.id, principal.name)
+                ?: throw WolfMansionBusinessException("村に参加していません")
+        return village to myself
     }
 
     private fun resolvePlayer(

--- a/backend/src/main/kotlin/com/ort/app/api/village/request/VillageChangeSkillRequest.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/request/VillageChangeSkillRequest.kt
@@ -1,0 +1,11 @@
+package com.ort.app.api.village.request
+
+import jakarta.validation.constraints.NotNull
+
+/** 希望役職 (第 1/第 2) の変更。 */
+data class VillageChangeSkillRequest(
+    @field:NotNull
+    val requestedSkill: String? = null,
+    @field:NotNull
+    val secondRequestedSkill: String? = null,
+)

--- a/e2e/tests/village-participate.spec.ts
+++ b/e2e/tests/village-participate.spec.ts
@@ -58,3 +58,45 @@ test("入村: キャラ選択 → 確認画面 (同意チェックで活性化) 
   await page.getByText("他の参加者への礼節を守り、迷惑をかけないことに同意します").click();
   await expect(submit).toBeEnabled();
 });
+
+test("入村 → 役職希望変更 → 退村の自己完結フロー", async ({ page }) => {
+  const villages = await findVillages(page, ["IN_PREPARATION"]);
+  test.skip(villages.length === 0, "募集中の村が無い DB のためスキップ");
+  const village = villages[villages.length - 1];
+
+  await page.goto("signup");
+  await page.waitForLoadState("networkidle");
+  await page.fill("#userId", uniqueUserId());
+  await page.fill("#password", "test1234!");
+  await page.getByRole("button", { name: "作成" }).click();
+  await expect(page).toHaveURL(/\/wolf-mansion$/);
+
+  await page.goto(`village/${village.id}`);
+  await expect(page.getByText("入村", { exact: true })).toBeVisible({ timeout: 15000 });
+
+  await page.getByLabel("キャラクター", { exact: true }).selectOption({ index: 1 });
+  await page.getByLabel("入村発言").fill("e2e の入村テストです。後で退村します。");
+  await page.getByRole("button", { name: "確認画面へ" }).click();
+  await page.getByText("ルールを確認し、同意します").click();
+  await page.getByText("他の参加者への礼節を守り、迷惑をかけないことに同意します").click();
+  await page.getByRole("button", { name: "入村する" }).click();
+
+  // 入村後は退村パネルが出る (= 参加状態になった)
+  await expect(page.getByRole("button", { name: "村を出る" })).toBeVisible({ timeout: 15000 });
+
+  // 役職希望を変更できる (希望可の村のみ)
+  const firstSkill = page.getByLabel("第一役職希望");
+  if ((await firstSkill.count()) > 0) {
+    await firstSkill.selectOption({ index: 1 });
+    await page.getByRole("button", { name: "役職希望を変更する" }).click();
+    await expect(page.getByText(/現在の役職希望: /)).toBeVisible();
+  }
+
+  // 退村して後片付け (confirm ダイアログを受諾)
+  page.on("dialog", (dialog) => dialog.accept());
+  await page.getByRole("button", { name: "村を出る" }).click();
+  await expect(page.getByRole("button", { name: "村を出る" })).toHaveCount(0, {
+    timeout: 15000,
+  });
+  await expect(page.getByText("入村", { exact: true })).toBeVisible();
+});

--- a/frontend/app/api/openapi.json
+++ b/frontend/app/api/openapi.json
@@ -664,6 +664,60 @@
         "tags": ["village-say-rest-controller"]
       }
     },
+    "/api/v1/villages/{id}/change-skill": {
+      "post": {
+        "operationId": "changeVillageRequestSkill",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VillageChangeSkillRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": ["village-participate-rest-controller"]
+      }
+    },
+    "/api/v1/villages/{id}/leave": {
+      "post": {
+        "operationId": "leaveVillage",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": ["village-participate-rest-controller"]
+      }
+    },
     "/api/v1/villages/{id}/messages": {
       "get": {
         "operationId": "getVillageMessages",
@@ -1221,6 +1275,28 @@
           }
         },
         "tags": ["village-rest-controller"]
+      }
+    },
+    "/api/v1/villages/{id}/switch-participate": {
+      "post": {
+        "operationId": "switchVillageParticipate",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": ["village-participate-rest-controller"]
       }
     },
     "/api/v1/villages/{id}/update": {
@@ -2581,6 +2657,18 @@
           }
         },
         "required": ["messageList"]
+      },
+      "VillageChangeSkillRequest": {
+        "type": "object",
+        "properties": {
+          "requestedSkill": {
+            "type": ["string", "null"]
+          },
+          "secondRequestedSkill": {
+            "type": ["string", "null"]
+          }
+        },
+        "required": ["requestedSkill", "secondRequestedSkill"]
       },
       "VillageCharaSetting": {
         "type": "object",

--- a/frontend/app/api/types.ts
+++ b/frontend/app/api/types.ts
@@ -291,6 +291,38 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/villages/{id}/change-skill": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["changeVillageRequestSkill"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/villages/{id}/leave": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["leaveVillage"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/villages/{id}/messages": {
     parameters: {
       query?: never;
@@ -477,6 +509,22 @@ export interface paths {
     get: operations["getMyVillageSituation"];
     put?: never;
     post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/villages/{id}/switch-participate": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["switchVillageParticipate"];
     delete?: never;
     options?: never;
     head?: never;
@@ -910,6 +958,10 @@ export interface components {
     };
     VillageAnchorMessagesContent: {
       messageList: components["schemas"]["VillageMessageContent"][];
+    };
+    VillageChangeSkillRequest: {
+      requestedSkill: string | null;
+      secondRequestedSkill: string | null;
     };
     VillageCharaSetting: {
       charachipIds: number[];
@@ -1770,6 +1822,50 @@ export interface operations {
       };
     };
   };
+  changeVillageRequestSkill: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["VillageChangeSkillRequest"];
+      };
+    };
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  leaveVillage: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
   getVillageMessages: {
     parameters: {
       query?: {
@@ -2070,6 +2166,26 @@ export interface operations {
         content: {
           "*/*": components["schemas"]["ParticipantSituationView"];
         };
+      };
+    };
+  };
+  switchVillageParticipate: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
     };
   };

--- a/frontend/app/components/ui/Panel.tsx
+++ b/frontend/app/components/ui/Panel.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react";
+
+/**
+ * タイトルバー付きのパネル (村画面のフォーム群など)。開閉が要る場合は
+ * `CollapsiblePanel` を使う。
+ */
+export function Panel({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className="mb-[20px] rounded border border-[#464545] bg-[#303030]">
+      <div className="rounded-t bg-[#464545] px-[15px] py-[10px]">
+        <span className="text-[15px] text-white">{title}</span>
+      </div>
+      <div className="p-[15px]">{children}</div>
+    </div>
+  );
+}

--- a/frontend/app/features/village/api.ts
+++ b/frontend/app/features/village/api.ts
@@ -207,3 +207,24 @@ export function participateVillage(
     body: formData,
   });
 }
+
+/** 希望役職変更のリクエスト。 */
+export type VillageChangeSkillRequest = components["schemas"]["VillageChangeSkillRequest"];
+
+/** 参加 ⇄ 見学を切り替える。要認証 → 204。 */
+export function switchVillageParticipate(id: number): Promise<void> {
+  return apiFetch<void>(`/api/v1/villages/${id}/switch-participate`, { method: "POST" });
+}
+
+/** 希望役職 (第 1/第 2) を変更する。要認証 → 204。 */
+export function changeVillageRequestSkill(
+  id: number,
+  request: VillageChangeSkillRequest,
+): Promise<void> {
+  return apiFetch<void>(`/api/v1/villages/${id}/change-skill`, { method: "POST", body: request });
+}
+
+/** 退村する。要認証 → 204。 */
+export function leaveVillage(id: number): Promise<void> {
+  return apiFetch<void>(`/api/v1/villages/${id}/leave`, { method: "POST" });
+}

--- a/frontend/app/routes/village/ActionPanel.tsx
+++ b/frontend/app/routes/village/ActionPanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import { Button } from "~/components/ui/Button";
+import { Panel } from "~/components/ui/Panel";
 import { selectClass } from "~/components/ui/Input";
 import type {
   ParticipantSituationView,
@@ -43,11 +44,8 @@ export function ActionPanel({
   const submitDisabled = overLimit || message.trim().length === 0;
 
   return (
-    <div className="mb-[20px] rounded border border-[#464545] bg-[#303030]">
-      <div className="rounded-t bg-[#464545] px-[15px] py-[10px]">
-        <span className="text-[15px] text-white">アクション</span>
-      </div>
-      <div className="p-[15px]">
+    <Panel title="アクション">
+      <div>
         <div className="mb-[10px] rounded border border-[#f39c12] p-[9px] text-[#f39c12]">
           推理、まとめ、および推理に繋がる内容のアクションは禁止です。
         </div>
@@ -103,6 +101,6 @@ export function ActionPanel({
           </Button>
         </div>
       </div>
-    </div>
+    </Panel>
   );
 }

--- a/frontend/app/routes/village/ParticipantOpsPanels.tsx
+++ b/frontend/app/routes/village/ParticipantOpsPanels.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import { Button } from "~/components/ui/Button";
+import { Panel } from "~/components/ui/Panel";
 import { selectClass } from "~/components/ui/Input";
 import {
   changeVillageRequestSkill,
@@ -9,17 +10,6 @@ import {
   type ParticipantSituationView,
 } from "~/features/village/api";
 import { ApiError } from "~/lib/api";
-
-function panelShell(title: string, children: React.ReactNode) {
-  return (
-    <div className="mb-[20px] rounded border border-[#464545] bg-[#303030]">
-      <div className="rounded-t bg-[#464545] px-[15px] py-[10px]">
-        <span className="text-[15px] text-white">{title}</span>
-      </div>
-      <div className="space-y-[10px] p-[15px] text-[12px]">{children}</div>
-    </div>
-  );
-}
 
 function errorMessage(e: unknown, fallback: string): string {
   return e instanceof ApiError ? e.detail : fallback;
@@ -48,16 +38,17 @@ export function SwitchParticipatePanel({
       setSubmitting(false);
     }
   };
-  return panelShell(
-    "参加見学切り替え",
-    <>
-      {error != null && <p className="text-[#e74c3c]">{error}</p>}
-      <div className="flex justify-end">
-        <Button onClick={submit} disabled={submitting}>
-          参加見学を切り替える
-        </Button>
+  return (
+    <Panel title="参加見学切り替え">
+      <div className="space-y-[10px] text-[12px]">
+        {error != null && <p className="text-[#e74c3c]">{error}</p>}
+        <div className="flex justify-end">
+          <Button onClick={submit} disabled={submitting}>
+            参加見学を切り替える
+          </Button>
+        </div>
       </div>
-    </>,
+    </Panel>
   );
 }
 
@@ -99,51 +90,52 @@ export function ChangeSkillPanel({
     }
   };
 
-  return panelShell(
-    "役職希望",
-    <>
-      {error != null && <p className="text-[#e74c3c]">{error}</p>}
-      <p>
-        現在の役職希望: {currentFirst}/{currentSecond}
-      </p>
-      <div className="flex gap-[10px]">
-        <label className="flex-1">
-          第一役職希望
-          <select
-            className={`${selectClass} mt-[5px]`}
-            value={first}
-            onChange={(e) => setFirst(e.target.value)}
-            aria-label="第一役職希望"
-          >
-            {skills.map((skill) => (
-              <option key={skill.code} value={skill.code}>
-                {skill.name}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="flex-1">
-          第二役職希望
-          <select
-            className={`${selectClass} mt-[5px]`}
-            value={second}
-            onChange={(e) => setSecond(e.target.value)}
-            aria-label="第二役職希望"
-          >
-            {skills.map((skill) => (
-              <option key={skill.code} value={skill.code}>
-                {skill.name}
-              </option>
-            ))}
-          </select>
-        </label>
+  return (
+    <Panel title="役職希望">
+      <div className="space-y-[10px] text-[12px]">
+        {error != null && <p className="text-[#e74c3c]">{error}</p>}
+        <p>
+          現在の役職希望: {currentFirst}/{currentSecond}
+        </p>
+        <div className="flex gap-[10px]">
+          <label className="flex-1">
+            第一役職希望
+            <select
+              className={`${selectClass} mt-[5px]`}
+              value={first}
+              onChange={(e) => setFirst(e.target.value)}
+              aria-label="第一役職希望"
+            >
+              {skills.map((skill) => (
+                <option key={skill.code} value={skill.code}>
+                  {skill.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex-1">
+            第二役職希望
+            <select
+              className={`${selectClass} mt-[5px]`}
+              value={second}
+              onChange={(e) => setSecond(e.target.value)}
+              aria-label="第二役職希望"
+            >
+              {skills.map((skill) => (
+                <option key={skill.code} value={skill.code}>
+                  {skill.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <div className="flex justify-end">
+          <Button onClick={submit} disabled={submitting}>
+            役職希望を変更する
+          </Button>
+        </div>
       </div>
-      <div className="flex justify-end">
-        <Button onClick={submit} disabled={submitting}>
-          役職希望を変更する
-        </Button>
-      </div>
-    </>,
+    </Panel>
   );
 }
 
@@ -171,15 +163,16 @@ export function LeavePanel({
       setSubmitting(false);
     }
   };
-  return panelShell(
-    "退村",
-    <>
-      {error != null && <p className="text-[#e74c3c]">{error}</p>}
-      <div className="flex justify-end">
-        <Button variant="danger" onClick={submit} disabled={submitting}>
-          村を出る
-        </Button>
+  return (
+    <Panel title="退村">
+      <div className="space-y-[10px] text-[12px]">
+        {error != null && <p className="text-[#e74c3c]">{error}</p>}
+        <div className="flex justify-end">
+          <Button variant="danger" onClick={submit} disabled={submitting}>
+            村を出る
+          </Button>
+        </div>
       </div>
-    </>,
+    </Panel>
   );
 }

--- a/frontend/app/routes/village/ParticipantOpsPanels.tsx
+++ b/frontend/app/routes/village/ParticipantOpsPanels.tsx
@@ -1,0 +1,185 @@
+import { useState } from "react";
+
+import { Button } from "~/components/ui/Button";
+import { selectClass } from "~/components/ui/Input";
+import {
+  changeVillageRequestSkill,
+  leaveVillage,
+  switchVillageParticipate,
+  type ParticipantSituationView,
+} from "~/features/village/api";
+import { ApiError } from "~/lib/api";
+
+function panelShell(title: string, children: React.ReactNode) {
+  return (
+    <div className="mb-[20px] rounded border border-[#464545] bg-[#303030]">
+      <div className="rounded-t bg-[#464545] px-[15px] py-[10px]">
+        <span className="text-[15px] text-white">{title}</span>
+      </div>
+      <div className="space-y-[10px] p-[15px] text-[12px]">{children}</div>
+    </div>
+  );
+}
+
+function errorMessage(e: unknown, fallback: string): string {
+  return e instanceof ApiError ? e.detail : fallback;
+}
+
+/** 参加 ⇄ 見学の切替。 */
+export function SwitchParticipatePanel({
+  villageId,
+  onDone,
+}: {
+  villageId: number;
+  onDone: () => Promise<unknown>;
+}) {
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const submit = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await switchVillageParticipate(villageId);
+      await onDone();
+    } catch (e) {
+      setError(errorMessage(e, "切り替えに失敗しました"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+  return panelShell(
+    "参加見学切り替え",
+    <>
+      {error != null && <p className="text-[#e74c3c]">{error}</p>}
+      <div className="flex justify-end">
+        <Button onClick={submit} disabled={submitting}>
+          参加見学を切り替える
+        </Button>
+      </div>
+    </>,
+  );
+}
+
+/** 希望役職 (第 1/第 2) の変更。 */
+export function ChangeSkillPanel({
+  villageId,
+  mySituation,
+  onDone,
+}: {
+  villageId: number;
+  mySituation: ParticipantSituationView;
+  onDone: () => Promise<unknown>;
+}) {
+  const skillRequest = mySituation.skillRequest;
+  const skills = skillRequest.selectableSkillList ?? [];
+  const [first, setFirst] = useState(skillRequest.requestedSkillCode ?? "LEFTOVER");
+  const [second, setSecond] = useState(skillRequest.secondRequestedSkillCode ?? "LEFTOVER");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const currentFirst = skills.find((s) => s.code === skillRequest.requestedSkillCode)?.name ?? "";
+  const currentSecond =
+    skills.find((s) => s.code === skillRequest.secondRequestedSkillCode)?.name ?? "";
+
+  const submit = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await changeVillageRequestSkill(villageId, {
+        requestedSkill: first,
+        secondRequestedSkill: second,
+      });
+      await onDone();
+    } catch (e) {
+      setError(errorMessage(e, "役職希望の変更に失敗しました"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return panelShell(
+    "役職希望",
+    <>
+      {error != null && <p className="text-[#e74c3c]">{error}</p>}
+      <p>
+        現在の役職希望: {currentFirst}/{currentSecond}
+      </p>
+      <div className="flex gap-[10px]">
+        <label className="flex-1">
+          第一役職希望
+          <select
+            className={`${selectClass} mt-[5px]`}
+            value={first}
+            onChange={(e) => setFirst(e.target.value)}
+            aria-label="第一役職希望"
+          >
+            {skills.map((skill) => (
+              <option key={skill.code} value={skill.code}>
+                {skill.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex-1">
+          第二役職希望
+          <select
+            className={`${selectClass} mt-[5px]`}
+            value={second}
+            onChange={(e) => setSecond(e.target.value)}
+            aria-label="第二役職希望"
+          >
+            {skills.map((skill) => (
+              <option key={skill.code} value={skill.code}>
+                {skill.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div className="flex justify-end">
+        <Button onClick={submit} disabled={submitting}>
+          役職希望を変更する
+        </Button>
+      </div>
+    </>,
+  );
+}
+
+/** 退村。 */
+export function LeavePanel({
+  villageId,
+  onDone,
+}: {
+  villageId: number;
+  onDone: () => Promise<unknown>;
+}) {
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const submit = async () => {
+    if (submitting) return;
+    if (!window.confirm("本当に退村してよろしいですか？")) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await leaveVillage(villageId);
+      await onDone();
+    } catch (e) {
+      setError(errorMessage(e, "退村に失敗しました"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+  return panelShell(
+    "退村",
+    <>
+      {error != null && <p className="text-[#e74c3c]">{error}</p>}
+      <div className="flex justify-end">
+        <Button variant="danger" onClick={submit} disabled={submitting}>
+          村を出る
+        </Button>
+      </div>
+    </>,
+  );
+}

--- a/frontend/app/routes/village/ParticipatePanel.tsx
+++ b/frontend/app/routes/village/ParticipatePanel.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef, useState } from "react";
 
 import { Button } from "~/components/ui/Button";
+import { Panel } from "~/components/ui/Panel";
 import { inlineInputClass, inputClass, selectClass, textareaClass } from "~/components/ui/Input";
 import {
   confirmVillageParticipate,
@@ -112,11 +113,8 @@ export function ParticipatePanel({
 
   if (step === "confirm") {
     return (
-      <div className="mb-[20px] rounded border border-[#464545] bg-[#303030]">
-        <div className="rounded-t bg-[#464545] px-[15px] py-[10px]">
-          <span className="text-[15px] text-white">入村確認</span>
-        </div>
-        <div className="p-[15px]">
+      <Panel title="入村確認">
+        <div>
           <p className="mb-[10px]">以下の内容で入村してよろしいですか？</p>
           <div className="flex">
             <div>
@@ -174,16 +172,13 @@ export function ParticipatePanel({
             </Button>
           </div>
         </div>
-      </div>
+      </Panel>
     );
   }
 
   return (
-    <div className="mb-[20px] rounded border border-[#464545] bg-[#303030]">
-      <div className="rounded-t bg-[#464545] px-[15px] py-[10px]">
-        <span className="text-[15px] text-white">入村</span>
-      </div>
-      <div className="space-y-[10px] p-[15px] text-[12px]">
+    <Panel title="入村">
+      <div className="space-y-[10px] text-[12px]">
         {!isOriginal && (
           <>
             {charachips.length > 1 && (
@@ -325,6 +320,6 @@ export function ParticipatePanel({
           </Button>
         </div>
       </div>
-    </div>
+    </Panel>
   );
 }

--- a/frontend/app/routes/village/SayPanel.tsx
+++ b/frontend/app/routes/village/SayPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 
 import { Button } from "~/components/ui/Button";
+import { Panel } from "~/components/ui/Panel";
 import { selectClass } from "~/components/ui/Input";
 import { MESSAGE_STYLES } from "~/components/ui/messageStyles";
 import type {
@@ -203,11 +204,8 @@ export function SayPanel({
   };
 
   return (
-    <div className="mb-[20px] rounded border border-[#464545] bg-[#303030]">
-      <div className="rounded-t bg-[#464545] px-[15px] py-[10px]">
-        <span className="text-[15px] text-white">発言</span>
-      </div>
-      <div className="p-[15px]">
+    <Panel title="発言">
+      <div>
         {myself?.isDead && (
           <div className="mb-[10px] rounded border border-[#e74c3c] p-[9px] text-[#e74c3c]">
             あなたは死亡しました。現世の思い出を語り合いましょう。
@@ -355,7 +353,7 @@ export function SayPanel({
           </div>
         )}
       </div>
-    </div>
+    </Panel>
   );
 }
 

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -41,6 +41,7 @@ import { DayList } from "./DayList";
 import { FilterModal } from "./FilterModal";
 import { FooterMenu } from "./FooterMenu";
 import { MessageArea } from "./MessageArea";
+import { ChangeSkillPanel, LeavePanel, SwitchParticipatePanel } from "./ParticipantOpsPanels";
 import { ParticipatePanel } from "./ParticipatePanel";
 import { type ReplyDraft } from "./MessageCard";
 import { MessageCard } from "./MessageCard";
@@ -391,6 +392,18 @@ export default function Village({ params }: Route.ComponentProps) {
               />
             </div>
           )}
+
+        {mySituation != null &&
+          mySituation.participate.isParticipating &&
+          mySituation.skillRequest.isAvailableSkillRequest && (
+            <ChangeSkillPanel villageId={villageId} mySituation={mySituation} onDone={invalidate} />
+          )}
+        {mySituation?.participate.isAvailableSwitchParticipate && (
+          <SwitchParticipatePanel villageId={villageId} onDone={invalidate} />
+        )}
+        {mySituation?.participate.isAvailableLeave && (
+          <LeavePanel villageId={villageId} onDone={invalidate} />
+        )}
 
         <DayList
           villageId={villageId}


### PR DESCRIPTION
closes .issues/step-8.7-8.8-participate-ops.md

## 概要

参加系の残り操作を REST + React 化 (step-8.7 + 8.8 を 1 PR に統合 — 同 controller・同規模の小操作 3 つのため)。見学入村は 8.6 の spectator チェックで実装済み。base は `feature/monorepo-step8`。

## backend

- `POST /api/v1/villages/{id}/switch-participate` / `change-skill` / `leave` (いずれも要認証 → 204)。可否の権威検証は既存 `VillageCoordinator.switchParticipate` / `changeRequestSkill` / `leave` (domain) に委譲。`VillageChangeSkillRequest` は code を CDef 検証してから渡す (SSR と同じ)

## frontend

- **3 パネル** (`ParticipantOpsPanels`、situation/me のフラグで出し分け): 役職希望 (現在の希望表示 + 第一/第二 select、`isAvailableSkillRequest` かつ参加中) / 参加見学切り替え (`isAvailableSwitchParticipate`) / 退村 (`isAvailableLeave`、**「本当に退村してよろしいですか？」confirm** = legacy parity)。各操作とも連打ガード + 完了で村系クエリ無効化

## 検証

- REST 実測: e2ejoin01 で change-skill 204 (→ WEREWOLF/SEER 反映) → leave 204 (→ 生存一覧から消滅。**8.6 で残置した村 2 の e2ejoin01 もこれで片付け済み**)
- e2e 1 件追加: **入村 → 役職希望変更 → 退村の自己完結フロー** (新規ユーザーで実入村し、最後に退村して後片付け)。全 61 件
- backend ktlintCheck/test green。frontend typecheck/lint/format/build green。gen:api 差分込み

🤖 Generated with [Claude Code](https://claude.com/claude-code)