### PR TITLE
feat: 村画面の能力セットを REST + React 化 (step-8.9)

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/village/VillageAbilityRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/VillageAbilityRestController.kt
@@ -1,0 +1,98 @@
+package com.ort.app.api.village
+
+import com.ort.app.api.village.request.VillageAbilityRequest
+import com.ort.app.api.village.response.AbilityCandidatesView
+import com.ort.app.application.coordinator.VillageCoordinator
+import com.ort.app.application.service.VillageService
+import com.ort.app.domain.model.village.Village
+import com.ort.app.domain.model.village.participant.VillageParticipant
+import com.ort.app.fw.exception.WolfMansionAuthException
+import com.ort.app.fw.exception.WolfMansionBusinessException
+import com.ort.app.fw.security.jwt.JwtPrincipal
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+
+/**
+ * 役職能力の REST。セット可否・対象妥当性は既存 VillageCoordinator.setAbility (domain) が検証する。
+ * 候補はビューア本人の役職知識に基づくため要認証。
+ */
+@RestController
+@RequestMapping("/api/v1/villages/{id}/ability")
+class VillageAbilityRestController(
+    private val villageService: VillageService,
+    private val villageCoordinator: VillageCoordinator,
+) {
+    /** 能力をセットする。 */
+    @Operation(operationId = "setVillageAbility")
+    @PostMapping
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun setAbility(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+        @RequestBody request: VillageAbilityRequest,
+    ) {
+        val (village, myself) = resolveParticipant(principal, id)
+        villageCoordinator.setAbility(
+            village,
+            myself,
+            request.attackerCharaId,
+            request.targetCharaId,
+            request.footstep,
+        )
+    }
+
+    /** 襲撃者を選んだときの襲撃対象候補。 */
+    @Operation(operationId = "getVillageAttackTargets")
+    @GetMapping("/attack-targets")
+    fun attackTargets(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+        @RequestParam charaId: Int,
+    ): AbilityCandidatesView {
+        val (village, myself) = resolveParticipant(principal, id)
+        val targets = villageCoordinator.getAttackableTargets(village, myself, charaId)
+        return AbilityCandidatesView(
+            targets = targets.list.map { AbilityCandidatesView.TargetView(it) },
+            footsteps = emptyList(),
+        )
+    }
+
+    /** 対象を選んだときの足音 (通過する部屋) 候補。 */
+    @Operation(operationId = "getVillageAbilityFootsteps")
+    @GetMapping("/footsteps")
+    fun footsteps(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+        @RequestParam(required = false) charaId: Int?,
+        @RequestParam(required = false) targetCharaId: Int?,
+    ): AbilityCandidatesView {
+        val (village, myself) = resolveParticipant(principal, id)
+        val footsteps = villageCoordinator.getSelectableFootstepList(village, myself, charaId, targetCharaId)
+        return AbilityCandidatesView(targets = emptyList(), footsteps = footsteps)
+    }
+
+    private fun resolveParticipant(
+        principal: JwtPrincipal?,
+        villageId: Int,
+    ): Pair<Village, VillageParticipant> {
+        // principal は filter chain の authenticated() で保証済み (到達時は非 null)。防御的に確認する
+        principal ?: throw WolfMansionAuthException("ログインしてください")
+        val village =
+            villageService.findVillage(villageId)
+                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "village not found")
+        val myself =
+            villageService.findVillageParticipant(village.id, principal.name)
+                ?: throw WolfMansionBusinessException("村に参加していません")
+        return village to myself
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/village/VillageRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/VillageRestController.kt
@@ -139,16 +139,18 @@ class VillageRestController(
         val charachips =
             village.setting.chara.let { charaService.findCharachips(it.charachipIds, it.isOriginalCharachip) }
         return ParticipantSituationView(
-            villageCoordinator.findParticipantSituation(
-                village = village,
-                username = principal.name,
-                myself = myself,
-                votes = votes,
-                abilities = abilities,
-                footsteps = footsteps,
-                charachips = charachips,
-                day = targetDay,
-            ),
+            situation =
+                villageCoordinator.findParticipantSituation(
+                    village = village,
+                    username = principal.name,
+                    myself = myself,
+                    votes = votes,
+                    abilities = abilities,
+                    footsteps = footsteps,
+                    charachips = charachips,
+                    day = targetDay,
+                ),
+            village = village,
         )
     }
 

--- a/backend/src/main/kotlin/com/ort/app/api/village/request/VillageAbilityRequest.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/request/VillageAbilityRequest.kt
@@ -1,0 +1,12 @@
+package com.ort.app.api.village.request
+
+/**
+ * 能力セット。役職の入力パターンにより使うフィールドが異なる
+ * (襲撃 = attacker + target + footstep / 対象選択 = target / 調査・徘徊 = footstep)。
+ */
+data class VillageAbilityRequest(
+    val attackerCharaId: Int? = null,
+    val targetCharaId: Int? = null,
+    /** 足音 (調査対象、または徘徊の通過部屋 CSV・「なし」) */
+    val footstep: String? = null,
+)

--- a/backend/src/main/kotlin/com/ort/app/api/village/response/AbilityCandidatesView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/response/AbilityCandidatesView.kt
@@ -1,0 +1,23 @@
+package com.ort.app.api.village.response
+
+import com.ort.app.domain.model.village.participant.VillageParticipant
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 能力セットの候補 (襲撃対象 / 足音)。ビューア本人の役職知識に基づくため認証必須 API でのみ返す。
+ */
+data class AbilityCandidatesView(
+    val targets: List<TargetView>,
+    val footsteps: List<String>,
+) {
+    @Schema(name = "AbilityCandidatesTarget")
+    data class TargetView(
+        val charaId: Int,
+        val name: String,
+    ) {
+        constructor(participant: VillageParticipant) : this(
+            charaId = participant.charaId,
+            name = participant.name(),
+        )
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/village/response/ParticipantSituationView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/response/ParticipantSituationView.kt
@@ -1,12 +1,16 @@
 package com.ort.app.api.village.response
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.ort.app.domain.model.chara.Chara
 import com.ort.app.domain.model.chara.CharaImage
 import com.ort.app.domain.model.chara.Charachip
 import com.ort.app.domain.model.situation.ParticipantSituation
+import com.ort.app.domain.model.situation.participant.ParticipantAbilitySituation
 import com.ort.app.domain.model.situation.participant.ParticipantSayMessageTypeSituation
 import com.ort.app.domain.model.situation.participant.ParticipantSayRestrictSituation
 import com.ort.app.domain.model.situation.participant.ParticipantSaySituation
+import com.ort.app.domain.model.skill.Skill
+import com.ort.app.domain.model.village.Village
 import com.ort.app.domain.model.village.participant.VillageParticipant
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -31,7 +35,7 @@ data class ParticipantSituationView(
     val admin: AdminView,
     val creator: CreatorView,
 ) {
-    constructor(situation: ParticipantSituation) : this(
+    constructor(situation: ParticipantSituation, village: Village) : this(
         myself = situation.participate.myself?.let { MyselfView(it) },
         participate = ParticipateView(situation),
         skillRequest = SkillRequestView(situation),
@@ -47,7 +51,7 @@ data class ParticipantSituationView(
                 isAvailableMemo = situation.rp.isAvailableMemo,
                 canAddImage = situation.rp.canAddImage,
             ),
-        ability = AbilityView(canUseAbility = situation.ability.canUseAbility),
+        ability = AbilityView(situation.ability, village),
         vote = VoteView(canVote = situation.vote.canVote),
         admin = AdminView(isAdmin = situation.admin.isAdmin),
         creator = CreatorView(situation),
@@ -64,6 +68,8 @@ data class ParticipantSituationView(
         val isSpectator: Boolean,
         /** Discord 通知キーワード (スペース区切り、未設定は null)。発言抽出のショートカットが使う */
         val notificationKeyword: String?,
+        /** 自分の役職 (本人にのみ返る。未割当は null) */
+        val skill: MyselfSkillView?,
     ) {
         constructor(myself: VillageParticipant) : this(
             id = myself.id,
@@ -78,6 +84,24 @@ data class ParticipantSituationView(
                     ?.keywords
                     ?.takeIf { it.isNotEmpty() }
                     ?.joinToString(separator = " "),
+            skill = myself.skill?.let { MyselfSkillView(it) },
+        )
+    }
+
+    @Schema(name = "ParticipantSituationViewMyselfSkill")
+    data class MyselfSkillView(
+        val code: String,
+        val name: String,
+        /** 足音の調査能力を持つか (調査型の能力 UI) */
+        val hasInvestigateAbility: Boolean,
+        /** 徘徊能力を持つか (部屋選択の能力 UI) */
+        val hasDisturbAbility: Boolean,
+    ) {
+        constructor(skill: Skill) : this(
+            code = skill.code,
+            name = skill.name,
+            hasInvestigateAbility = skill.hasInvestigateAbility(),
+            hasDisturbAbility = skill.hasDisturbAbility(),
         )
     }
 
@@ -265,7 +289,99 @@ data class ParticipantSituationView(
     @Schema(name = "ParticipantSituationViewAbility")
     data class AbilityView(
         val canUseAbility: Boolean,
-    )
+        /** 対象の候補 (足音調査型は targetFootstepList を使う) */
+        val targetList: List<AbilityTargetView>,
+        /** 襲撃者の候補 (襲撃能力を持つ陣営のみ非空) */
+        val attackerList: List<AbilityTargetView>,
+        /** 足音の候補 (調査型・対象+足音型) */
+        val targetFootstepList: List<String>,
+        /** 現在セット中の襲撃者 */
+        val attackerCharaId: Int?,
+        /** 現在セット中の対象 */
+        val targetCharaId: Int?,
+        /** 現在セット中の足音 */
+        val targetFootstep: String?,
+        /** 徘徊で現在セット中の通過部屋 (CSV または「なし」) */
+        val footstep: String?,
+        /** 現在のセット内容の説明文 */
+        val targetingMessage: String?,
+        /** 対象 select の前置文言 */
+        val targetPrefix: String?,
+        /** 対象 select の後置文言 */
+        val targetSuffix: String?,
+        val isAvailableNoTarget: Boolean,
+        /** 対象選択に加えて通過する部屋の選択が要るか */
+        val isTargetingAndFootstep: Boolean,
+        /** 能力セット履歴 */
+        val skillHistoryList: List<String>,
+        /** 人狼の名前 (狂信者などに見える)。空なら非表示 */
+        val werewolfNames: String,
+        /** C 国狂人の名前 (人狼に見える)。2 文字目が大文字のため Jackson と SpringDoc で名前が割れないよう明示する */
+        @get:JsonProperty("cMadmanNames")
+        val cMadmanNames: String,
+        /** 妖狐の名前 (背徳者に見える) */
+        val foxNames: String,
+        /** 恋人の関係 (恋人陣営に見える、複数行) */
+        val loversNames: String,
+        /** 共鳴者の名前 */
+        val masonsNames: String,
+        /** 共有者の名前 */
+        val listenMasonsNames: String,
+    ) {
+        constructor(ability: ParticipantAbilitySituation, village: Village) : this(
+            canUseAbility = ability.canUseAbility,
+            targetList = ability.targetList.map { AbilityTargetView(it) },
+            attackerList = ability.attackerList.map { AbilityTargetView(it) },
+            targetFootstepList = ability.targetFootstepList,
+            attackerCharaId = ability.attacker?.charaId,
+            targetCharaId = ability.target?.charaId,
+            targetFootstep = ability.targetFootstep,
+            footstep = ability.footstep,
+            targetingMessage = ability.targetingMessage,
+            targetPrefix = ability.targetPrefix,
+            targetSuffix = ability.targetSuffix,
+            isAvailableNoTarget = ability.isAvailableNoTarget,
+            isTargetingAndFootstep = ability.isTargetingAndFootstep,
+            skillHistoryList = ability.skillHistoryList,
+            werewolfNames = ability.wolfList.joinToString("、") { it.name() },
+            cMadmanNames = ability.cMadmanList.joinToString("、") { it.name() },
+            foxNames = ability.foxList.joinToString("、") { it.name() },
+            loversNames = mapLoversNames(village, ability.loversList),
+            masonsNames = ability.masonsList.joinToString("、") { it.name() },
+            listenMasonsNames = ability.listenMasonsList.joinToString("、") { it.name() },
+        )
+
+        companion object {
+            private fun mapLoversNames(
+                village: Village,
+                loversList: List<VillageParticipant>,
+            ): String {
+                val list =
+                    loversList.flatMap { lover ->
+                        lover.status.loverIdList.map { targetId ->
+                            "${lover.name()} → ${village.participants.member(targetId).name()}"
+                        }
+                    }
+                if (list.isEmpty()) return ""
+                return list.joinToString(
+                    prefix = "この村で恋に落ちているのは\n",
+                    separator = "\n",
+                    postfix = "\nです。",
+                )
+            }
+        }
+    }
+
+    @Schema(name = "ParticipantSituationViewAbilityTarget")
+    data class AbilityTargetView(
+        val charaId: Int,
+        val name: String,
+    ) {
+        constructor(participant: VillageParticipant) : this(
+            charaId = participant.charaId,
+            name = participant.name(),
+        )
+    }
 
     @Schema(name = "ParticipantSituationViewVote")
     data class VoteView(

--- a/backend/src/test/kotlin/com/ort/app/api/village/response/ParticipantSituationViewTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/api/village/response/ParticipantSituationViewTest.kt
@@ -12,6 +12,7 @@ import com.ort.app.domain.model.situation.participant.ParticipantSaySituation
 import com.ort.app.domain.model.situation.participant.ParticipantSkillRequestSituation
 import com.ort.app.domain.model.situation.participant.ParticipantVoteSituation
 import com.ort.app.domain.model.skill.Skill
+import com.ort.app.domain.model.village.createDay1Village
 import com.ort.app.domain.model.village.createVillageParticipant
 import com.ort.dbflute.allcommon.CDef
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -23,7 +24,7 @@ import org.junit.jupiter.api.Test
 internal class ParticipantSituationViewTest {
     @Test
     fun `未参加でもフラグがそのまま写像される`() {
-        val view = ParticipantSituationView(createSituation(myselfParticipant = null))
+        val view = ParticipantSituationView(createSituation(myselfParticipant = null), createDay1Village())
 
         assertNull(view.myself)
         assertFalse(view.participate.isParticipating)
@@ -41,6 +42,7 @@ internal class ParticipantSituationViewTest {
         val view =
             ParticipantSituationView(
                 createSituation(myselfParticipant = participant, isParticipating = true),
+                createDay1Village(),
             )
 
         assertEquals(participant.id, view.myself!!.id)

--- a/e2e/tests/village-ability.spec.ts
+++ b/e2e/tests/village-ability.spec.ts
@@ -1,0 +1,122 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * 役職能力セットの e2e。能力を使える参加者が必要なため、進行中の村と
+ * ローカル開発 DB のテストユーザー (testuser01〜16 / password=testuser) を
+ * 走査して能力者を動的に探し、見つからなければスキップする。
+ * セットは現在値の再セットに留め、共有 DB の進行状態を変えない。
+ */
+
+type SimpleVillage = { id: number; name: string };
+
+type AbilityView = {
+  canUseAbility: boolean;
+  attackerList: { charaId: number; name: string }[];
+  attackerCharaId: number | null;
+  targetCharaId: number | null;
+  footstep: string | null;
+  targetingMessage: string | null;
+  werewolfNames: string;
+};
+
+type Candidate = { villageId: number; userId: string; ability: AbilityView };
+
+const CANDIDATE_USERS = Array.from(
+  { length: 16 },
+  (_, i) => `testuser${String(i + 1).padStart(2, "0")}`,
+);
+
+async function findVillages(page: Page, statuses: string[]): Promise<SimpleVillage[]> {
+  const query = statuses.map((s) => `status=${s}`).join("&");
+  const res = await page.request.get(`/wolf-mansion-api/api/v1/villages?${query}`);
+  expect(res.ok()).toBeTruthy();
+  const body = (await res.json()) as { villages: SimpleVillage[] };
+  return body.villages;
+}
+
+async function login(page: Page, userId: string): Promise<boolean> {
+  const res = await page.request.post(`/wolf-mansion-api/api/v1/auth/login`, {
+    data: { userId, password: "testuser" },
+  });
+  return res.ok();
+}
+
+/** 能力を使える (user, village) の組を探す。filter で絞り込み条件を追加できる。 */
+async function findAbilityCandidate(
+  page: Page,
+  filter: (ability: AbilityView) => boolean,
+): Promise<Candidate | null> {
+  const villages = await findVillages(page, ["IN_PROGRESS"]);
+  if (villages.length === 0) return null;
+  for (const userId of CANDIDATE_USERS) {
+    if (!(await login(page, userId))) continue;
+    for (const village of villages) {
+      const res = await page.request.get(
+        `/wolf-mansion-api/api/v1/villages/${village.id}/situation/me`,
+      );
+      if (!res.ok()) continue;
+      const body = (await res.json()) as { ability: AbilityView };
+      if (body.ability.canUseAbility && filter(body.ability)) {
+        return { villageId: village.id, userId, ability: body.ability };
+      }
+    }
+  }
+  return null;
+}
+
+test("能力者で村画面を開くと役職パネルが表示される", async ({ page }) => {
+  const candidate = await findAbilityCandidate(page, () => true);
+  test.skip(candidate == null, "能力を使える参加者が見つからない DB のためスキップ");
+  if (candidate == null) return;
+
+  await page.goto(`village/${candidate.villageId}`);
+  await expect(page.getByText("役職", { exact: true }).first()).toBeVisible({ timeout: 15000 });
+
+  // 現在のセット内容の説明文が出る (セット済みの場合)
+  if (candidate.ability.targetingMessage != null) {
+    await expect(page.getByText(candidate.ability.targetingMessage)).toBeVisible();
+  }
+  // 人狼系なら仲間の名前が見える
+  if (candidate.ability.werewolfNames !== "") {
+    await expect(page.getByText(`この村の人狼は、 ${candidate.ability.werewolfNames} です。`)).toBeVisible();
+  }
+});
+
+test("人狼が現在の襲撃セットを再セットできる (共有 DB の状態を変えない)", async ({ page }) => {
+  // 襲撃型で現在セット済み (再セットしても状態が変わらない) の参加者に限定する
+  const candidate = await findAbilityCandidate(
+    page,
+    (ability) =>
+      ability.attackerList.length > 0 &&
+      ability.attackerCharaId != null &&
+      ability.targetCharaId != null &&
+      ability.footstep != null,
+  );
+  test.skip(candidate == null, "襲撃をセット済みの人狼が見つからない DB のためスキップ");
+  if (candidate == null) return;
+
+  await page.goto(`village/${candidate.villageId}`);
+  await expect(page.getByRole("button", { name: "能力セット" })).toBeVisible({ timeout: 15000 });
+
+  // 初期表示で現在のセット値が選択済みになるのを待つ (対象候補は遅延取得)
+  const targetSelect = page.getByLabel("能力の対象");
+  await expect(targetSelect).toHaveValue(String(candidate.ability.targetCharaId), {
+    timeout: 15000,
+  });
+  await expect(page.getByLabel("通過する部屋")).toHaveValue(candidate.ability.footstep ?? "");
+
+  const [response] = await Promise.all([
+    page.waitForResponse(
+      (res) =>
+        res.url().includes(`/api/v1/villages/${candidate.villageId}/ability`) &&
+        res.request().method() === "POST",
+    ),
+    page.getByRole("button", { name: "能力セット" }).click(),
+  ]);
+  expect(response.status()).toBe(204);
+
+  // 再セット後も同じセット内容の説明文が表示される
+  if (candidate.ability.targetingMessage != null) {
+    await expect(page.getByText(candidate.ability.targetingMessage)).toBeVisible();
+  }
+});

--- a/frontend/app/api/openapi.json
+++ b/frontend/app/api/openapi.json
@@ -593,6 +593,123 @@
         "tags": ["village-rest-controller"]
       }
     },
+    "/api/v1/villages/{id}/ability": {
+      "post": {
+        "operationId": "setVillageAbility",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VillageAbilityRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": ["village-ability-rest-controller"]
+      }
+    },
+    "/api/v1/villages/{id}/ability/attack-targets": {
+      "get": {
+        "operationId": "getVillageAttackTargets",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "in": "query",
+            "name": "charaId",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/AbilityCandidatesView"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": ["village-ability-rest-controller"]
+      }
+    },
+    "/api/v1/villages/{id}/ability/footsteps": {
+      "get": {
+        "operationId": "getVillageAbilityFootsteps",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "in": "query",
+            "name": "charaId",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "in": "query",
+            "name": "targetCharaId",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/AbilityCandidatesView"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": ["village-ability-rest-controller"]
+      }
+    },
     "/api/v1/villages/{id}/action": {
       "post": {
         "operationId": "actionVillage",
@@ -1331,6 +1448,37 @@
   },
   "components": {
     "schemas": {
+      "AbilityCandidatesTarget": {
+        "type": "object",
+        "properties": {
+          "charaId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["charaId", "name"]
+      },
+      "AbilityCandidatesView": {
+        "type": "object",
+        "properties": {
+          "footsteps": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "targets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AbilityCandidatesTarget"
+            }
+          }
+        },
+        "required": ["footsteps", "targets"]
+      },
       "AbilityType": {
         "type": "object",
         "properties": {
@@ -1751,11 +1899,109 @@
       "ParticipantSituationViewAbility": {
         "type": "object",
         "properties": {
+          "attackerCharaId": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          },
+          "attackerList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParticipantSituationViewAbilityTarget"
+            }
+          },
+          "cMadmanNames": {
+            "type": "string"
+          },
           "canUseAbility": {
             "type": "boolean"
+          },
+          "footstep": {
+            "type": ["string", "null"]
+          },
+          "foxNames": {
+            "type": "string"
+          },
+          "isAvailableNoTarget": {
+            "type": "boolean"
+          },
+          "isTargetingAndFootstep": {
+            "type": "boolean"
+          },
+          "listenMasonsNames": {
+            "type": "string"
+          },
+          "loversNames": {
+            "type": "string"
+          },
+          "masonsNames": {
+            "type": "string"
+          },
+          "skillHistoryList": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "targetCharaId": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          },
+          "targetFootstep": {
+            "type": ["string", "null"]
+          },
+          "targetFootstepList": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "targetList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParticipantSituationViewAbilityTarget"
+            }
+          },
+          "targetPrefix": {
+            "type": ["string", "null"]
+          },
+          "targetSuffix": {
+            "type": ["string", "null"]
+          },
+          "targetingMessage": {
+            "type": ["string", "null"]
+          },
+          "werewolfNames": {
+            "type": "string"
           }
         },
-        "required": ["canUseAbility"]
+        "required": [
+          "attackerList",
+          "cMadmanNames",
+          "canUseAbility",
+          "foxNames",
+          "isAvailableNoTarget",
+          "isTargetingAndFootstep",
+          "listenMasonsNames",
+          "loversNames",
+          "masonsNames",
+          "skillHistoryList",
+          "targetFootstepList",
+          "targetList",
+          "werewolfNames"
+        ]
+      },
+      "ParticipantSituationViewAbilityTarget": {
+        "type": "object",
+        "properties": {
+          "charaId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["charaId", "name"]
       },
       "ParticipantSituationViewAdmin": {
         "type": "object",
@@ -1834,9 +2080,37 @@
           },
           "shortName": {
             "type": "string"
+          },
+          "skill": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ParticipantSituationViewMyselfSkill"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": ["charaId", "id", "isDead", "isSpectator", "name", "shortName"]
+      },
+      "ParticipantSituationViewMyselfSkill": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "hasDisturbAbility": {
+            "type": "boolean"
+          },
+          "hasInvestigateAbility": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["code", "hasDisturbAbility", "hasInvestigateAbility", "name"]
       },
       "ParticipantSituationViewParticipate": {
         "type": "object",
@@ -2612,6 +2886,22 @@
           }
         },
         "required": ["skillCodes"]
+      },
+      "VillageAbilityRequest": {
+        "type": "object",
+        "properties": {
+          "attackerCharaId": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          },
+          "footstep": {
+            "type": ["string", "null"]
+          },
+          "targetCharaId": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          }
+        }
       },
       "VillageActionRequest": {
         "type": "object",

--- a/frontend/app/api/types.ts
+++ b/frontend/app/api/types.ts
@@ -259,6 +259,54 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/villages/{id}/ability": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["setVillageAbility"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/villages/{id}/ability/attack-targets": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["getVillageAttackTargets"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/villages/{id}/ability/footsteps": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["getVillageAbilityFootsteps"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/villages/{id}/action": {
     parameters: {
       query?: never;
@@ -551,6 +599,15 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
   schemas: {
+    AbilityCandidatesTarget: {
+      /** Format: int32 */
+      charaId: number;
+      name: string;
+    };
+    AbilityCandidatesView: {
+      footsteps: string[];
+      targets: components["schemas"]["AbilityCandidatesTarget"][];
+    };
     AbilityType: {
       code: string;
       name: string;
@@ -685,7 +742,33 @@ export interface components {
       vote: components["schemas"]["ParticipantSituationViewVote"];
     };
     ParticipantSituationViewAbility: {
+      /** Format: int32 */
+      attackerCharaId?: number | null;
+      attackerList: components["schemas"]["ParticipantSituationViewAbilityTarget"][];
+      cMadmanNames: string;
       canUseAbility: boolean;
+      footstep?: string | null;
+      foxNames: string;
+      isAvailableNoTarget: boolean;
+      isTargetingAndFootstep: boolean;
+      listenMasonsNames: string;
+      loversNames: string;
+      masonsNames: string;
+      skillHistoryList: string[];
+      /** Format: int32 */
+      targetCharaId?: number | null;
+      targetFootstep?: string | null;
+      targetFootstepList: string[];
+      targetList: components["schemas"]["ParticipantSituationViewAbilityTarget"][];
+      targetPrefix?: string | null;
+      targetSuffix?: string | null;
+      targetingMessage?: string | null;
+      werewolfNames: string;
+    };
+    ParticipantSituationViewAbilityTarget: {
+      /** Format: int32 */
+      charaId: number;
+      name: string;
     };
     ParticipantSituationViewAdmin: {
       isAdmin: boolean;
@@ -712,6 +795,13 @@ export interface components {
       name: string;
       notificationKeyword?: string | null;
       shortName: string;
+      skill?: components["schemas"]["ParticipantSituationViewMyselfSkill"] | null;
+    };
+    ParticipantSituationViewMyselfSkill: {
+      code: string;
+      hasDisturbAbility: boolean;
+      hasInvestigateAbility: boolean;
+      name: string;
     };
     ParticipantSituationViewParticipate: {
       isAvailableLeave: boolean;
@@ -946,6 +1036,13 @@ export interface components {
     };
     SkillSearchResponse: {
       skillCodes: string[];
+    };
+    VillageAbilityRequest: {
+      /** Format: int32 */
+      attackerCharaId?: number | null;
+      footstep?: string | null;
+      /** Format: int32 */
+      targetCharaId?: number | null;
     };
     VillageActionRequest: {
       convertDisable?: boolean | null;
@@ -1768,6 +1865,79 @@ export interface operations {
         };
         content: {
           "*/*": components["schemas"]["VillageDetailView"];
+        };
+      };
+    };
+  };
+  setVillageAbility: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["VillageAbilityRequest"];
+      };
+    };
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  getVillageAttackTargets: {
+    parameters: {
+      query: {
+        charaId: number;
+      };
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["AbilityCandidatesView"];
+        };
+      };
+    };
+  };
+  getVillageAbilityFootsteps: {
+    parameters: {
+      query?: {
+        charaId?: number;
+        targetCharaId?: number;
+      };
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["AbilityCandidatesView"];
         };
       };
     };

--- a/frontend/app/features/village/api.ts
+++ b/frontend/app/features/village/api.ts
@@ -228,3 +228,35 @@ export function changeVillageRequestSkill(
 export function leaveVillage(id: number): Promise<void> {
   return apiFetch<void>(`/api/v1/villages/${id}/leave`, { method: "POST" });
 }
+
+/** 能力セットのリクエスト。 */
+export type VillageAbilityRequest = components["schemas"]["VillageAbilityRequest"];
+/** 能力セットの候補 (襲撃対象 / 足音)。 */
+export type AbilityCandidatesView = components["schemas"]["AbilityCandidatesView"];
+
+/** 能力をセットする。要認証 → 204。 */
+export function setVillageAbility(id: number, request: VillageAbilityRequest): Promise<void> {
+  return apiFetch<void>(`/api/v1/villages/${id}/ability`, { method: "POST", body: request });
+}
+
+/** 襲撃者を選んだときの襲撃対象候補。 */
+export function fetchAttackTargets(id: number, charaId: number): Promise<AbilityCandidatesView> {
+  return apiFetch<AbilityCandidatesView>(
+    `/api/v1/villages/${id}/ability/attack-targets?charaId=${charaId}`,
+  );
+}
+
+/** 対象を選んだときの足音 (通過する部屋) 候補。 */
+export function fetchAbilityFootsteps(
+  id: number,
+  charaId: number | null,
+  targetCharaId: number | null,
+): Promise<AbilityCandidatesView> {
+  const params = new URLSearchParams();
+  if (charaId != null) params.set("charaId", String(charaId));
+  if (targetCharaId != null) params.set("targetCharaId", String(targetCharaId));
+  const query = params.toString();
+  return apiFetch<AbilityCandidatesView>(
+    `/api/v1/villages/${id}/ability/footsteps${query !== "" ? `?${query}` : ""}`,
+  );
+}

--- a/frontend/app/routes/village/AbilityPanel.tsx
+++ b/frontend/app/routes/village/AbilityPanel.tsx
@@ -1,0 +1,323 @@
+import { useEffect, useState } from "react";
+
+import { Button } from "~/components/ui/Button";
+import { selectClass } from "~/components/ui/Input";
+import { Panel } from "~/components/ui/Panel";
+import {
+  fetchAbilityFootsteps,
+  fetchAttackTargets,
+  setVillageAbility,
+  type ParticipantSituationView,
+  type VillageAbilityRequest,
+  type VillageRoomAssignedRow,
+} from "~/features/village/api";
+import { ApiError } from "~/lib/api";
+
+const NO_FOOTSTEP = "なし";
+
+/**
+ * 役職能力のセット。入力パターンは situation の素材で出し分ける:
+ * 襲撃 (襲撃者 + 対象 + 足音) / 調査 (足音 select) / 徘徊 (部屋トグル) /
+ * 対象 + 足音 / 対象のみ (対象なし許容含む)。
+ */
+export function AbilityPanel({
+  villageId,
+  mySituation,
+  roomAssignedRows,
+  onDone,
+}: {
+  villageId: number;
+  mySituation: ParticipantSituationView;
+  roomAssignedRows: VillageRoomAssignedRow[] | null | undefined;
+  onDone: () => Promise<unknown>;
+}) {
+  const ability = mySituation.ability;
+  const skill = mySituation.myself?.skill;
+
+  const isAttack = (ability.attackerList ?? []).length > 0;
+  const isInvestigate = skill?.hasInvestigateAbility ?? false;
+  const isDisturb = (skill?.hasDisturbAbility ?? false) && (ability.targetList ?? []).length === 0;
+
+  const [attackerCharaId, setAttackerCharaId] = useState<string>(
+    ability.attackerCharaId != null ? String(ability.attackerCharaId) : "",
+  );
+  const [targetCharaId, setTargetCharaId] = useState<string>(
+    ability.targetCharaId != null ? String(ability.targetCharaId) : "",
+  );
+  const [footstep, setFootstep] = useState<string>(
+    ability.targetFootstep ?? ability.footstep ?? "",
+  );
+  // 徘徊の通過部屋 (CSV をトグル選択で組み立てる)
+  const [disturbRooms, setDisturbRooms] = useState<string[]>(() => {
+    const current = ability.footstep;
+    return current == null || current === NO_FOOTSTEP ? [] : current.split(",");
+  });
+  const [targets, setTargets] = useState(ability.targetList ?? []);
+  const [footstepOptions, setFootstepOptions] = useState<string[]>(
+    ability.targetFootstepList ?? [],
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // 襲撃の対象候補と現在対象の足音候補は situation に含まれないため、初期表示時に取得する
+  useEffect(() => {
+    if (!ability.canUseAbility) return;
+    if (isAttack && attackerCharaId !== "") {
+      fetchAttackTargets(villageId, Number(attackerCharaId))
+        .then((response) => setTargets(response.targets ?? []))
+        .catch(() => {});
+    }
+    if ((isAttack || ability.isTargetingAndFootstep) && targetCharaId !== "") {
+      fetchAbilityFootsteps(
+        villageId,
+        isAttack && attackerCharaId !== "" ? Number(attackerCharaId) : null,
+        Number(targetCharaId),
+      )
+        .then((response) => setFootstepOptions(response.footsteps ?? []))
+        .catch(() => {});
+    }
+    // 初期表示のみ。以降の変更は onAttackerChange / onTargetChange が取得する
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // 襲撃者を選ぶと対象候補が変わり、対象を選ぶと足音候補が変わる
+  const onAttackerChange = async (value: string) => {
+    setAttackerCharaId(value);
+    setTargetCharaId("");
+    setFootstep("");
+    if (value === "") return;
+    try {
+      const response = await fetchAttackTargets(villageId, Number(value));
+      setTargets(response.targets ?? []);
+    } catch {
+      setTargets([]);
+    }
+  };
+
+  const onTargetChange = async (value: string) => {
+    setTargetCharaId(value);
+    setFootstep("");
+    if (!(isAttack || ability.isTargetingAndFootstep) || value === "") return;
+    try {
+      const response = await fetchAbilityFootsteps(
+        villageId,
+        isAttack && attackerCharaId !== "" ? Number(attackerCharaId) : null,
+        Number(value),
+      );
+      setFootstepOptions(response.footsteps ?? []);
+    } catch {
+      setFootstepOptions([]);
+    }
+  };
+
+  const submit = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    const request: VillageAbilityRequest = isDisturb
+      ? { footstep: disturbRooms.length === 0 ? NO_FOOTSTEP : disturbRooms.join(",") }
+      : isInvestigate
+        ? { footstep }
+        : {
+            attackerCharaId: isAttack && attackerCharaId !== "" ? Number(attackerCharaId) : null,
+            targetCharaId: targetCharaId === "" ? null : Number(targetCharaId),
+            footstep: footstep === "" ? null : footstep,
+          };
+    try {
+      await setVillageAbility(villageId, request);
+      await onDone();
+    } catch (e) {
+      setError(e instanceof ApiError ? e.detail : "能力セットに失敗しました");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const needsFootstepSelect = isAttack || ability.isTargetingAndFootstep;
+
+  return (
+    <Panel title="役職">
+      <div className="space-y-[10px] text-[12px]">
+        {error != null && <p className="text-[#e74c3c]">{error}</p>}
+        {ability.targetingMessage != null && <p>{ability.targetingMessage}</p>}
+
+        {ability.canUseAbility && isDisturb && (
+          <div>
+            <p>
+              任意の部屋からその直線上の部屋に向かって徘徊し、徘徊した部屋に足音を響かせることが可能です。
+              部屋を選択してセットしてください。徘徊しない場合は何も選択せずセットしてください。
+            </p>
+            {roomAssignedRows != null && (
+              <div className="mt-[10px] overflow-x-auto">
+                <table className="border-collapse border border-[#464545] text-[10.32px]">
+                  <tbody>
+                    {roomAssignedRows.map((row, rowIndex) => (
+                      <tr key={rowIndex}>
+                        {(row.roomAssignedList ?? []).map((room) => {
+                          const selected = disturbRooms.includes(room.roomNumber ?? "");
+                          return (
+                            <td
+                              key={room.roomNumber}
+                              className={`cursor-pointer border border-[#464545] p-[5px] text-center ${
+                                selected ? "bg-[#0ce3ac]/30" : ""
+                              }`}
+                              onClick={() =>
+                                setDisturbRooms((prev) =>
+                                  prev.includes(room.roomNumber ?? "")
+                                    ? prev.filter((r) => r !== room.roomNumber)
+                                    : [...prev, room.roomNumber ?? ""],
+                                )
+                              }
+                            >
+                              {room.roomNumber} {room.charaShortName ?? ""}
+                            </td>
+                          );
+                        })}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+            <p className="mt-[5px]">
+              通過する部屋: {disturbRooms.length === 0 ? NO_FOOTSTEP : disturbRooms.join(",")}
+            </p>
+          </div>
+        )}
+
+        {ability.canUseAbility && !isDisturb && isInvestigate && (
+          <div>
+            {footstepOptions.length === 0 ? (
+              <p>調査対象の足音がないため、本日は能力セットできません。</p>
+            ) : (
+              <div className="flex flex-wrap items-center gap-[5px]">
+                <select
+                  className={`${selectClass} max-w-[240px]`}
+                  value={footstep}
+                  onChange={(e) => setFootstep(e.target.value)}
+                  aria-label="調査する足音"
+                >
+                  <option value="">選択してください</option>
+                  {footstepOptions.map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </select>
+                <span>を調査する</span>
+              </div>
+            )}
+          </div>
+        )}
+
+        {ability.canUseAbility && !isDisturb && !isInvestigate && (
+          <div className="space-y-[10px]">
+            {isAttack && (
+              <div className="flex flex-wrap items-center gap-[5px]">
+                <span>襲撃者</span>
+                <select
+                  className={`${selectClass} max-w-[240px]`}
+                  value={attackerCharaId}
+                  onChange={(e) => onAttackerChange(e.target.value)}
+                  aria-label="襲撃者"
+                >
+                  {(ability.attackerList ?? []).map((attacker) => (
+                    <option key={attacker.charaId} value={attacker.charaId}>
+                      {attacker.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+            {(targets.length > 0 || ability.isAvailableNoTarget) && (
+              <div className="flex flex-wrap items-center gap-[5px]">
+                {ability.targetPrefix != null && <span>{ability.targetPrefix}</span>}
+                <select
+                  className={`${selectClass} max-w-[240px]`}
+                  value={targetCharaId}
+                  onChange={(e) => onTargetChange(e.target.value)}
+                  aria-label="能力の対象"
+                >
+                  {ability.isAvailableNoTarget && <option value="">なし</option>}
+                  {!ability.isAvailableNoTarget && <option value="">選択してください</option>}
+                  {targets.map((target) => (
+                    <option key={target.charaId} value={target.charaId}>
+                      {target.name}
+                    </option>
+                  ))}
+                </select>
+                {ability.targetSuffix != null && <span>{ability.targetSuffix}</span>}
+              </div>
+            )}
+            {needsFootstepSelect && (
+              <div className="flex flex-wrap items-center gap-[5px]">
+                <span>通過する部屋</span>
+                <select
+                  className={`${selectClass} max-w-[240px]`}
+                  value={footstep}
+                  onChange={(e) => setFootstep(e.target.value)}
+                  aria-label="通過する部屋"
+                >
+                  <option value="">選択してください</option>
+                  {footstepOptions.map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+          </div>
+        )}
+
+        {ability.canUseAbility && (
+          <div className="flex justify-end">
+            <Button
+              onClick={submit}
+              disabled={submitting || (isInvestigate && !isDisturb && footstepOptions.length === 0)}
+            >
+              能力セット
+            </Button>
+          </div>
+        )}
+
+        <FactionNotes ability={ability} />
+
+        {(ability.skillHistoryList ?? []).length > 0 && (
+          <div>
+            <hr className="my-[10px] border-[#464545]" />
+            <strong>能力セット履歴</strong>
+            {(ability.skillHistoryList ?? []).map((history, index) => (
+              <p key={index}>{history}</p>
+            ))}
+          </div>
+        )}
+      </div>
+    </Panel>
+  );
+}
+
+/** 自陣営の仲間名リスト (見える役職にのみ situation が値を返す)。 */
+function FactionNotes({ ability }: { ability: ParticipantSituationView["ability"] }) {
+  const notes: { key: string; text: string }[] = [];
+  if (ability.werewolfNames)
+    notes.push({ key: "wolf", text: `この村の人狼は、 ${ability.werewolfNames} です。` });
+  if (ability.cMadmanNames)
+    notes.push({ key: "cmad", text: `この村のC国狂人は、 ${ability.cMadmanNames} です。` });
+  if (ability.foxNames)
+    notes.push({ key: "fox", text: `この村の妖狐は、 ${ability.foxNames} です。` });
+  if (ability.masonsNames)
+    notes.push({ key: "mason", text: `この村の共鳴者は、 ${ability.masonsNames} です。` });
+  if (ability.listenMasonsNames)
+    notes.push({ key: "listen", text: `この村の共有者は、 ${ability.listenMasonsNames} です。` });
+  if (notes.length === 0 && !ability.loversNames) return null;
+  return (
+    <div>
+      <hr className="my-[10px] border-[#464545]" />
+      {notes.map((note) => (
+        <p key={note.key}>{note.text}</p>
+      ))}
+      {ability.loversNames && <p className="whitespace-pre-line">{ability.loversNames}</p>}
+    </div>
+  );
+}

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -35,6 +35,7 @@ import {
 } from "~/features/village/useVillage";
 import { ApiError } from "~/lib/api";
 import { siteMeta } from "~/lib/meta";
+import { AbilityPanel } from "./AbilityPanel";
 import { ActionPanel } from "./ActionPanel";
 import { AgeLimitModal } from "./AgeLimitModal";
 import { DayList } from "./DayList";
@@ -373,6 +374,15 @@ export default function Village({ params }: Route.ComponentProps) {
             mySituation={mySituation}
             participants={situation?.participantList ?? []}
             onConfirm={onActionConfirm}
+          />
+        )}
+
+        {mySituation != null && mySituation.ability.canUseAbility && (
+          <AbilityPanel
+            villageId={villageId}
+            mySituation={mySituation}
+            roomAssignedRows={situation?.roomAssignedRowList}
+            onDone={invalidate}
           />
         )}
 


### PR DESCRIPTION
closes .issues/step-8.9-village-ability.md

## 概要

役職能力のセットを REST + React 化。能力の入力パターン (襲撃 / 調査 / 徘徊 / 対象+足音 / 対象のみ) を situation/me の素材で出し分ける。base は `feature/monorepo-step8`。

## backend

- `ParticipantSituationView.AbilityView` を全面拡張: 対象/襲撃者候補・足音候補・現在セット値・説明文 (`targetingMessage`/`targetPrefix`/`targetSuffix`)・`isAvailableNoTarget`/`isTargetingAndFootstep`・能力セット履歴・陣営仲間名 (人狼/C国狂人/妖狐/恋人/共鳴者/共有者)。`MyselfView.skill` (調査・徘徊フラグ) 追加。マスクは既存 `ParticipantAbilitySituation` (domain) に委譲し二重実装しない
- `VillageAbilityRestController`: `POST /api/v1/villages/{id}/ability` (204) / `GET ability/attack-targets` / `GET ability/footsteps`。可否・対象妥当性の権威検証は既存 `VillageCoordinator.setAbility` (domain)
- `cMadmanNames` は 2 文字目大文字のため Jackson (`cmadmanNames`) と SpringDoc (`cMadmanNames`) で名前が割れ、spec に重複フィールドが出ていた → `@get:JsonProperty` で明示して解消

## frontend

- `AbilityPanel`: 襲撃 (襲撃者 select → 対象 select → 通過部屋 select、候補は API で連動取得) / 調査 (足音 select、候補なし時は文言 + ボタン無効) / 徘徊 (部屋トグルテーブルで CSV 組み立て、未選択=「なし」) / 対象+足音 / 対象のみ (「なし」許容)。陣営仲間名 + 能力セット履歴も表示。連打ガード + 完了で村系クエリ無効化
- 襲撃の対象候補・現在対象の足音候補は situation に含まれないため初期表示時に取得 (現在セット値が select に選択済みで出る)。襲撃者/対象変更時は足音をリセット (候補が変わるのに古い値を送って 400 になるのを防止)

## 検証

- REST 実測 (村 5): 人狼 testuser03 で situation/me の ability 全項目 → attack-targets → footsteps → POST 204 → セット反映を確認後、元の状態に復元。狩人 testuser06 で対象+足音パターン (護衛対象/を護衛する/footsteps) も確認。未認証 401 / 不正対象 400 (「選択できない対象を指定しています」)
- SPA 実 UI (村 5・人狼): 初期表示で現在セット値が選択済み、対象変更で足音候補が連動更新、能力セット POST 204 → 説明文反映
- e2e 2 件追加 (能力者を動的探索、いなければ skip / 再セットのみで共有 DB を変えない)。**全 63 件 green**
- backend ktlintCheck/test green。frontend typecheck/lint/format/build green。gen:api 差分込み

🤖 Generated with [Claude Code](https://claude.com/claude-code)