### PR TITLE
feat: 村画面の投票を REST + React 化 (step-8.10)

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/village/VillageVoteRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/VillageVoteRestController.kt
@@ -1,0 +1,47 @@
+package com.ort.app.api.village
+
+import com.ort.app.api.village.request.VillageVoteRequest
+import com.ort.app.application.coordinator.VillageCoordinator
+import com.ort.app.application.service.VillageService
+import com.ort.app.fw.exception.WolfMansionAuthException
+import com.ort.app.fw.exception.WolfMansionBusinessException
+import com.ort.app.fw.security.jwt.JwtPrincipal
+import io.swagger.v3.oas.annotations.Operation
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+
+/** 投票の REST。投票可否・対象妥当性は既存 VillageCoordinator.setVote (domain) が検証する。 */
+@RestController
+@RequestMapping("/api/v1/villages/{id}/vote")
+class VillageVoteRestController(
+    private val villageService: VillageService,
+    private val villageCoordinator: VillageCoordinator,
+) {
+    /** 投票をセットする。 */
+    @Operation(operationId = "setVillageVote")
+    @PostMapping
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun setVote(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+        @RequestBody @Valid request: VillageVoteRequest,
+    ) {
+        // principal は filter chain の authenticated() で保証済み (到達時は非 null)。防御的に確認する
+        principal ?: throw WolfMansionAuthException("ログインしてください")
+        val village =
+            villageService.findVillage(id)
+                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "village not found")
+        val myself =
+            villageService.findVillageParticipant(village.id, principal.name)
+                ?: throw WolfMansionBusinessException("村に参加していません")
+        villageCoordinator.setVote(village, myself, request.targetCharaId!!)
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/village/request/VillageVoteRequest.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/request/VillageVoteRequest.kt
@@ -1,0 +1,9 @@
+package com.ort.app.api.village.request
+
+import jakarta.validation.constraints.NotNull
+
+/** 投票セット。対象の妥当性は domain (VoteDomainService.assertVote) が検証する。 */
+data class VillageVoteRequest(
+    @field:NotNull
+    val targetCharaId: Int? = null,
+)

--- a/backend/src/main/kotlin/com/ort/app/api/village/response/ParticipantSituationView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/response/ParticipantSituationView.kt
@@ -9,6 +9,7 @@ import com.ort.app.domain.model.situation.participant.ParticipantAbilitySituatio
 import com.ort.app.domain.model.situation.participant.ParticipantSayMessageTypeSituation
 import com.ort.app.domain.model.situation.participant.ParticipantSayRestrictSituation
 import com.ort.app.domain.model.situation.participant.ParticipantSaySituation
+import com.ort.app.domain.model.situation.participant.ParticipantVoteSituation
 import com.ort.app.domain.model.skill.Skill
 import com.ort.app.domain.model.village.Village
 import com.ort.app.domain.model.village.participant.VillageParticipant
@@ -52,7 +53,7 @@ data class ParticipantSituationView(
                 canAddImage = situation.rp.canAddImage,
             ),
         ability = AbilityView(situation.ability, village),
-        vote = VoteView(canVote = situation.vote.canVote),
+        vote = VoteView(situation.vote),
         admin = AdminView(isAdmin = situation.admin.isAdmin),
         creator = CreatorView(situation),
     )
@@ -386,7 +387,20 @@ data class ParticipantSituationView(
     @Schema(name = "ParticipantSituationViewVote")
     data class VoteView(
         val canVote: Boolean,
-    )
+        /** 投票先の候補 */
+        val targetList: List<AbilityTargetView>,
+        /** 現在の投票先 */
+        val targetCharaId: Int?,
+        /** 現在の投票先の表示名 */
+        val targetName: String?,
+    ) {
+        constructor(vote: ParticipantVoteSituation) : this(
+            canVote = vote.canVote,
+            targetList = vote.targetList.map { AbilityTargetView(it) },
+            targetCharaId = vote.target?.charaId,
+            targetName = vote.target?.name(),
+        )
+    }
 
     @Schema(name = "ParticipantSituationViewAdmin")
     data class AdminView(

--- a/e2e/tests/village-vote.spec.ts
+++ b/e2e/tests/village-vote.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * 投票セットの e2e。投票できる参加者が必要なため、進行中の村と
+ * ローカル開発 DB のテストユーザー (testuser01〜16 / password=testuser) を
+ * 走査して投票可能者を動的に探し、見つからなければスキップする。
+ * 元の投票先に戻して終わるため共有 DB の進行状態を変えない。
+ */
+
+type SimpleVillage = { id: number; name: string };
+
+type VoteView = {
+  canVote: boolean;
+  targetList: { charaId: number; name: string }[];
+  targetCharaId: number | null;
+  targetName: string | null;
+};
+
+type Candidate = { villageId: number; userId: string; vote: VoteView };
+
+const CANDIDATE_USERS = Array.from(
+  { length: 16 },
+  (_, i) => `testuser${String(i + 1).padStart(2, "0")}`,
+);
+
+async function findVillages(page: Page, statuses: string[]): Promise<SimpleVillage[]> {
+  const query = statuses.map((s) => `status=${s}`).join("&");
+  const res = await page.request.get(`/wolf-mansion-api/api/v1/villages?${query}`);
+  expect(res.ok()).toBeTruthy();
+  const body = (await res.json()) as { villages: SimpleVillage[] };
+  return body.villages;
+}
+
+async function login(page: Page, userId: string): Promise<boolean> {
+  const res = await page.request.post(`/wolf-mansion-api/api/v1/auth/login`, {
+    data: { userId, password: "testuser" },
+  });
+  return res.ok();
+}
+
+async function findVoteCandidate(
+  page: Page,
+  filter: (vote: VoteView) => boolean,
+): Promise<Candidate | null> {
+  const villages = await findVillages(page, ["IN_PROGRESS"]);
+  if (villages.length === 0) return null;
+  for (const userId of CANDIDATE_USERS) {
+    if (!(await login(page, userId))) continue;
+    for (const village of villages) {
+      const res = await page.request.get(
+        `/wolf-mansion-api/api/v1/villages/${village.id}/situation/me`,
+      );
+      if (!res.ok()) continue;
+      const body = (await res.json()) as { vote: VoteView };
+      if (body.vote.canVote && filter(body.vote)) {
+        return { villageId: village.id, userId, vote: body.vote };
+      }
+    }
+  }
+  return null;
+}
+
+test("投票可能な参加者に投票パネルが表示される", async ({ page }) => {
+  const candidate = await findVoteCandidate(page, () => true);
+  test.skip(candidate == null, "投票できる参加者が見つからない DB のためスキップ");
+  if (candidate == null) return;
+
+  await page.goto(`village/${candidate.villageId}`);
+  await expect(page.getByRole("button", { name: "投票セット" })).toBeVisible({ timeout: 15000 });
+  await expect(
+    page.getByText(`現在の投票先: ${candidate.vote.targetName ?? "なし"}`),
+  ).toBeVisible();
+  // 未セットの場合は突然死の警告が出る
+  if (candidate.vote.targetCharaId == null) {
+    await expect(page.getByText("(未セットのままだと突然死します)")).toBeVisible();
+  }
+});
+
+test("投票先を変更してセットできる (元に戻して共有 DB の状態を変えない)", async ({ page }) => {
+  // 復元のためセット済みかつ候補 2 名以上の参加者に限定する
+  const candidate = await findVoteCandidate(
+    page,
+    (vote) => vote.targetCharaId != null && vote.targetList.length >= 2,
+  );
+  test.skip(candidate == null, "投票セット済みの参加者が見つからない DB のためスキップ");
+  if (candidate == null) return;
+
+  const original = candidate.vote.targetCharaId;
+  const another = candidate.vote.targetList.find((t) => t.charaId !== original);
+  expect(another).toBeTruthy();
+  if (another == null) return;
+
+  await page.goto(`village/${candidate.villageId}`);
+  await expect(page.getByRole("button", { name: "投票セット" })).toBeVisible({ timeout: 15000 });
+
+  await page.getByLabel("投票先").selectOption(String(another.charaId));
+  await page.getByRole("button", { name: "投票セット" }).click();
+  await expect(page.getByText(`現在の投票先: ${another.name}`)).toBeVisible({ timeout: 15000 });
+
+  // 元の投票先に戻す
+  await page.getByLabel("投票先").selectOption(String(original));
+  await page.getByRole("button", { name: "投票セット" }).click();
+  await expect(page.getByText(`現在の投票先: ${candidate.vote.targetName}`)).toBeVisible({
+    timeout: 15000,
+  });
+});

--- a/frontend/app/api/openapi.json
+++ b/frontend/app/api/openapi.json
@@ -1444,6 +1444,38 @@
         },
         "tags": ["village-rest-controller"]
       }
+    },
+    "/api/v1/villages/{id}/vote": {
+      "post": {
+        "operationId": "setVillageVote",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VillageVoteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": ["village-vote-rest-controller"]
+      }
     }
   },
   "components": {
@@ -2340,9 +2372,22 @@
         "properties": {
           "canVote": {
             "type": "boolean"
+          },
+          "targetCharaId": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          },
+          "targetList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParticipantSituationViewAbilityTarget"
+            }
+          },
+          "targetName": {
+            "type": ["string", "null"]
           }
         },
-        "required": ["canVote"]
+        "required": ["canVote", "targetList"]
       },
       "PasswordChangeRequest": {
         "type": "object",
@@ -4135,6 +4180,16 @@
           }
         },
         "required": ["maxVoteCount", "voteList"]
+      },
+      "VillageVoteRequest": {
+        "type": "object",
+        "properties": {
+          "targetCharaId": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          }
+        },
+        "required": ["targetCharaId"]
       },
       "WolfAllocation": {
         "type": "object",

--- a/frontend/app/api/types.ts
+++ b/frontend/app/api/types.ts
@@ -595,6 +595,22 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/villages/{id}/vote": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["setVillageVote"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -877,6 +893,10 @@ export interface components {
     };
     ParticipantSituationViewVote: {
       canVote: boolean;
+      /** Format: int32 */
+      targetCharaId?: number | null;
+      targetList: components["schemas"]["ParticipantSituationViewAbilityTarget"][];
+      targetName?: string | null;
     };
     PasswordChangeRequest: {
       confirmPassword: string | null;
@@ -1401,6 +1421,10 @@ export interface components {
       /** Format: int32 */
       maxVoteCount: number;
       voteList: components["schemas"]["VillageMemberVoteContent"][];
+    };
+    VillageVoteRequest: {
+      /** Format: int32 */
+      targetCharaId: number | null;
     };
     WolfAllocation: {
       /** Format: int32 */
@@ -2378,6 +2402,30 @@ export interface operations {
         content: {
           "*/*": components["schemas"]["VillageUpdateResponse"];
         };
+      };
+    };
+  };
+  setVillageVote: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["VillageVoteRequest"];
+      };
+    };
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
     };
   };

--- a/frontend/app/components/ui/Panel.tsx
+++ b/frontend/app/components/ui/Panel.tsx
@@ -2,13 +2,27 @@ import type { ReactNode } from "react";
 
 /**
  * タイトルバー付きのパネル (村画面のフォーム群など)。開閉が要る場合は
- * `CollapsiblePanel` を使う。
+ * `CollapsiblePanel` を使う。警告状態などでタイトルバーの見た目を変える場合は
+ * `headerClassName`、タイトル横の注記は `headerExtra` で指定する。
  */
-export function Panel({ title, children }: { title: string; children: ReactNode }) {
+export function Panel({
+  title,
+  headerClassName = "bg-[#464545]",
+  headerExtra,
+  children,
+}: {
+  title: string;
+  headerClassName?: string;
+  headerExtra?: ReactNode;
+  children: ReactNode;
+}) {
   return (
     <div className="mb-[20px] rounded border border-[#464545] bg-[#303030]">
-      <div className="rounded-t bg-[#464545] px-[15px] py-[10px]">
+      <div className={`rounded-t px-[15px] py-[10px] ${headerClassName}`}>
         <span className="text-[15px] text-white">{title}</span>
+        {headerExtra != null && (
+          <span className="ml-[5px] text-[12px] text-white">{headerExtra}</span>
+        )}
       </div>
       <div className="p-[15px]">{children}</div>
     </div>

--- a/frontend/app/features/village/api.ts
+++ b/frontend/app/features/village/api.ts
@@ -260,3 +260,11 @@ export function fetchAbilityFootsteps(
     `/api/v1/villages/${id}/ability/footsteps${query !== "" ? `?${query}` : ""}`,
   );
 }
+
+/** 投票セットのリクエスト。 */
+export type VillageVoteRequest = components["schemas"]["VillageVoteRequest"];
+
+/** 投票をセットする。要認証 → 204。 */
+export function setVillageVote(id: number, request: VillageVoteRequest): Promise<void> {
+  return apiFetch<void>(`/api/v1/villages/${id}/vote`, { method: "POST", body: request });
+}

--- a/frontend/app/routes/village/VotePanel.tsx
+++ b/frontend/app/routes/village/VotePanel.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+
+import { Button } from "~/components/ui/Button";
+import { selectClass } from "~/components/ui/Input";
+import { Panel } from "~/components/ui/Panel";
+import { setVillageVote, type ParticipantSituationView } from "~/features/village/api";
+import { ApiError } from "~/lib/api";
+
+/** 処刑対象への投票。未セットのまま日付が更新されると突然死するため警告を出す。 */
+export function VotePanel({
+  villageId,
+  mySituation,
+  onDone,
+}: {
+  villageId: number;
+  mySituation: ParticipantSituationView;
+  onDone: () => Promise<unknown>;
+}) {
+  const vote = mySituation.vote;
+  const [targetCharaId, setTargetCharaId] = useState<string>(
+    vote.targetCharaId != null ? String(vote.targetCharaId) : "",
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const submit = async () => {
+    if (submitting || targetCharaId === "") return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await setVillageVote(villageId, { targetCharaId: Number(targetCharaId) });
+      await onDone();
+    } catch (e) {
+      setError(e instanceof ApiError ? e.detail : "投票セットに失敗しました");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const isUnset = vote.targetCharaId == null;
+  return (
+    <Panel
+      title="投票"
+      headerClassName={isUnset ? "bg-[#ff0000]" : "bg-[#464545]"}
+      headerExtra={isUnset ? "(未セットのままだと突然死します)" : null}
+    >
+      <div className="space-y-[10px] text-[12px]">
+        {error != null && <p className="text-[#e74c3c]">{error}</p>}
+        <p>現在の投票先: {vote.targetName ?? "なし"}</p>
+        <hr className="border-[#464545]" />
+        <p>一番票を集めた人物が処刑されます。同数の場合はランダムで決定されます。</p>
+        <div className="flex flex-wrap items-center gap-[5px]">
+          <select
+            className={`${selectClass} max-w-[240px]`}
+            value={targetCharaId}
+            onChange={(e) => setTargetCharaId(e.target.value)}
+            aria-label="投票先"
+          >
+            {targetCharaId === "" && <option value="">選択してください</option>}
+            {(vote.targetList ?? []).map((target) => (
+              <option key={target.charaId} value={target.charaId}>
+                {target.name}
+              </option>
+            ))}
+          </select>
+          <span>に投票する</span>
+        </div>
+        <div className="flex justify-end">
+          <Button onClick={submit} disabled={submitting || targetCharaId === ""}>
+            投票セット
+          </Button>
+        </div>
+      </div>
+    </Panel>
+  );
+}

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -36,6 +36,7 @@ import {
 import { ApiError } from "~/lib/api";
 import { siteMeta } from "~/lib/meta";
 import { AbilityPanel } from "./AbilityPanel";
+import { VotePanel } from "./VotePanel";
 import { ActionPanel } from "./ActionPanel";
 import { AgeLimitModal } from "./AgeLimitModal";
 import { DayList } from "./DayList";
@@ -384,6 +385,10 @@ export default function Village({ params }: Route.ComponentProps) {
             roomAssignedRows={situation?.roomAssignedRowList}
             onDone={invalidate}
           />
+        )}
+
+        {mySituation != null && mySituation.vote.canVote && (
+          <VotePanel villageId={villageId} mySituation={mySituation} onDone={invalidate} />
         )}
 
         {mySituation != null &&

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -36,7 +36,6 @@ import {
 import { ApiError } from "~/lib/api";
 import { siteMeta } from "~/lib/meta";
 import { AbilityPanel } from "./AbilityPanel";
-import { VotePanel } from "./VotePanel";
 import { ActionPanel } from "./ActionPanel";
 import { AgeLimitModal } from "./AgeLimitModal";
 import { DayList } from "./DayList";
@@ -50,6 +49,7 @@ import { MessageCard } from "./MessageCard";
 import { SayPanel } from "./SayPanel";
 import { SituationPanel } from "./SituationPanel";
 import { useCountdown } from "./useCountdown";
+import { VotePanel } from "./VotePanel";
 import type { Route } from "./+types/route";
 
 export function meta(_: Route.MetaArgs) {


### PR DESCRIPTION
closes .issues/step-8.10-village-vote.md

## 概要

処刑対象への投票セットを REST + React 化 (village-vote.md が正本)。base は `feature/monorepo-step8`。

## backend

- `ParticipantSituationView.VoteView` を拡張: 投票候補 `targetList` (生存者・部屋番号順 = domain の並び)、現在の投票先 (`targetCharaId`/`targetName`)。素材は既存 `ParticipantVoteSituation` (domain) をそのまま map
- `VillageVoteRestController`: `POST /api/v1/villages/{id}/vote` (要認証 → 204)。投票可否・対象妥当性の権威検証は既存 `VillageCoordinator.setVote` → `VoteDomainService.assertVote` (domain)

## frontend

- `VotePanel`: 現在の投票先表示 + 投票先 select + 「に投票する」+ 投票セット。**未セット時はタイトルバーが赤背景 + 「(未セットのままだと突然死します)」** (legacy parity)。連打ガード + 完了で村系クエリ無効化
- `Panel` に `headerClassName` / `headerExtra` を追加 (警告状態のタイトルバー表現を component 側に持たせる)
- 未セット時の select は「選択してください」プレースホルダで明示選択を要求 (legacy は先頭候補がデフォルト選択されるが、誤投票防止のため意図的に変更)

## 検証

- REST 実測 (村 5・testuser03): situation/me の vote (candidates 15 名/現在先) → POST 204 → 反映 → 元に復元。未認証 401 / 投票不可対象 400 (「投票できない対象に投票しています」) / targetCharaId 欠落 400
- SPA 実 UI: 現在の投票先が select に選択済みで初期表示、変更 → セット → 「現在の投票先」反映 → 復元
- e2e 2 件追加 (投票可能者を動的探索、いなければ skip / 元に戻して共有 DB を変えない)。**全 65 件 green**
- backend ktlintCheck/test green。frontend typecheck/lint/format/build green。gen:api 差分込み

🤖 Generated with [Claude Code](https://claude.com/claude-code)