### PR TITLE
feat: 村画面のコミットを REST + React 化 (step-8.11)

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/village/VillageCommitRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/VillageCommitRestController.kt
@@ -1,0 +1,47 @@
+package com.ort.app.api.village
+
+import com.ort.app.api.village.request.VillageCommitRequest
+import com.ort.app.application.coordinator.VillageCoordinator
+import com.ort.app.application.service.VillageService
+import com.ort.app.fw.exception.WolfMansionAuthException
+import com.ort.app.fw.exception.WolfMansionBusinessException
+import com.ort.app.fw.security.jwt.JwtPrincipal
+import io.swagger.v3.oas.annotations.Operation
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+
+/** コミット (時間前の日付更新確定) の REST。可否は既存 VillageCoordinator.setCommit (domain) が検証する。 */
+@RestController
+@RequestMapping("/api/v1/villages/{id}/commit")
+class VillageCommitRestController(
+    private val villageService: VillageService,
+    private val villageCoordinator: VillageCoordinator,
+) {
+    /** コミットを ON/OFF する (トグル)。 */
+    @Operation(operationId = "setVillageCommit")
+    @PostMapping
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun setCommit(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+        @RequestBody @Valid request: VillageCommitRequest,
+    ) {
+        // principal は filter chain の authenticated() で保証済み (到達時は非 null)。防御的に確認する
+        principal ?: throw WolfMansionAuthException("ログインしてください")
+        val village =
+            villageService.findVillage(id)
+                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "village not found")
+        val myself =
+            villageService.findVillageParticipant(village.id, principal.name)
+                ?: throw WolfMansionBusinessException("村に参加していません")
+        villageCoordinator.setCommit(village, myself, request.commit!!)
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/village/request/VillageCommitRequest.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/request/VillageCommitRequest.kt
@@ -1,0 +1,12 @@
+package com.ort.app.api.village.request
+
+import jakarta.validation.constraints.NotNull
+
+/**
+ * コミットの ON/OFF。永続化はトグル (現在の状態を反転) で、[commit] は
+ * システムメッセージの文言 (コミットした / 取り消した) にのみ使われる。
+ */
+data class VillageCommitRequest(
+    @field:NotNull
+    val commit: Boolean? = null,
+)

--- a/e2e/tests/village-ability.spec.ts
+++ b/e2e/tests/village-ability.spec.ts
@@ -72,9 +72,12 @@ test("能力者で村画面を開くと役職パネルが表示される", async
   await page.goto(`village/${candidate.villageId}`);
   await expect(page.getByText("役職", { exact: true }).first()).toBeVisible({ timeout: 15000 });
 
-  // 現在のセット内容の説明文が出る (セット済みの場合)
+  // 現在のセット内容の説明文が出る (セット済みの場合)。「なし」等の短文は
+  // select の option などにも一致しうるため first で見る
   if (candidate.ability.targetingMessage != null) {
-    await expect(page.getByText(candidate.ability.targetingMessage)).toBeVisible();
+    await expect(
+      page.getByText(candidate.ability.targetingMessage, { exact: true }).first(),
+    ).toBeVisible();
   }
   // 人狼系なら仲間の名前が見える
   if (candidate.ability.werewolfNames !== "") {

--- a/e2e/tests/village-commit.spec.ts
+++ b/e2e/tests/village-commit.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * コミットの e2e。コミット可の村の参加者が必要なため、進行中の村と
+ * ローカル開発 DB のテストユーザー (testuser01〜16 / password=testuser) を
+ * 走査して動的に探し、見つからなければスキップする。
+ * ON → OFF と元に戻して終わるため共有 DB の進行状態を変えない
+ * (未コミットの参加者を選ぶので、自分のコミットで全員コミットが成立して
+ * 日付更新が走ることもない)。
+ */
+
+type SimpleVillage = { id: number; name: string };
+
+type CommitView = { isAvailableCommit: boolean; isCommitting: boolean };
+
+type Candidate = { villageId: number; userId: string; commit: CommitView };
+
+const CANDIDATE_USERS = Array.from(
+  { length: 16 },
+  (_, i) => `testuser${String(i + 1).padStart(2, "0")}`,
+);
+
+async function findVillages(page: Page, statuses: string[]): Promise<SimpleVillage[]> {
+  const query = statuses.map((s) => `status=${s}`).join("&");
+  const res = await page.request.get(`/wolf-mansion-api/api/v1/villages?${query}`);
+  expect(res.ok()).toBeTruthy();
+  const body = (await res.json()) as { villages: SimpleVillage[] };
+  return body.villages;
+}
+
+async function login(page: Page, userId: string): Promise<boolean> {
+  const res = await page.request.post(`/wolf-mansion-api/api/v1/auth/login`, {
+    data: { userId, password: "testuser" },
+  });
+  return res.ok();
+}
+
+async function findCommitCandidate(page: Page): Promise<Candidate | null> {
+  const villages = await findVillages(page, ["IN_PROGRESS"]);
+  if (villages.length === 0) return null;
+  for (const userId of CANDIDATE_USERS) {
+    if (!(await login(page, userId))) continue;
+    for (const village of villages) {
+      const res = await page.request.get(
+        `/wolf-mansion-api/api/v1/villages/${village.id}/situation/me`,
+      );
+      if (!res.ok()) continue;
+      const body = (await res.json()) as { commit: CommitView };
+      if (body.commit.isAvailableCommit && !body.commit.isCommitting) {
+        return { villageId: village.id, userId, commit: body.commit };
+      }
+    }
+  }
+  return null;
+}
+
+test("コミット可の村でコミット ON → OFF を切り替えられる", async ({ page }) => {
+  const candidate = await findCommitCandidate(page);
+  test.skip(candidate == null, "コミットできる参加者が見つからない DB のためスキップ");
+  if (candidate == null) return;
+
+  await page.goto(`village/${candidate.villageId}`);
+  const commitButton = page.getByRole("button", { name: "コミットする" });
+  await expect(commitButton).toBeVisible({ timeout: 15000 });
+
+  // 年齢制限村は確認モーダルが被るため閉じる
+  const ageLimitConfirm = page.getByRole("button", { name: "表示する" });
+  if ((await ageLimitConfirm.count()) > 0) {
+    await ageLimitConfirm.click();
+  }
+
+  await commitButton.click();
+  const cancelButton = page.getByRole("button", { name: "コミットを取り消す" });
+  await expect(cancelButton).toBeVisible({ timeout: 15000 });
+
+  // 元に戻して終わる
+  await cancelButton.click();
+  await expect(page.getByRole("button", { name: "コミットする" })).toBeVisible({
+    timeout: 15000,
+  });
+});

--- a/frontend/app/api/openapi.json
+++ b/frontend/app/api/openapi.json
@@ -813,6 +813,38 @@
         "tags": ["village-participate-rest-controller"]
       }
     },
+    "/api/v1/villages/{id}/commit": {
+      "post": {
+        "operationId": "setVillageCommit",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VillageCommitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": ["village-commit-rest-controller"]
+      }
+    },
     "/api/v1/villages/{id}/leave": {
       "post": {
         "operationId": "leaveVillage",
@@ -3027,6 +3059,15 @@
           }
         },
         "required": ["charachipIds", "dummyCharaId", "isOriginalCharachip"]
+      },
+      "VillageCommitRequest": {
+        "type": "object",
+        "properties": {
+          "commit": {
+            "type": ["boolean", "null"]
+          }
+        },
+        "required": ["commit"]
       },
       "VillageCreateRequest": {
         "type": "object",

--- a/frontend/app/api/types.ts
+++ b/frontend/app/api/types.ts
@@ -355,6 +355,22 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/villages/{id}/commit": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["setVillageCommit"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/villages/{id}/leave": {
     parameters: {
       query?: never;
@@ -1086,6 +1102,9 @@ export interface components {
       dummyCharaId: number;
       dummyDay1Message?: string | null;
       isOriginalCharachip: boolean;
+    };
+    VillageCommitRequest: {
+      commit: boolean | null;
     };
     VillageCreateRequest: {
       ageLimit?: string | null;
@@ -2028,6 +2047,30 @@ export interface operations {
     requestBody: {
       content: {
         "application/json": components["schemas"]["VillageChangeSkillRequest"];
+      };
+    };
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  setVillageCommit: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["VillageCommitRequest"];
       };
     };
     responses: {

--- a/frontend/app/features/village/api.ts
+++ b/frontend/app/features/village/api.ts
@@ -268,3 +268,11 @@ export type VillageVoteRequest = components["schemas"]["VillageVoteRequest"];
 export function setVillageVote(id: number, request: VillageVoteRequest): Promise<void> {
   return apiFetch<void>(`/api/v1/villages/${id}/vote`, { method: "POST", body: request });
 }
+
+/** コミット ON/OFF のリクエスト。 */
+export type VillageCommitRequest = components["schemas"]["VillageCommitRequest"];
+
+/** コミットを ON/OFF する。要認証 → 204。 */
+export function setVillageCommit(id: number, request: VillageCommitRequest): Promise<void> {
+  return apiFetch<void>(`/api/v1/villages/${id}/commit`, { method: "POST", body: request });
+}

--- a/frontend/app/routes/village/CommitPanel.tsx
+++ b/frontend/app/routes/village/CommitPanel.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+
+import { Button } from "~/components/ui/Button";
+import { Panel } from "~/components/ui/Panel";
+import { setVillageCommit, type ParticipantSituationView } from "~/features/village/api";
+import { ApiError } from "~/lib/api";
+
+/** コミット (全員が揃ったら時間前でも日付更新を確定) の ON/OFF。 */
+export function CommitPanel({
+  villageId,
+  mySituation,
+  onDone,
+}: {
+  villageId: number;
+  mySituation: ParticipantSituationView;
+  onDone: () => Promise<unknown>;
+}) {
+  const isCommitting = mySituation.commit.isCommitting;
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const submit = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await setVillageCommit(villageId, { commit: !isCommitting });
+      await onDone();
+    } catch (e) {
+      setError(e instanceof ApiError ? e.detail : "コミットに失敗しました");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Panel title="コミット">
+      <div className="space-y-[10px] text-[12px]">
+        {error != null && <p className="text-[#e74c3c]">{error}</p>}
+        <div className="flex justify-end">
+          <Button onClick={submit} disabled={submitting}>
+            {isCommitting ? "コミットを取り消す" : "コミットする"}
+          </Button>
+        </div>
+      </div>
+    </Panel>
+  );
+}

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -38,6 +38,7 @@ import { siteMeta } from "~/lib/meta";
 import { AbilityPanel } from "./AbilityPanel";
 import { ActionPanel } from "./ActionPanel";
 import { AgeLimitModal } from "./AgeLimitModal";
+import { CommitPanel } from "./CommitPanel";
 import { DayList } from "./DayList";
 import { FilterModal } from "./FilterModal";
 import { FooterMenu } from "./FooterMenu";
@@ -389,6 +390,10 @@ export default function Village({ params }: Route.ComponentProps) {
 
         {mySituation != null && mySituation.vote.canVote && (
           <VotePanel villageId={villageId} mySituation={mySituation} onDone={invalidate} />
+        )}
+
+        {mySituation != null && mySituation.commit.isAvailableCommit && (
+          <CommitPanel villageId={villageId} mySituation={mySituation} onDone={invalidate} />
         )}
 
         {mySituation != null &&


### PR DESCRIPTION
closes .issues/step-8.11-village-commit.md

## 概要

コミット (全員が揃ったら時間前でも日付更新を確定) の ON/OFF を REST + React 化 (village-commit.md が正本)。base は `feature/monorepo-step8`。

## backend

- `VillageCommitRestController`: `POST /api/v1/villages/{id}/commit` (要認証 → 204)。可否の権威検証は既存 `VillageCoordinator.setCommit` → `CommitDomainService.assertCommit` (domain)。永続化はトグル (現在状態を反転) で、`commit` boolean はシステムメッセージ文言にのみ使われる (SSR と同じ) — Request クラスのコメントに明記
- `ParticipantSituationView.CommitView` は既存の `isAvailableCommit`/`isCommitting` のままで足りるため変更なし

## frontend

- `CommitPanel`: `isCommitting` でボタン文言を「コミットする / コミットを取り消す」に切替 (legacy parity)。連打ガード + 完了で村系クエリ無効化

## 検証

- コミット可の村がローカル DB に無かったため、**検証用の村 6「step8 コミット動作確認用の村」を新規作成** (SPA 村作成 + 設定流用 + コミットあり) し、SSR debug メニュー (人数分入村 ×8 / 日付を進める ×2) で進行中 2 日目に
- REST 実測 (村 6・testuser01): ON 204 → `isCommitting: true` → OFF 204 → `false`。未認証 401 / コミット不可村 (村 5) 400 (「コミットできません」) / `commit` 欠落 400
- SPA 実 UI: ボタン文言の切替を両方向確認
- e2e 1 件追加 (コミット可の未コミット参加者を動的探索、いなければ skip / ON → OFF で元に戻す)。村 6 に流用で付いた R18 タグは年齢制限モーダルが既存 e2e を妨げるため除去。村 6 追加で 8.9 の ability spec が「なし」の短文 targetingMessage に遭遇し strict mode violation したため `exact + first` に堅牢化。**全 66 件 green**
- backend ktlintCheck/test green。frontend typecheck/lint/format/build green。gen:api 差分込み

🤖 Generated with [Claude Code](https://claude.com/claude-code)