### PR TITLE
feat: 村画面の名前変更・簡易メモを REST + React 化 (step-8.12)

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/village/VillageRpRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/VillageRpRestController.kt
@@ -1,0 +1,97 @@
+package com.ort.app.api.village
+
+import com.ort.app.api.village.request.VillageChangeNameRequest
+import com.ort.app.api.village.request.VillageMemoRequest
+import com.ort.app.application.coordinator.VillageCoordinator
+import com.ort.app.application.service.CharaService
+import com.ort.app.application.service.VillageService
+import com.ort.app.domain.model.village.Village
+import com.ort.app.domain.model.village.participant.VillageParticipant
+import com.ort.app.domain.service.RpDomainService
+import com.ort.app.fw.exception.WolfMansionAuthException
+import com.ort.app.fw.exception.WolfMansionBusinessException
+import com.ort.app.fw.security.jwt.JwtPrincipal
+import io.swagger.v3.oas.annotations.Operation
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+
+/**
+ * RP 支援 (名前変更・簡易メモ) の REST。SSR は表示制御のみで実行可否を検証していないため、
+ * RpDomainService の situation 変換を流用して可否をサーバ側でも検証する。
+ */
+@RestController
+@RequestMapping("/api/v1/villages/{id}")
+class VillageRpRestController(
+    private val villageService: VillageService,
+    private val charaService: CharaService,
+    private val villageCoordinator: VillageCoordinator,
+    private val rpDomainService: RpDomainService,
+) {
+    /** キャラ名・略称を変更する。 */
+    @Operation(operationId = "changeVillageCharaName")
+    @PostMapping("/change-name")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun changeName(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+        @RequestBody @Valid request: VillageChangeNameRequest,
+    ) {
+        val (village, myself) = resolveParticipant(principal, id)
+        if (!rpSituation(village, myself).isAvailableChangeName) {
+            throw WolfMansionBusinessException("名前を変更できません")
+        }
+        villageCoordinator.changeName(village, myself, request.name!!, request.shortName!!)
+    }
+
+    /** 簡易メモを変更する。 */
+    @Operation(operationId = "changeVillageMemo")
+    @PostMapping("/memo")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun changeMemo(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+        @RequestBody @Valid request: VillageMemoRequest,
+    ) {
+        val (village, myself) = resolveParticipant(principal, id)
+        if (!rpSituation(village, myself).isAvailableMemo) {
+            throw WolfMansionBusinessException("簡易メモを変更できません")
+        }
+        villageService.changeMemo(myself, request.memo!!)
+    }
+
+    private fun rpSituation(
+        village: Village,
+        myself: VillageParticipant,
+    ) = rpDomainService.convertToSituation(
+        village = village,
+        myself = myself,
+        charachips =
+            village.setting.chara.let {
+                charaService.findCharachips(it.charachipIds, it.isOriginalCharachip)
+            },
+        day = village.latestDay(),
+    )
+
+    private fun resolveParticipant(
+        principal: JwtPrincipal?,
+        villageId: Int,
+    ): Pair<Village, VillageParticipant> {
+        // principal は filter chain の authenticated() で保証済み (到達時は非 null)。防御的に確認する
+        principal ?: throw WolfMansionAuthException("ログインしてください")
+        val village =
+            villageService.findVillage(villageId)
+                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "village not found")
+        val myself =
+            villageService.findVillageParticipant(village.id, principal.name)
+                ?: throw WolfMansionBusinessException("村に参加していません")
+        return village to myself
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/village/request/VillageChangeNameRequest.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/request/VillageChangeNameRequest.kt
@@ -3,7 +3,7 @@ package com.ort.app.api.village.request
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 
-/** キャラ名・略称の変更。制約は SSR の VillageChangeNameForm と同じ。 */
+/** キャラ名・略称の変更。 */
 data class VillageChangeNameRequest(
     @field:NotBlank
     @field:Size(min = 1, max = 40)

--- a/backend/src/main/kotlin/com/ort/app/api/village/request/VillageChangeNameRequest.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/request/VillageChangeNameRequest.kt
@@ -1,0 +1,14 @@
+package com.ort.app.api.village.request
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+/** キャラ名・略称の変更。制約は SSR の VillageChangeNameForm と同じ。 */
+data class VillageChangeNameRequest(
+    @field:NotBlank
+    @field:Size(min = 1, max = 40)
+    val name: String? = null,
+    @field:NotBlank
+    @field:Size(min = 1, max = 1)
+    val shortName: String? = null,
+)

--- a/backend/src/main/kotlin/com/ort/app/api/village/request/VillageMemoRequest.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/request/VillageMemoRequest.kt
@@ -1,0 +1,11 @@
+package com.ort.app.api.village.request
+
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+
+/** 簡易メモの変更 (空文字でクリア)。参加者一覧に表示される公開情報。 */
+data class VillageMemoRequest(
+    @field:NotNull
+    @field:Size(max = 20)
+    val memo: String? = null,
+)

--- a/backend/src/main/kotlin/com/ort/app/api/village/response/ParticipantSituationView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/response/ParticipantSituationView.kt
@@ -6,6 +6,7 @@ import com.ort.app.domain.model.chara.CharaImage
 import com.ort.app.domain.model.chara.Charachip
 import com.ort.app.domain.model.situation.ParticipantSituation
 import com.ort.app.domain.model.situation.participant.ParticipantAbilitySituation
+import com.ort.app.domain.model.situation.participant.ParticipantRpSituation
 import com.ort.app.domain.model.situation.participant.ParticipantSayMessageTypeSituation
 import com.ort.app.domain.model.situation.participant.ParticipantSayRestrictSituation
 import com.ort.app.domain.model.situation.participant.ParticipantSaySituation
@@ -46,12 +47,7 @@ data class ParticipantSituationView(
                 isCommitting = situation.commit.isCommitting,
             ),
         say = SayView(situation.say),
-        rp =
-            RpView(
-                isAvailableChangeName = situation.rp.isAvailableChangeName,
-                isAvailableMemo = situation.rp.isAvailableMemo,
-                canAddImage = situation.rp.canAddImage,
-            ),
+        rp = RpView(situation.rp, situation.participate.myself),
         ability = AbilityView(situation.ability, village),
         vote = VoteView(situation.vote),
         admin = AdminView(isAdmin = situation.admin.isAdmin),
@@ -285,7 +281,22 @@ data class ParticipantSituationView(
         val isAvailableChangeName: Boolean,
         val isAvailableMemo: Boolean,
         val canAddImage: Boolean,
-    )
+        /** 現在のキャラ名 (部屋番号なしの生値。変更フォームの初期値) */
+        val name: String?,
+        /** 現在の略称 */
+        val shortName: String?,
+        /** 現在の簡易メモ (参加者一覧に表示される公開情報) */
+        val memo: String?,
+    ) {
+        constructor(rp: ParticipantRpSituation, myself: VillageParticipant?) : this(
+            isAvailableChangeName = rp.isAvailableChangeName,
+            isAvailableMemo = rp.isAvailableMemo,
+            canAddImage = rp.canAddImage,
+            name = myself?.charaName?.name,
+            shortName = myself?.charaName?.shortName,
+            memo = myself?.memo,
+        )
+    }
 
     @Schema(name = "ParticipantSituationViewAbility")
     data class AbilityView(

--- a/e2e/tests/village-rp.spec.ts
+++ b/e2e/tests/village-rp.spec.ts
@@ -111,10 +111,20 @@ test("キャラ名を変更できる (元に戻す)", async ({ page }) => {
   const testName = `${candidate.rp.name}改`;
   await nameInput.fill(testName);
   await page.getByRole("button", { name: "名前を変更する" }).click();
-  await expect(nameInput).toHaveValue(testName, { timeout: 15000 });
 
-  // 元に戻す
+  // 状況の参加者タブにサーバ反映された新しい名前が出る (ローカル state でなく round-trip を検証)
+  await page.getByRole("button", { name: "参加者" }).click();
+  await expect(page.getByText(testName).first()).toBeVisible({ timeout: 15000 });
+
+  // 元に戻す (変更履歴のシステムメッセージに旧名が残るため、復元はサーバ状態で検証する)
   await nameInput.fill(candidate.rp.name ?? "");
   await page.getByRole("button", { name: "名前を変更する" }).click();
-  await expect(nameInput).toHaveValue(candidate.rp.name ?? "", { timeout: 15000 });
+  await expect(async () => {
+    const res = await page.request.get(
+      `/wolf-mansion-api/api/v1/villages/${candidate.villageId}/situation/me`,
+    );
+    expect(res.ok()).toBeTruthy();
+    const body = (await res.json()) as { rp: RpView };
+    expect(body.rp.name).toBe(candidate.rp.name);
+  }).toPass({ timeout: 15000 });
 });

--- a/e2e/tests/village-rp.spec.ts
+++ b/e2e/tests/village-rp.spec.ts
@@ -1,0 +1,120 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * RP 支援 (名前変更・簡易メモ) の e2e。進行中の村の参加者を
+ * ローカル開発 DB のテストユーザー (testuser01〜16 / password=testuser) から
+ * 動的に探し、見つからなければスキップする。変更後は元の値に戻して終わるため
+ * 共有 DB の進行状態を変えない。
+ */
+
+type SimpleVillage = { id: number; name: string };
+
+type RpView = {
+  isAvailableChangeName: boolean;
+  isAvailableMemo: boolean;
+  name: string | null;
+  shortName: string | null;
+  memo: string | null;
+};
+
+type Candidate = { villageId: number; userId: string; rp: RpView };
+
+const CANDIDATE_USERS = Array.from(
+  { length: 16 },
+  (_, i) => `testuser${String(i + 1).padStart(2, "0")}`,
+);
+
+async function findVillages(page: Page, statuses: string[]): Promise<SimpleVillage[]> {
+  const query = statuses.map((s) => `status=${s}`).join("&");
+  const res = await page.request.get(`/wolf-mansion-api/api/v1/villages?${query}`);
+  expect(res.ok()).toBeTruthy();
+  const body = (await res.json()) as { villages: SimpleVillage[] };
+  return body.villages;
+}
+
+async function login(page: Page, userId: string): Promise<boolean> {
+  const res = await page.request.post(`/wolf-mansion-api/api/v1/auth/login`, {
+    data: { userId, password: "testuser" },
+  });
+  return res.ok();
+}
+
+async function findRpCandidate(
+  page: Page,
+  filter: (rp: RpView) => boolean,
+): Promise<Candidate | null> {
+  const villages = await findVillages(page, ["IN_PROGRESS"]);
+  if (villages.length === 0) return null;
+  for (const userId of CANDIDATE_USERS) {
+    if (!(await login(page, userId))) continue;
+    for (const village of villages) {
+      const res = await page.request.get(
+        `/wolf-mansion-api/api/v1/villages/${village.id}/situation/me`,
+      );
+      if (!res.ok()) continue;
+      const body = (await res.json()) as { rp: RpView };
+      if (filter(body.rp)) {
+        return { villageId: village.id, userId, rp: body.rp };
+      }
+    }
+  }
+  return null;
+}
+
+async function dismissAgeLimitModal(page: Page) {
+  const ageLimitConfirm = page.getByRole("button", { name: "表示する" });
+  if ((await ageLimitConfirm.count()) > 0) {
+    await ageLimitConfirm.click();
+  }
+}
+
+test("簡易メモを変更すると参加者一覧に表示される (元に戻す)", async ({ page }) => {
+  const candidate = await findRpCandidate(page, (rp) => rp.isAvailableMemo);
+  test.skip(candidate == null, "簡易メモを変更できる参加者が見つからない DB のためスキップ");
+  if (candidate == null) return;
+
+  await page.goto(`village/${candidate.villageId}`);
+  const memoInput = page.getByLabel("簡易メモ");
+  await expect(memoInput).toBeVisible({ timeout: 15000 });
+  await dismissAgeLimitModal(page);
+
+  const testMemo = "e2eメモ";
+  await memoInput.fill(testMemo);
+  await page.getByRole("button", { name: "簡易メモを変更する" }).click();
+
+  // 状況の参加者タブに [memo] が出る (公開情報)
+  await page.getByRole("button", { name: "参加者" }).click();
+  await expect(page.getByText(`[${testMemo}]`)).toBeVisible({ timeout: 15000 });
+
+  // 元に戻す
+  await memoInput.fill(candidate.rp.memo ?? "");
+  await page.getByRole("button", { name: "簡易メモを変更する" }).click();
+  await expect(page.getByText(`[${testMemo}]`)).toHaveCount(0, { timeout: 15000 });
+});
+
+test("キャラ名を変更できる (元に戻す)", async ({ page }) => {
+  const candidate = await findRpCandidate(
+    page,
+    (rp) => rp.isAvailableChangeName && rp.name != null && rp.shortName != null,
+  );
+  test.skip(candidate == null, "名前を変更できる参加者が見つからない DB のためスキップ");
+  if (candidate == null) return;
+
+  await page.goto(`village/${candidate.villageId}`);
+  const nameInput = page.getByLabel("名前", { exact: true });
+  await expect(nameInput).toBeVisible({ timeout: 15000 });
+  await dismissAgeLimitModal(page);
+
+  // 現在の名前が初期表示される
+  await expect(nameInput).toHaveValue(candidate.rp.name ?? "");
+
+  const testName = `${candidate.rp.name}改`;
+  await nameInput.fill(testName);
+  await page.getByRole("button", { name: "名前を変更する" }).click();
+  await expect(nameInput).toHaveValue(testName, { timeout: 15000 });
+
+  // 元に戻す
+  await nameInput.fill(candidate.rp.name ?? "");
+  await page.getByRole("button", { name: "名前を変更する" }).click();
+  await expect(nameInput).toHaveValue(candidate.rp.name ?? "", { timeout: 15000 });
+});

--- a/frontend/app/api/openapi.json
+++ b/frontend/app/api/openapi.json
@@ -781,6 +781,38 @@
         "tags": ["village-say-rest-controller"]
       }
     },
+    "/api/v1/villages/{id}/change-name": {
+      "post": {
+        "operationId": "changeVillageCharaName",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VillageChangeNameRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": ["village-rp-rest-controller"]
+      }
+    },
     "/api/v1/villages/{id}/change-skill": {
       "post": {
         "operationId": "changeVillageRequestSkill",
@@ -865,6 +897,38 @@
           }
         },
         "tags": ["village-participate-rest-controller"]
+      }
+    },
+    "/api/v1/villages/{id}/memo": {
+      "post": {
+        "operationId": "changeVillageMemo",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VillageMemoRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": ["village-rp-rest-controller"]
       }
     },
     "/api/v1/villages/{id}/messages": {
@@ -2267,6 +2331,15 @@
           },
           "isAvailableMemo": {
             "type": "boolean"
+          },
+          "memo": {
+            "type": ["string", "null"]
+          },
+          "name": {
+            "type": ["string", "null"]
+          },
+          "shortName": {
+            "type": ["string", "null"]
           }
         },
         "required": ["canAddImage", "isAvailableChangeName", "isAvailableMemo"]
@@ -3025,6 +3098,22 @@
         },
         "required": ["messageList"]
       },
+      "VillageChangeNameRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": ["string", "null"],
+            "maxLength": 40,
+            "minLength": 1
+          },
+          "shortName": {
+            "type": ["string", "null"],
+            "maxLength": 1,
+            "minLength": 1
+          }
+        },
+        "required": ["name", "shortName"]
+      },
       "VillageChangeSkillRequest": {
         "type": "object",
         "properties": {
@@ -3576,6 +3665,17 @@
           }
         },
         "required": ["charaName", "voteTargetList"]
+      },
+      "VillageMemoRequest": {
+        "type": "object",
+        "properties": {
+          "memo": {
+            "type": ["string", "null"],
+            "maxLength": 20,
+            "minLength": 0
+          }
+        },
+        "required": ["memo"]
       },
       "VillageMessageContent": {
         "type": "object",

--- a/frontend/app/api/types.ts
+++ b/frontend/app/api/types.ts
@@ -339,6 +339,22 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/villages/{id}/change-name": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["changeVillageCharaName"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/villages/{id}/change-skill": {
     parameters: {
       query?: never;
@@ -381,6 +397,22 @@ export interface paths {
     get?: never;
     put?: never;
     post: operations["leaveVillage"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/villages/{id}/memo": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["changeVillageMemo"];
     delete?: never;
     options?: never;
     head?: never;
@@ -864,6 +896,9 @@ export interface components {
       canAddImage: boolean;
       isAvailableChangeName: boolean;
       isAvailableMemo: boolean;
+      memo?: string | null;
+      name?: string | null;
+      shortName?: string | null;
     };
     ParticipantSituationViewSay: {
       defaultMessageTypeCode?: string | null;
@@ -1092,6 +1127,10 @@ export interface components {
     VillageAnchorMessagesContent: {
       messageList: components["schemas"]["VillageMessageContent"][];
     };
+    VillageChangeNameRequest: {
+      name: string | null;
+      shortName: string | null;
+    };
     VillageChangeSkillRequest: {
       requestedSkill: string | null;
       secondRequestedSkill: string | null;
@@ -1250,6 +1289,9 @@ export interface components {
     VillageMemberVoteContent: {
       charaName: string;
       voteTargetList: string[];
+    };
+    VillageMemoRequest: {
+      memo: string | null;
     };
     VillageMessageContent: {
       canReply: boolean;
@@ -2035,6 +2077,30 @@ export interface operations {
       };
     };
   };
+  changeVillageCharaName: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["VillageChangeNameRequest"];
+      };
+    };
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
   changeVillageRequestSkill: {
     parameters: {
       query?: never;
@@ -2093,6 +2159,30 @@ export interface operations {
       cookie?: never;
     };
     requestBody?: never;
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  changeVillageMemo: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["VillageMemoRequest"];
+      };
+    };
     responses: {
       /** @description No Content */
       204: {

--- a/frontend/app/features/village/api.ts
+++ b/frontend/app/features/village/api.ts
@@ -276,3 +276,21 @@ export type VillageCommitRequest = components["schemas"]["VillageCommitRequest"]
 export function setVillageCommit(id: number, request: VillageCommitRequest): Promise<void> {
   return apiFetch<void>(`/api/v1/villages/${id}/commit`, { method: "POST", body: request });
 }
+
+/** キャラ名・略称変更のリクエスト。 */
+export type VillageChangeNameRequest = components["schemas"]["VillageChangeNameRequest"];
+/** 簡易メモ変更のリクエスト。 */
+export type VillageMemoRequest = components["schemas"]["VillageMemoRequest"];
+
+/** キャラ名・略称を変更する。要認証 → 204。 */
+export function changeVillageCharaName(
+  id: number,
+  request: VillageChangeNameRequest,
+): Promise<void> {
+  return apiFetch<void>(`/api/v1/villages/${id}/change-name`, { method: "POST", body: request });
+}
+
+/** 簡易メモを変更する。要認証 → 204。 */
+export function changeVillageMemo(id: number, request: VillageMemoRequest): Promise<void> {
+  return apiFetch<void>(`/api/v1/villages/${id}/memo`, { method: "POST", body: request });
+}

--- a/frontend/app/routes/village/RpPanel.tsx
+++ b/frontend/app/routes/village/RpPanel.tsx
@@ -1,0 +1,158 @@
+import { useState } from "react";
+
+import { Button } from "~/components/ui/Button";
+import { inputClass } from "~/components/ui/Input";
+import { Panel } from "~/components/ui/Panel";
+import {
+  changeVillageCharaName,
+  changeVillageMemo,
+  type ParticipantSituationView,
+} from "~/features/village/api";
+import { ApiError } from "~/lib/api";
+
+/**
+ * RP 支援 (名前変更・簡易メモ)。簡易メモは参加者一覧に表示される公開情報で、
+ * 自分専用メモではない。
+ */
+export function RpPanel({
+  villageId,
+  mySituation,
+  onDone,
+}: {
+  villageId: number;
+  mySituation: ParticipantSituationView;
+  onDone: () => Promise<unknown>;
+}) {
+  const rp = mySituation.rp;
+  return (
+    <Panel title="名前変更・簡易メモ">
+      <div className="space-y-[15px] text-[12px]">
+        <ul className="list-disc space-y-[3px] rounded border border-[#f39c12] p-[10px] pl-[25px] text-[#f39c12]">
+          <li>進行中は、推理、まとめ、および推理に繋がる内容は記載しないでください。</li>
+          <li>簡易メモは状況欄の参加者一覧に表示されます。</li>
+          {!rp.isAvailableChangeName && (
+            <li>このキャラチップは制作者様の意向により名前変更ができません。</li>
+          )}
+        </ul>
+        {rp.isAvailableChangeName && (
+          <ChangeNameForm villageId={villageId} rp={rp} onDone={onDone} />
+        )}
+        {rp.isAvailableMemo && <MemoForm villageId={villageId} rp={rp} onDone={onDone} />}
+      </div>
+    </Panel>
+  );
+}
+
+function ChangeNameForm({
+  villageId,
+  rp,
+  onDone,
+}: {
+  villageId: number;
+  rp: ParticipantSituationView["rp"];
+  onDone: () => Promise<unknown>;
+}) {
+  const [name, setName] = useState(rp.name ?? "");
+  const [shortName, setShortName] = useState(rp.shortName ?? "");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const submit = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await changeVillageCharaName(villageId, { name, shortName });
+      await onDone();
+    } catch (e) {
+      setError(e instanceof ApiError ? e.detail : "名前の変更に失敗しました");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-[10px]">
+      <strong>名前変更</strong>
+      {error != null && <p className="text-[#e74c3c]">{error}</p>}
+      <label className="block">
+        略称
+        <input
+          type="text"
+          className={`${inputClass} mt-[5px]`}
+          value={shortName}
+          maxLength={1}
+          onChange={(e) => setShortName(e.target.value)}
+          aria-label="略称"
+        />
+      </label>
+      <label className="block">
+        名前
+        <input
+          type="text"
+          className={`${inputClass} mt-[5px]`}
+          value={name}
+          maxLength={40}
+          onChange={(e) => setName(e.target.value)}
+          aria-label="名前"
+        />
+      </label>
+      <div className="flex justify-end">
+        <Button onClick={submit} disabled={submitting || name === "" || shortName === ""}>
+          名前を変更する
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function MemoForm({
+  villageId,
+  rp,
+  onDone,
+}: {
+  villageId: number;
+  rp: ParticipantSituationView["rp"];
+  onDone: () => Promise<unknown>;
+}) {
+  const [memo, setMemo] = useState(rp.memo ?? "");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const submit = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await changeVillageMemo(villageId, { memo });
+      await onDone();
+    } catch (e) {
+      setError(e instanceof ApiError ? e.detail : "簡易メモの変更に失敗しました");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-[10px]">
+      <strong>簡易メモ変更</strong>
+      {error != null && <p className="text-[#e74c3c]">{error}</p>}
+      <label className="block">
+        簡易メモ
+        <input
+          type="text"
+          className={`${inputClass} mt-[5px]`}
+          value={memo}
+          maxLength={20}
+          onChange={(e) => setMemo(e.target.value)}
+          aria-label="簡易メモ"
+        />
+      </label>
+      <div className="flex justify-end">
+        <Button onClick={submit} disabled={submitting}>
+          簡易メモを変更する
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -47,6 +47,7 @@ import { ChangeSkillPanel, LeavePanel, SwitchParticipatePanel } from "./Particip
 import { ParticipatePanel } from "./ParticipatePanel";
 import { type ReplyDraft } from "./MessageCard";
 import { MessageCard } from "./MessageCard";
+import { RpPanel } from "./RpPanel";
 import { SayPanel } from "./SayPanel";
 import { SituationPanel } from "./SituationPanel";
 import { useCountdown } from "./useCountdown";
@@ -395,6 +396,11 @@ export default function Village({ params }: Route.ComponentProps) {
         {mySituation != null && mySituation.commit.isAvailableCommit && (
           <CommitPanel villageId={villageId} mySituation={mySituation} onDone={invalidate} />
         )}
+
+        {mySituation != null &&
+          (mySituation.rp.isAvailableChangeName || mySituation.rp.isAvailableMemo) && (
+            <RpPanel villageId={villageId} mySituation={mySituation} onDone={invalidate} />
+          )}
 
         {mySituation != null &&
           !mySituation.participate.isParticipating &&


### PR DESCRIPTION
closes .issues/step-8.12-village-rp.md

## 概要

RP 支援のうち名前変更・簡易メモを REST + React 化 (village-rp.md が正本)。**表情差分 (原画村限定の画像アップロード) は 8.12.1 として分割** (原画村フィクスチャが必要なため)。base は `feature/monorepo-step8`。

## backend

- `ParticipantSituationView.RpView` を拡張: 現在のキャラ名 (部屋番号なしの生値)・略称・簡易メモ (変更フォームの初期値用)
- `VillageRpRestController`: `POST /api/v1/villages/{id}/change-name` / `POST /memo` (いずれも要認証 → 204)。**SSR は表示制御のみで実行可否を検証していなかったため、`RpDomainService.convertToSituation` を流用してサーバ側でも可否を検証** (キャラチップ制作者の意向による名前変更不可などを API 層でも強制)
- 制約は SSR の Form と同じ (`name` 1〜40 / `shortName` 1 字 / `memo` 〜20、`@Size` で spec にも出す)

## frontend

- `RpPanel`「名前変更・簡易メモ」: 注意書き (推理禁止 / メモは参加者一覧に表示 / キャラチップ非対応時の文言) + 名前変更フォーム (現在値プリフィル) + 簡易メモフォーム。`isAvailableChangeName` / `isAvailableMemo` で個別出し分け。連打ガード + 完了で村系クエリ無効化

## 検証

- REST 実測 (村 6・testuser01): rp 拡張 (name/shortName/memo プリフィル) → change-name 204 → 反映 → 復元。memo 204 → **公開 situation の参加者一覧 (`memberList[].statusMemberList[].memo`) に反映** → クリア。未認証 401 / name 41 字 400 / shortName 2 字 400
- SPA 実 UI: プリフィル確認、メモ変更 → 参加者タブに `[メモ]` 表示 → クリア
- e2e 2 件追加 (動的探索 + 元に戻す自己完結)。auth.spec が並列実行で 1 回 flaky → 単独・再実行で pass。**全 68 件 green**
- backend ktlintCheck/test green。frontend typecheck/lint/format/build green。gen:api 差分込み

🤖 Generated with [Claude Code](https://claude.com/claude-code)