### PR TITLE
feat: 村画面のユーザー設定 (表示設定 + Discord 通知設定) を REST + React 化 (step-8.13)

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/village/VillageNotificationRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/VillageNotificationRestController.kt
@@ -1,0 +1,76 @@
+package com.ort.app.api.village
+
+import com.ort.app.api.village.request.VillageNotificationRequest
+import com.ort.app.application.service.NotificationService
+import com.ort.app.application.service.VillageService
+import com.ort.app.domain.model.village.participant.VillageParticipantNotificationCondition
+import com.ort.app.fw.exception.WolfMansionAuthException
+import com.ort.app.fw.exception.WolfMansionBusinessException
+import com.ort.app.fw.security.jwt.JwtPrincipal
+import io.swagger.v3.oas.annotations.Operation
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+
+/** Discord 通知設定の REST。保存後に webhook へテスト通知を送る (失敗しても保存は成立)。 */
+@RestController
+@RequestMapping("/api/v1/villages/{id}/notification-setting")
+class VillageNotificationRestController(
+    private val villageService: VillageService,
+    private val notificationService: NotificationService,
+) {
+    /** 通知設定を保存する。 */
+    @Operation(operationId = "saveVillageNotificationSetting")
+    @PostMapping
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun save(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+        @RequestBody @Valid request: VillageNotificationRequest,
+    ) {
+        // principal は filter chain の authenticated() で保証済み (到達時は非 null)。防御的に確認する
+        principal ?: throw WolfMansionAuthException("ログインしてください")
+        val village =
+            villageService.findVillage(id)
+                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "village not found")
+        val myself =
+            villageService.findVillageParticipant(village.id, principal.name)
+                ?: throw WolfMansionBusinessException("村に参加していません")
+
+        villageService.registerNotification(
+            myself.copy(
+                notification =
+                    VillageParticipantNotificationCondition(
+                        discordWebhookUrl = request.webhookUrl!!,
+                        village =
+                            VillageParticipantNotificationCondition.VillageCondition(
+                                start = request.villageStart ?: false,
+                                dayChange = request.villageDaychange ?: false,
+                                epilogue = request.villageEpilogue ?: false,
+                            ),
+                        message =
+                            VillageParticipantNotificationCondition.MessageCondition(
+                                secretSay = request.secretSay ?: false,
+                                abilitySay = request.abilitySay ?: false,
+                                anchor = request.anchorSay ?: false,
+                                keywords =
+                                    request.keyword
+                                        ?.trim()
+                                        ?.replace("　", " ")
+                                        ?.split(" ")
+                                        ?.filter { it.isNotEmpty() }
+                                        ?: emptyList(),
+                            ),
+                    ),
+            ),
+        )
+        notificationService.notifyTest(request.webhookUrl, village.id)
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/village/VillageNotificationRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/VillageNotificationRestController.kt
@@ -43,12 +43,13 @@ class VillageNotificationRestController(
         val myself =
             villageService.findVillageParticipant(village.id, principal.name)
                 ?: throw WolfMansionBusinessException("村に参加していません")
+        val webhookUrl = request.webhookUrl!!
 
         villageService.registerNotification(
             myself.copy(
                 notification =
                     VillageParticipantNotificationCondition(
-                        discordWebhookUrl = request.webhookUrl!!,
+                        discordWebhookUrl = webhookUrl,
                         village =
                             VillageParticipantNotificationCondition.VillageCondition(
                                 start = request.villageStart ?: false,
@@ -71,6 +72,6 @@ class VillageNotificationRestController(
                     ),
             ),
         )
-        notificationService.notifyTest(request.webhookUrl, village.id)
+        notificationService.notifyTest(webhookUrl, village.id)
     }
 }

--- a/backend/src/main/kotlin/com/ort/app/api/village/request/VillageNotificationRequest.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/request/VillageNotificationRequest.kt
@@ -1,0 +1,25 @@
+package com.ort.app.api.village.request
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+/** Discord 通知設定の保存。保存時に webhook へテスト通知を送る。 */
+data class VillageNotificationRequest(
+    @field:NotBlank
+    val webhookUrl: String? = null,
+    /** 村が開始したら通知 */
+    val villageStart: Boolean? = null,
+    /** 日付更新で通知 */
+    val villageDaychange: Boolean? = null,
+    /** エピローグを迎えたら通知 */
+    val villageEpilogue: Boolean? = null,
+    /** 新着秘話で通知 */
+    val secretSay: Boolean? = null,
+    /** 新着役職窓発言で通知 */
+    val abilitySay: Boolean? = null,
+    /** 自分宛アンカーで通知 */
+    val anchorSay: Boolean? = null,
+    /** キーワード通知 (スペース区切り) */
+    @field:Size(max = 30)
+    val keyword: String? = null,
+)

--- a/backend/src/main/kotlin/com/ort/app/api/village/response/ParticipantSituationView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/response/ParticipantSituationView.kt
@@ -14,6 +14,7 @@ import com.ort.app.domain.model.situation.participant.ParticipantVoteSituation
 import com.ort.app.domain.model.skill.Skill
 import com.ort.app.domain.model.village.Village
 import com.ort.app.domain.model.village.participant.VillageParticipant
+import com.ort.app.domain.model.village.participant.VillageParticipantNotificationCondition
 import io.swagger.v3.oas.annotations.media.Schema
 
 /**
@@ -65,6 +66,8 @@ data class ParticipantSituationView(
         val isSpectator: Boolean,
         /** Discord 通知キーワード (スペース区切り、未設定は null)。発言抽出のショートカットが使う */
         val notificationKeyword: String?,
+        /** Discord 通知設定 (本人にのみ返る。未設定は null)。設定フォームの初期値用 */
+        val notification: MyselfNotificationView?,
         /** 自分の役職 (本人にのみ返る。未割当は null) */
         val skill: MyselfSkillView?,
     ) {
@@ -81,7 +84,32 @@ data class ParticipantSituationView(
                     ?.keywords
                     ?.takeIf { it.isNotEmpty() }
                     ?.joinToString(separator = " "),
+            notification = myself.notification?.let { MyselfNotificationView(it) },
             skill = myself.skill?.let { MyselfSkillView(it) },
+        )
+    }
+
+    @Schema(name = "ParticipantSituationViewMyselfNotification")
+    data class MyselfNotificationView(
+        val webhookUrl: String,
+        val villageStart: Boolean,
+        val villageDaychange: Boolean,
+        val villageEpilogue: Boolean,
+        val secretSay: Boolean,
+        val abilitySay: Boolean,
+        val anchorSay: Boolean,
+        /** キーワード (スペース区切り) */
+        val keyword: String,
+    ) {
+        constructor(notification: VillageParticipantNotificationCondition) : this(
+            webhookUrl = notification.discordWebhookUrl,
+            villageStart = notification.village.start,
+            villageDaychange = notification.village.dayChange,
+            villageEpilogue = notification.village.epilogue,
+            secretSay = notification.message.secretSay,
+            abilitySay = notification.message.abilitySay,
+            anchorSay = notification.message.anchor,
+            keyword = notification.message.keywords.joinToString(" "),
         )
     }
 

--- a/e2e/tests/village-settings.spec.ts
+++ b/e2e/tests/village-settings.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * 設定モーダル (表示設定 / Discord 通知設定) の e2e。
+ * 表示設定はブラウザ保存 (localStorage) のため DB を変更しない。
+ * 通知設定はサーバ保存のため保存はせず、参加者にフォームが出ることまでを確認する。
+ */
+
+type SimpleVillage = { id: number; name: string };
+
+const CANDIDATE_USERS = Array.from(
+  { length: 16 },
+  (_, i) => `testuser${String(i + 1).padStart(2, "0")}`,
+);
+
+async function findVillages(page: Page, statuses: string[]): Promise<SimpleVillage[]> {
+  const query = statuses.map((s) => `status=${s}`).join("&");
+  const res = await page.request.get(`/wolf-mansion-api/api/v1/villages?${query}`);
+  expect(res.ok()).toBeTruthy();
+  const body = (await res.json()) as { villages: SimpleVillage[] };
+  return body.villages;
+}
+
+async function login(page: Page, userId: string): Promise<boolean> {
+  const res = await page.request.post(`/wolf-mansion-api/api/v1/auth/login`, {
+    data: { userId, password: "testuser" },
+  });
+  return res.ok();
+}
+
+/** 村に参加している (myself が返る) ユーザーと村の組を探す。 */
+async function findParticipant(
+  page: Page,
+): Promise<{ villageId: number; userId: string } | null> {
+  const villages = await findVillages(page, ["IN_PROGRESS"]);
+  if (villages.length === 0) return null;
+  for (const userId of CANDIDATE_USERS) {
+    if (!(await login(page, userId))) continue;
+    for (const village of villages) {
+      const res = await page.request.get(
+        `/wolf-mansion-api/api/v1/villages/${village.id}/situation/me`,
+      );
+      if (!res.ok()) continue;
+      const body = (await res.json()) as { myself: unknown };
+      if (body.myself != null) return { villageId: village.id, userId };
+    }
+  }
+  return null;
+}
+
+async function dismissAgeLimitModal(page: Page) {
+  const ageLimitConfirm = page.getByRole("button", { name: "表示する", exact: true });
+  if ((await ageLimitConfirm.count()) > 0) {
+    await ageLimitConfirm.click();
+  }
+}
+
+test("設定モーダルで表示設定を変更でき、ブラウザに保存される", async ({ page }) => {
+  const villages = await findVillages(page, ["IN_PROGRESS", "IN_PREPARATION"]);
+  test.skip(villages.length === 0, "村が無い DB のためスキップ");
+  const village = villages[0];
+
+  await page.goto(`village/${village.id}`);
+  await expect(page.getByRole("button", { name: "設定" })).toBeVisible({ timeout: 15000 });
+  await dismissAgeLimitModal(page);
+  await page.getByRole("button", { name: "設定" }).click();
+
+  const dialog = page.getByRole("dialog", { name: "設定" });
+  await expect(dialog.getByRole("heading", { name: "表示設定", exact: true })).toBeVisible();
+
+  // ページサイズ変更が保存される
+  await dialog.getByLabel("ページあたりの表示発言数").selectOption("10");
+  const stored = await page.evaluate(() =>
+    localStorage.getItem("wolf-mansion-display-settings"),
+  );
+  expect(stored).toContain('"pageSize":10');
+
+  // リセットでデフォルト (50) に戻る
+  await dialog.getByRole("button", { name: "リセット" }).click();
+  const reset = await page.evaluate(() => localStorage.getItem("wolf-mansion-display-settings"));
+  expect(reset).toContain('"pageSize":50');
+
+  // 未ログイン or 未参加では Discord 通知設定が出ない (このテストは未ログイン)
+  await expect(dialog.getByText("Discord通知設定")).toHaveCount(0);
+
+  await dialog.getByRole("button", { name: "閉じる", exact: true }).last().click();
+  await expect(dialog).toHaveCount(0);
+});
+
+test("参加者の設定モーダルには Discord 通知設定が表示される", async ({ page }) => {
+  const candidate = await findParticipant(page);
+  test.skip(candidate == null, "進行中の村の参加者が見つからない DB のためスキップ");
+  if (candidate == null) return;
+
+  await page.goto(`village/${candidate.villageId}`);
+  await expect(page.getByRole("button", { name: "設定" })).toBeVisible({ timeout: 15000 });
+  await dismissAgeLimitModal(page);
+  await page.getByRole("button", { name: "設定" }).click();
+
+  const dialog = page.getByRole("dialog", { name: "設定" });
+  await expect(dialog.getByText("Discord通知設定")).toBeVisible();
+  // webhookUrl が空のうちは保存できない (誤送信防止)
+  await expect(dialog.getByRole("button", { name: "保存" })).toBeDisabled();
+  await dialog.getByLabel("WebhookURL").fill("https://discord.com/api/webhooks/x/y");
+  await expect(dialog.getByRole("button", { name: "保存" })).toBeEnabled();
+});

--- a/frontend/app/api/openapi.json
+++ b/frontend/app/api/openapi.json
@@ -1212,6 +1212,38 @@
         "tags": ["village-message-rest-controller"]
       }
     },
+    "/api/v1/villages/{id}/notification-setting": {
+      "post": {
+        "operationId": "saveVillageNotificationSetting",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VillageNotificationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": ["village-notification-rest-controller"]
+      }
+    },
     "/api/v1/villages/{id}/participants": {
       "get": {
         "operationId": "getVillageParticipants",
@@ -2203,6 +2235,16 @@
           "name": {
             "type": "string"
           },
+          "notification": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ParticipantSituationViewMyselfNotification"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "notificationKeyword": {
             "type": ["string", "null"]
           },
@@ -2221,6 +2263,45 @@
           }
         },
         "required": ["charaId", "id", "isDead", "isSpectator", "name", "shortName"]
+      },
+      "ParticipantSituationViewMyselfNotification": {
+        "type": "object",
+        "properties": {
+          "abilitySay": {
+            "type": "boolean"
+          },
+          "anchorSay": {
+            "type": "boolean"
+          },
+          "keyword": {
+            "type": "string"
+          },
+          "secretSay": {
+            "type": "boolean"
+          },
+          "villageDaychange": {
+            "type": "boolean"
+          },
+          "villageEpilogue": {
+            "type": "boolean"
+          },
+          "villageStart": {
+            "type": "boolean"
+          },
+          "webhookUrl": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "abilitySay",
+          "anchorSay",
+          "keyword",
+          "secretSay",
+          "villageDaychange",
+          "villageEpilogue",
+          "villageStart",
+          "webhookUrl"
+        ]
       },
       "ParticipantSituationViewMyselfSkill": {
         "type": "object",
@@ -3812,6 +3893,39 @@
           "messageList",
           "pageNumList"
         ]
+      },
+      "VillageNotificationRequest": {
+        "type": "object",
+        "properties": {
+          "abilitySay": {
+            "type": ["boolean", "null"]
+          },
+          "anchorSay": {
+            "type": ["boolean", "null"]
+          },
+          "keyword": {
+            "type": ["string", "null"],
+            "maxLength": 30,
+            "minLength": 0
+          },
+          "secretSay": {
+            "type": ["boolean", "null"]
+          },
+          "villageDaychange": {
+            "type": ["boolean", "null"]
+          },
+          "villageEpilogue": {
+            "type": ["boolean", "null"]
+          },
+          "villageStart": {
+            "type": ["boolean", "null"]
+          },
+          "webhookUrl": {
+            "type": ["string", "null"],
+            "minLength": 1
+          }
+        },
+        "required": ["webhookUrl"]
       },
       "VillageOrganize": {
         "type": "object",

--- a/frontend/app/api/types.ts
+++ b/frontend/app/api/types.ts
@@ -483,6 +483,22 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/villages/{id}/notification-setting": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["saveVillageNotificationSetting"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/villages/{id}/participants": {
     parameters: {
       query?: never;
@@ -857,9 +873,20 @@ export interface components {
       isDead: boolean;
       isSpectator: boolean;
       name: string;
+      notification?: components["schemas"]["ParticipantSituationViewMyselfNotification"] | null;
       notificationKeyword?: string | null;
       shortName: string;
       skill?: components["schemas"]["ParticipantSituationViewMyselfSkill"] | null;
+    };
+    ParticipantSituationViewMyselfNotification: {
+      abilitySay: boolean;
+      anchorSay: boolean;
+      keyword: string;
+      secretSay: boolean;
+      villageDaychange: boolean;
+      villageEpilogue: boolean;
+      villageStart: boolean;
+      webhookUrl: string;
     };
     ParticipantSituationViewMyselfSkill: {
       code: string;
@@ -1334,6 +1361,16 @@ export interface components {
       pageNumList: number[];
       suddenlyDeathMessage?: string | null;
       villageStatusMessage?: string | null;
+    };
+    VillageNotificationRequest: {
+      abilitySay?: boolean | null;
+      anchorSay?: boolean | null;
+      keyword?: string | null;
+      secretSay?: boolean | null;
+      villageDaychange?: boolean | null;
+      villageEpilogue?: boolean | null;
+      villageStart?: boolean | null;
+      webhookUrl: string | null;
     };
     VillageOrganize: {
       fixedOrganization: string;
@@ -2299,6 +2336,30 @@ export interface operations {
         content: {
           "*/*": components["schemas"]["VillageLatestMessageDatetimeContent"];
         };
+      };
+    };
+  };
+  saveVillageNotificationSetting: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["VillageNotificationRequest"];
+      };
+    };
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
     };
   };

--- a/frontend/app/features/village/api.ts
+++ b/frontend/app/features/village/api.ts
@@ -294,3 +294,17 @@ export function changeVillageCharaName(
 export function changeVillageMemo(id: number, request: VillageMemoRequest): Promise<void> {
   return apiFetch<void>(`/api/v1/villages/${id}/memo`, { method: "POST", body: request });
 }
+
+/** Discord 通知設定のリクエスト。 */
+export type VillageNotificationRequest = components["schemas"]["VillageNotificationRequest"];
+
+/** Discord 通知設定を保存する (保存時にテスト通知が届く)。要認証 → 204。 */
+export function saveVillageNotificationSetting(
+  id: number,
+  request: VillageNotificationRequest,
+): Promise<void> {
+  return apiFetch<void>(`/api/v1/villages/${id}/notification-setting`, {
+    method: "POST",
+    body: request,
+  });
+}

--- a/frontend/app/features/village/displaySettings.ts
+++ b/frontend/app/features/village/displaySettings.ts
@@ -1,0 +1,53 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export const PAGE_SIZE_OPTIONS = [10, 20, 30, 50, 100, 200, 300, 500] as const;
+
+export type DisplaySettings = {
+  /** 発言ログをページ分割する */
+  isPaging: boolean;
+  /** ページあたりの表示発言数 */
+  pageSize: number;
+  /** 更新検知時に自動で読み込む (最新ページ表示中のみ) */
+  autoReload: boolean;
+  /** 発言フォームに文字装飾ボタンを表示する */
+  showDecorationButtons: boolean;
+  /** 発言の画像を大きく表示する */
+  largeImage: boolean;
+  /** 発言の文字を大きく表示する */
+  largeText: boolean;
+};
+
+/** 文字サイズだけは画面サイズで初期値を変える (小さい画面で大きい文字は崩れるため)。 */
+function defaultLargeText(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.matchMedia("(min-width: 1024px)").matches;
+}
+
+function defaults(): DisplaySettings {
+  return {
+    isPaging: true,
+    pageSize: 50,
+    autoReload: true,
+    showDecorationButtons: true,
+    largeImage: false,
+    largeText: defaultLargeText(),
+  };
+}
+
+type DisplaySettingsStore = DisplaySettings & {
+  update: (settings: Partial<DisplaySettings>) => void;
+  reset: () => void;
+};
+
+/** 村画面の表示設定。サーバには持たずブラウザ (localStorage) に保存する。 */
+export const useDisplaySettings = create<DisplaySettingsStore>()(
+  persist(
+    (set) => ({
+      ...defaults(),
+      update: (settings) => set(settings),
+      reset: () => set(defaults()),
+    }),
+    { name: "wolf-mansion-display-settings" },
+  ),
+);

--- a/frontend/app/routes/village/FooterMenu.tsx
+++ b/frontend/app/routes/village/FooterMenu.tsx
@@ -41,7 +41,7 @@ function MenuButton({
 }
 
 /**
- * 画面下部に固定表示する操作メニュー。抽出 / 情報 / 設定はそれぞれのモーダル実装までは
+ * 画面下部に固定表示する操作メニュー。情報はモーダル実装までは
  * 無効状態で出す (ボタン構成は最終形を保つ)。新着発言を検知したら更新アイコンを点滅させる。
  */
 export function FooterMenu({
@@ -49,6 +49,7 @@ export function FooterMenu({
   hasNewMessage = false,
   onFilter,
   filtering = false,
+  onSettings,
 }: {
   onRefresh: () => void;
   hasNewMessage?: boolean;
@@ -56,6 +57,8 @@ export function FooterMenu({
   onFilter?: () => void;
   /** 抽出条件が適用中か (ボタンを「抽出中」のアクティブ表示にする) */
   filtering?: boolean;
+  /** 設定モーダルを開く。 */
+  onSettings?: () => void;
 }) {
   const iconClass = "h-[14px] w-[14px]";
   const gotoTop = () => window.scrollTo({ top: 0 });
@@ -90,7 +93,12 @@ export function FooterMenu({
           active={filtering}
         />
         <MenuButton icon={<InformationCircleIcon className={iconClass} />} label="情報" disabled />
-        <MenuButton icon={<Cog6ToothIcon className={iconClass} />} label="設定" disabled />
+        <MenuButton
+          icon={<Cog6ToothIcon className={iconClass} />}
+          label="設定"
+          onClick={onSettings}
+          disabled={onSettings == null}
+        />
       </div>
     </div>
   );

--- a/frontend/app/routes/village/MessageArea.tsx
+++ b/frontend/app/routes/village/MessageArea.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 
 import { MESSAGE_STYLES } from "~/components/ui/messageStyles";
 import type { VillageMessageListContent } from "~/features/village/api";
+import { useDisplaySettings } from "~/features/village/displaySettings";
 import { EMPTY_FILTER, type MessageFilter } from "~/features/village/filter";
 import { useVillageMessages } from "~/features/village/useMessages";
 import { MessageCard, type ReplyDraft } from "./MessageCard";
@@ -52,19 +53,22 @@ export function MessageArea({
     d == null ? { pageNum: 1, isDispLatest: true } : { pageNum: 1, isDispLatest: false };
   const [page, setPage] = useState<PageState>(() => initialPage(day));
 
-  // 日付遷移・抽出条件の変更で先頭ページに戻す (絞り込み後に存在しないページを引かないため)
+  const isPaging = useDisplaySettings((s) => s.isPaging);
+  const pageSize = useDisplaySettings((s) => s.pageSize);
+
+  // 日付遷移・抽出条件・ページ設定の変更で先頭ページに戻す (存在しないページを引かないため)
   const filterKey = JSON.stringify(filter);
   useEffect(() => {
     setPage(initialPage(day));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [day, filterKey]);
+  }, [day, filterKey, isPaging, pageSize]);
 
   const { data, isLoading } = useVillageMessages(villageId, {
     day,
-    pageSize: 30,
-    pageNum: page.isDispLatest ? undefined : page.pageNum,
-    isPaging: true,
-    isDispLatest: page.isDispLatest,
+    pageSize: isPaging ? pageSize : undefined,
+    pageNum: isPaging && !page.isDispLatest ? page.pageNum : undefined,
+    isPaging,
+    isDispLatest: isPaging ? page.isDispLatest : undefined,
     participantIds: filter.participantIds.length > 0 ? filter.participantIds : undefined,
     toParticipantIds: filter.toParticipantIds.length > 0 ? filter.toParticipantIds : undefined,
     types: filter.types.length > 0 ? filter.types : undefined,

--- a/frontend/app/routes/village/MessageCard.tsx
+++ b/frontend/app/routes/village/MessageCard.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router";
 
 import { DEFAULT_MESSAGE_STYLE, MESSAGE_STYLES } from "~/components/ui/messageStyles";
 import { fetchAnchorMessage, type VillageMessageContent } from "~/features/village/api";
+import { useDisplaySettings } from "~/features/village/displaySettings";
 import { formatMessageTime, replaceIdLink, toMessageHtml } from "./messageHtml";
 import { ParticipantsTable } from "./ParticipantsTable";
 
@@ -122,6 +123,8 @@ export function MessageCard({
   onSecret?: (reply: ReplyDraft) => void;
 }) {
   const [expandedAnchors, setExpandedAnchors] = useState<ExpandedAnchor[]>([]);
+  const largeImage = useDisplaySettings((s) => s.largeImage);
+  const imageScale = largeImage ? 2 : 1;
 
   const html = useMemo(() => {
     const converted = toMessageHtml(
@@ -192,6 +195,7 @@ export function MessageCard({
     copyAnchor,
     villageId,
     spoiled,
+    imageScale,
     onReply,
     onSecret,
   );
@@ -235,6 +239,7 @@ function renderBody(
   copyAnchor: (text: string) => void,
   villageId: number,
   spoiled: boolean,
+  imageScale: number,
   onReply?: (reply: ReplyDraft) => void,
   onSecret?: (reply: ReplyDraft) => void,
 ) {
@@ -298,8 +303,8 @@ function renderBody(
             {message.characterImageUrl != null && (
               <img
                 src={message.characterImageUrl}
-                width={message.width ?? undefined}
-                height={message.height ?? undefined}
+                width={message.width != null ? message.width * imageScale : undefined}
+                height={message.height != null ? message.height * imageScale : undefined}
                 alt={message.characterName ?? ""}
               />
             )}

--- a/frontend/app/routes/village/SayPanel.tsx
+++ b/frontend/app/routes/village/SayPanel.tsx
@@ -9,6 +9,7 @@ import type {
   VillageDetailView,
   VillageSayRequest,
 } from "~/features/village/api";
+import { useDisplaySettings } from "~/features/village/displaySettings";
 import { MessageCard, type ReplyDraft } from "./MessageCard";
 export type { ReplyDraft };
 
@@ -92,6 +93,7 @@ export function SayPanel({
 }) {
   const say = mySituation.say;
   const myself = mySituation.myself;
+  const showDecorationButtons = useDisplaySettings((s) => s.showDecorationButtons);
   const selectable = say.selectableMessageTypeList ?? [];
   const images = say.selectableCharaImageList ?? [];
 
@@ -263,8 +265,12 @@ export function SayPanel({
           </div>
         )}
 
-        {/* 装飾タグ・ランダム機能 */}
-        <div className="mt-[10px] flex flex-wrap items-center gap-[5px]">
+        {/* 装飾タグ・ランダム機能 (表示設定でまとめて非表示にできる) */}
+        <div
+          className={`mt-[10px] flex-wrap items-center gap-[5px] ${
+            showDecorationButtons ? "flex" : "hidden"
+          }`}
+        >
           {DECORATION_TAGS.map((tag) => (
             <button
               key={tag.name}

--- a/frontend/app/routes/village/SettingsModal.tsx
+++ b/frontend/app/routes/village/SettingsModal.tsx
@@ -1,0 +1,266 @@
+import { useState, type ReactNode } from "react";
+
+import { Button } from "~/components/ui/Button";
+import { inputClass, selectClass } from "~/components/ui/Input";
+import { Modal } from "~/components/ui/Modal";
+import {
+  saveVillageNotificationSetting,
+  type ParticipantSituationView,
+} from "~/features/village/api";
+import { PAGE_SIZE_OPTIONS, useDisplaySettings } from "~/features/village/displaySettings";
+import { ApiError } from "~/lib/api";
+
+function SettingRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex flex-wrap items-start gap-[10px]">
+      <span className="w-[140px] shrink-0 pt-[2px] text-right font-bold">{label}</span>
+      <div className="min-w-[200px] flex-1">{children}</div>
+    </div>
+  );
+}
+
+function CheckRow({
+  label,
+  checked,
+  onChange,
+  text,
+  note,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (value: boolean) => void;
+  text: string;
+  note?: string;
+}) {
+  return (
+    <SettingRow label={label}>
+      <label className="flex cursor-pointer items-center gap-[5px]">
+        <input type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} />
+        {text}
+      </label>
+      {note != null && <p className="mt-[3px] text-[10.32px] text-gray-400">{note}</p>}
+    </SettingRow>
+  );
+}
+
+function SectionTitle({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <hr className="my-[15px] border-[#464545]" />
+      <h5 className="mb-[10px] text-[14px] font-bold">{children}</h5>
+    </>
+  );
+}
+
+/** 表示設定 (ブラウザ保存) と Discord 通知設定 (サーバ保存)。footer-menu の「設定」から開く。 */
+export function SettingsModal({
+  open,
+  onClose,
+  villageId,
+  mySituation,
+}: {
+  open: boolean;
+  onClose: () => void;
+  villageId: number;
+  mySituation: ParticipantSituationView | null | undefined;
+}) {
+  const settings = useDisplaySettings();
+
+  return (
+    <Modal open={open} onClose={onClose} title="設定">
+      <div className="space-y-[10px] p-[15px] text-[12px]">
+        <h4 className="text-[16px] font-bold">表示設定</h4>
+        <SectionTitle>ページ分割</SectionTitle>
+        <CheckRow
+          label="ページ分割"
+          checked={settings.isPaging}
+          onChange={(isPaging) => settings.update({ isPaging })}
+          text="ページ分割する"
+        />
+        <SettingRow label="ページあたりの表示発言数">
+          <select
+            className={`${selectClass} max-w-[120px]`}
+            value={settings.pageSize}
+            onChange={(e) => settings.update({ pageSize: Number(e.target.value) })}
+            aria-label="ページあたりの表示発言数"
+          >
+            {PAGE_SIZE_OPTIONS.map((size) => (
+              <option key={size} value={size}>
+                {size}
+              </option>
+            ))}
+          </select>
+        </SettingRow>
+        <SectionTitle>更新通知</SectionTitle>
+        <CheckRow
+          label="自動更新"
+          checked={settings.autoReload}
+          onChange={(autoReload) => settings.update({ autoReload })}
+          text="更新検知時自動で読み込む"
+          note="最新ページにいる時に更新を検知したら自動で更新します。"
+        />
+        <SectionTitle>便利機能</SectionTitle>
+        <CheckRow
+          label="文字装飾ボタン"
+          checked={settings.showDecorationButtons}
+          onChange={(showDecorationButtons) => settings.update({ showDecorationButtons })}
+          text="表示する"
+        />
+        <SectionTitle>発言表示</SectionTitle>
+        <CheckRow
+          label="画像の大きさ"
+          checked={settings.largeImage}
+          onChange={(largeImage) => settings.update({ largeImage })}
+          text="画像を大きく表示する"
+        />
+        <CheckRow
+          label="文字の大きさ"
+          checked={settings.largeText}
+          onChange={(largeText) => settings.update({ largeText })}
+          text="文字を大きく表示する"
+        />
+        <SectionTitle>表示設定のリセット</SectionTitle>
+        <div className="flex justify-end">
+          <Button variant="danger" onClick={() => settings.reset()}>
+            リセット
+          </Button>
+        </div>
+
+        {mySituation?.myself != null && (
+          <NotificationSection villageId={villageId} mySituation={mySituation} />
+        )}
+
+        <hr className="my-[15px] border-[#464545]" />
+        <div className="flex justify-end">
+          <Button variant="info" onClick={onClose}>
+            閉じる
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function NotificationSection({
+  villageId,
+  mySituation,
+}: {
+  villageId: number;
+  mySituation: ParticipantSituationView;
+}) {
+  const current = mySituation.myself?.notification;
+  const [webhookUrl, setWebhookUrl] = useState(current?.webhookUrl ?? "");
+  const [villageStart, setVillageStart] = useState(current?.villageStart ?? false);
+  const [villageDaychange, setVillageDaychange] = useState(current?.villageDaychange ?? false);
+  const [villageEpilogue, setVillageEpilogue] = useState(current?.villageEpilogue ?? false);
+  const [secretSay, setSecretSay] = useState(current?.secretSay ?? false);
+  const [anchorSay, setAnchorSay] = useState(current?.anchorSay ?? false);
+  const [abilitySay, setAbilitySay] = useState(current?.abilitySay ?? false);
+  const [keyword, setKeyword] = useState(current?.keyword ?? "");
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const submit = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    setSaved(false);
+    try {
+      await saveVillageNotificationSetting(villageId, {
+        webhookUrl,
+        villageStart,
+        villageDaychange,
+        villageEpilogue,
+        secretSay,
+        anchorSay,
+        abilitySay,
+        keyword,
+      });
+      setSaved(true);
+    } catch (e) {
+      setError(e instanceof ApiError ? e.detail : "通知設定の保存に失敗しました");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-[10px]">
+      <hr className="my-[15px] border-[#464545]" />
+      <h4 className="text-[16px] font-bold">Discord通知設定</h4>
+      {error != null && <p className="text-[#e74c3c]">{error}</p>}
+      {saved && <p className="text-[#00bc8c]">保存しました。テスト通知を確認してください。</p>}
+      <SettingRow label="WebhookURL">
+        <input
+          type="text"
+          className={inputClass}
+          value={webhookUrl}
+          onChange={(e) => setWebhookUrl(e.target.value)}
+          aria-label="WebhookURL"
+        />
+      </SettingRow>
+      <CheckRow
+        label=""
+        checked={villageStart}
+        onChange={setVillageStart}
+        text="開始通知"
+        note="進行中に遷移した際に通知します。"
+      />
+      <CheckRow
+        label=""
+        checked={villageDaychange}
+        onChange={setVillageDaychange}
+        text="日付更新通知"
+        note="日付が更新された際に通知します。"
+      />
+      <CheckRow
+        label=""
+        checked={villageEpilogue}
+        onChange={setVillageEpilogue}
+        text="エピローグ通知"
+        note="エピローグに遷移した際に通知します。"
+      />
+      <CheckRow
+        label=""
+        checked={secretSay}
+        onChange={setSecretSay}
+        text="秘話通知"
+        note="秘話を受け取った際に通知します。"
+      />
+      <CheckRow
+        label=""
+        checked={anchorSay}
+        onChange={setAnchorSay}
+        text="アンカー通知"
+        note="あなたの発言がアンカー指定された際に通知します（梟視点の場合は通知されません）。"
+      />
+      <CheckRow
+        label=""
+        checked={abilitySay}
+        onChange={setAbilitySay}
+        text="役職窓通知"
+        note="役職窓発言を受け取った際に通知します（梟視点の場合は通知されません）。"
+      />
+      <SettingRow label="キーワード（スペース区切り、計30文字まで）">
+        <input
+          type="text"
+          className={inputClass}
+          value={keyword}
+          maxLength={30}
+          onChange={(e) => setKeyword(e.target.value)}
+          aria-label="通知キーワード"
+        />
+        <p className="mt-[3px] text-[10.32px] text-gray-400">
+          指定したキーワードが含まれる発言を受け取った際に通知します（梟視点の場合は通知されません）。
+        </p>
+      </SettingRow>
+      <div className="flex items-center justify-end gap-[10px]">
+        <span className="text-[10.32px] text-gray-400">保存するとテスト通知が届きます。</span>
+        <Button onClick={submit} disabled={submitting || webhookUrl.trim() === ""}>
+          保存
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -18,6 +18,7 @@ import {
   type VillageParticipateRequest,
   type VillageSayRequest,
 } from "~/features/village/api";
+import { useDisplaySettings } from "~/features/village/displaySettings";
 import {
   applyFilterToParams,
   EMPTY_FILTER,
@@ -49,6 +50,7 @@ import { type ReplyDraft } from "./MessageCard";
 import { MessageCard } from "./MessageCard";
 import { RpPanel } from "./RpPanel";
 import { SayPanel } from "./SayPanel";
+import { SettingsModal } from "./SettingsModal";
 import { SituationPanel } from "./SituationPanel";
 import { useCountdown } from "./useCountdown";
 import { VotePanel } from "./VotePanel";
@@ -141,6 +143,7 @@ export default function Village({ params }: Route.ComponentProps) {
   const [searchParams, setSearchParams] = useSearchParams();
   const filter = parseFilter(searchParams);
   const [filterOpen, setFilterOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const applyFilter = (next: MessageFilter) =>
     setSearchParams(applyFilterToParams(searchParams, next));
   const applyFilterNewTab = (next: MessageFilter) => {
@@ -254,6 +257,13 @@ export default function Village({ params }: Route.ComponentProps) {
     loadedMessages?.latestMessageDatetime,
     latestDay != null && currentDay === latestDay,
   );
+  // 自動更新設定が ON なら、新着検知時に更新ボタンを押すのと同じ再読み込みを行う
+  const autoReload = useDisplaySettings((s) => s.autoReload);
+  const largeText = useDisplaySettings((s) => s.largeText);
+  useEffect(() => {
+    if (hasNewMessage && autoReload) void invalidate();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasNewMessage, autoReload]);
   // ログイン中のはずなのに認証が立て直せない (refresh 失敗) 場合は再ログインを促す
   const sessionExpired =
     me != null && mySituationError instanceof ApiError && mySituationError.status === 401;
@@ -290,7 +300,7 @@ export default function Village({ params }: Route.ComponentProps) {
 
   return (
     <PageLayout noAd={noAd}>
-      <div className="px-[15px] pb-[45px]">
+      <div className={`px-[15px] pb-[45px] ${largeText ? "text-[150%]" : ""}`}>
         {/* 村タイトル */}
         <div className="flex">
           <h1 className="my-[10.5px] flex-1 text-[15px] font-normal">
@@ -458,6 +468,13 @@ export default function Village({ params }: Route.ComponentProps) {
         hasNewMessage={hasNewMessage}
         onFilter={() => setFilterOpen(true)}
         filtering={isFiltering(filter)}
+        onSettings={() => setSettingsOpen(true)}
+      />
+      <SettingsModal
+        open={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+        villageId={villageId}
+        mySituation={mySituation}
       />
       <FilterModal
         open={filterOpen}


### PR DESCRIPTION
closes .issues/step-8.13-village-user-settings.md

## 概要

footer-menu「設定」から開くユーザー設定モーダルを実装 (village-user-settings.md が正本)。**表示設定はブラウザ保存 (localStorage + zustand persist、API なし)**、**Discord 通知設定はサーバ保存 (REST)** の 2 セクション構成。base は `feature/monorepo-step8`。

## backend

- `VillageNotificationRestController`: `POST /api/v1/villages/{id}/notification-setting` (要認証 → 204)。SSR と同じく `villageService.registerNotification` + 保存後の `notifyTest` (webhook へのテスト通知。送信失敗しても保存は成立)
- `MyselfView.notification` 追加 (webhookUrl + 各通知フラグ + keyword、設定フォームの初期値用。本人にのみ返る)。既存の `notificationKeyword` (抽出ショートカット用) は維持
- キーワードは SSR と同じ正規化 (全角スペース→半角・分割) + 空要素除去

## frontend

- `displaySettings.ts`: zustand persist の表示設定 store。**移行ドキュメント確定のデフォルト値** (ページ分割する/50、自動更新 ON、文字装飾ボタン表示、画像大 off、**文字大は lg 以上で on のレスポンシブ初期値**)。localStorage に保存値があればそれを優先
- `SettingsModal`: 表示設定 (ページ分割/表示発言数 10〜500/自動更新/文字装飾ボタン/画像・文字の大きさ/リセット) + Discord 通知設定 (参加者のみ表示、webhookUrl 空は保存不可)
- 設定の反映先: `MessageArea` (pageSize/isPaging、変更時はページリセット) / `MessageCard` (画像 ×2、アンカー展開にも適用) / `SayPanel` (装飾ボタン行の表示) / `route.tsx` (文字 150% / **自動更新 = 新着検知時に更新ボタンと同じ invalidate**)
- `FooterMenu` の「設定」を有効化

## 検証

- REST 実測 (村 6・testuser01): 保存前 null → 保存 204 → situation/me の `myself.notification` に全項目反映 (keyword 正規化込み) → 検証データは掃除済み。webhookUrl 空 400 / 未認証 401 / keyword 31 字 400
- SPA 実 UI: モーダル全項目描画、ページサイズ変更で `pageSize=10` の即時再取得、ページ分割 OFF で `isPaging=false`、localStorage 永続化、リセットでデフォルト復帰、webhookUrl 空で保存ボタン無効
- e2e 2 件追加 (表示設定はブラウザ保存のため DB 非汚染 / 通知設定はフォーム表示までで保存しない)。**全 70 件 green**
- backend ktlintCheck/test green。frontend typecheck/lint/format/build green。gen:api 差分込み

🤖 Generated with [Claude Code](https://claude.com/claude-code)