### PR TITLE
feat: 村画面の村建て機能を REST + React 化 (step-8.15)

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/view/village/VillageFilterParticipantContent.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/view/village/VillageFilterParticipantContent.kt
@@ -6,6 +6,8 @@ import com.ort.app.domain.model.village.participant.VillageParticipant
 
 data class VillageFilterParticipantContent(
     val id: Int,
+    /** キャラ ID (強制退村など参加者をキャラで指定する操作に使う) */
+    val charaId: Int,
     val name: String,
     val imgWidth: Int,
     val imgHeight: Int,
@@ -18,6 +20,7 @@ data class VillageFilterParticipantContent(
         charachips: Charachips,
     ) : this(
         id = participant.id,
+        charaId = participant.charaId,
         name = participant.name(),
         imgWidth = charachips.chara(participant.charaId).size.width,
         imgHeight = charachips.chara(participant.charaId).size.height,

--- a/backend/src/main/kotlin/com/ort/app/api/village/VillageCreatorRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/VillageCreatorRestController.kt
@@ -95,6 +95,10 @@ class VillageCreatorRestController(
         val village = resolveCreatorVillage(principal, id)
         // プロローグ以外では退村画面が表示されないが、サーバ側でも状態を検証する
         if (!village.status.isPrologue()) throw WolfMansionBusinessException("プロローグ中でなければ強制退村できません")
+        // 不参加キャラの指定は coordinator 内で NoSuchElementException (500) になるため先に検証する
+        if (village.allParticipants(excludeDummy = true).list.none { it.charaId == request.charaId }) {
+            throw WolfMansionBusinessException("村に参加していないキャラクターです")
+        }
         creatorCoordinator.kick(id, request.charaId!!)
     }
 

--- a/backend/src/main/kotlin/com/ort/app/api/village/VillageCreatorRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/VillageCreatorRestController.kt
@@ -1,0 +1,167 @@
+package com.ort.app.api.village
+
+import com.ort.app.api.request.VillageSayForm
+import com.ort.app.api.request.validator.CreatorSayFormValidator
+import com.ort.app.api.view.VillageSayConfirmContent
+import com.ort.app.api.village.request.VillageCreatorSayRequest
+import com.ort.app.api.village.request.VillageKickRequest
+import com.ort.app.application.coordinator.CreatorCoordinator
+import com.ort.app.application.service.CharaService
+import com.ort.app.application.service.RandomKeywordService
+import com.ort.app.application.service.VillageService
+import com.ort.app.domain.model.village.Village
+import com.ort.app.domain.service.MessageDomainService
+import com.ort.app.fw.exception.WolfMansionAuthException
+import com.ort.app.fw.exception.WolfMansionBusinessException
+import com.ort.app.fw.exception.WolfMansionValidationException
+import com.ort.app.fw.exception.WolfMansionValidationException.FieldErrorItem
+import com.ort.app.fw.security.jwt.JwtPrincipal
+import com.ort.dbflute.allcommon.CDef
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.context.MessageSource
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.validation.BeanPropertyBindingResult
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+import java.util.Locale
+
+/** 村建て (creator) 機能の REST。権限検証は resolveCreatorVillage で一元化する。 */
+@RestController
+@RequestMapping("/api/v1/villages/{id}/creator")
+class VillageCreatorRestController(
+    private val villageService: VillageService,
+    private val creatorCoordinator: CreatorCoordinator,
+    private val charaService: CharaService,
+    private val randomKeywordService: RandomKeywordService,
+    private val messageDomainService: MessageDomainService,
+    private val creatorSayFormValidator: CreatorSayFormValidator,
+    private val messageSource: MessageSource,
+) {
+    /** 村建て発言の確認 (プレビュー)。表示用に整形済みの発言を返す (まだ保存しない)。 */
+    @Operation(operationId = "confirmVillageCreatorSay")
+    @PostMapping("/say-confirm")
+    fun confirm(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+        @RequestBody @Validated request: VillageCreatorSayRequest,
+    ): VillageSayConfirmContent {
+        val village = resolveCreatorVillage(principal, id)
+        validate(request)
+        val message = messageDomainService.createCreatorMessage(village, request.message!!, request.convertDisable ?: false)
+        val charas =
+            village.setting.chara.let {
+                charaService.findCharachips(it.charachipIds, it.isOriginalCharachip).charas()
+            }
+        return VillageSayConfirmContent(
+            village = village,
+            message = message,
+            fromParticipant = null,
+            player = null,
+            charas = charas,
+            keywords = randomKeywordService.findRandomKeywords(),
+        )
+    }
+
+    /** 村建て発言する。 */
+    @Operation(operationId = "sayVillageCreator")
+    @PostMapping("/say")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun say(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+        @RequestBody @Validated request: VillageCreatorSayRequest,
+    ) {
+        resolveCreatorVillage(principal, id)
+        validate(request)
+        creatorCoordinator.say(id, request.message!!, request.convertDisable ?: false)
+    }
+
+    /** 強制退村 (プロローグ中のみ)。 */
+    @Operation(operationId = "kickVillageParticipant")
+    @PostMapping("/kick")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun kick(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+        @RequestBody @Validated request: VillageKickRequest,
+    ) {
+        val village = resolveCreatorVillage(principal, id)
+        // プロローグ以外では退村画面が表示されないが、サーバ側でも状態を検証する
+        if (!village.status.isPrologue()) throw WolfMansionBusinessException("プロローグ中でなければ強制退村できません")
+        creatorCoordinator.kick(id, request.charaId!!)
+    }
+
+    /** 廃村。可否は CreatorCoordinator (domain) が検証する。 */
+    @Operation(operationId = "cancelVillage")
+    @PostMapping("/cancel")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun cancel(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+    ) {
+        resolveCreatorVillage(principal, id)
+        creatorCoordinator.cancel(id)
+    }
+
+    /** エピローグ延長。可否は CreatorCoordinator (domain) が検証する。 */
+    @Operation(operationId = "extendVillageEpilogue")
+    @PostMapping("/extend-epilogue")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun extendEpilogue(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+    ) {
+        resolveCreatorVillage(principal, id)
+        creatorCoordinator.extendEpilogue(id)
+    }
+
+    /** エピローグ短縮。可否は CreatorCoordinator (domain) が検証する。 */
+    @Operation(operationId = "shortenVillageEpilogue")
+    @PostMapping("/shorten-epilogue")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun shortenEpilogue(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+    ) {
+        resolveCreatorVillage(principal, id)
+        creatorCoordinator.shortenEpilogue(id)
+    }
+
+    private fun resolveCreatorVillage(
+        principal: JwtPrincipal?,
+        villageId: Int,
+    ): Village {
+        // principal は filter chain の authenticated() で保証済み (到達時は非 null)。防御的に確認する
+        principal ?: throw WolfMansionAuthException("ログインしてください")
+        val village =
+            villageService.findVillage(villageId)
+                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "village not found")
+        if (!creatorCoordinator.isCreator(principal.name, village.id)) throw WolfMansionBusinessException("村建てプレイヤーのみ実行できます")
+        return village
+    }
+
+    private fun validate(request: VillageCreatorSayRequest) {
+        val form =
+            VillageSayForm(
+                message = request.message,
+                messageType = CDef.MessageType.村建て発言.code(),
+                convertDisable = request.convertDisable,
+            )
+        val errors = BeanPropertyBindingResult(form, "creatorSayForm")
+        creatorSayFormValidator.validate(form, errors)
+        if (errors.hasErrors()) {
+            throw WolfMansionValidationException(
+                errors.fieldErrors.map {
+                    FieldErrorItem(it.field, messageSource.getMessage(it, Locale.JAPAN))
+                },
+            )
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/village/request/VillageCreatorSayRequest.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/request/VillageCreatorSayRequest.kt
@@ -1,0 +1,11 @@
+package com.ort.app.api.village.request
+
+import jakarta.validation.constraints.NotBlank
+
+/**
+ * 村建て発言 (天の声)。文字数・行数制限は CreatorSayFormValidator (通常発言より寛容な 1000 字 / 40 行) を流用して検証する。
+ */
+data class VillageCreatorSayRequest(
+    @field:NotBlank val message: String? = null,
+    val convertDisable: Boolean? = null,
+)

--- a/backend/src/main/kotlin/com/ort/app/api/village/request/VillageKickRequest.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/request/VillageKickRequest.kt
@@ -1,0 +1,10 @@
+package com.ort.app.api.village.request
+
+import jakarta.validation.constraints.NotNull
+
+/**
+ * 強制退村 (プロローグ中のみ)。
+ */
+data class VillageKickRequest(
+    @field:NotNull val charaId: Int? = null,
+)

--- a/backend/src/main/kotlin/com/ort/app/api/village/response/ParticipantSituationView.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/response/ParticipantSituationView.kt
@@ -454,6 +454,7 @@ data class ParticipantSituationView(
         val isAvailableKick: Boolean,
         val isAvailableModifySetting: Boolean,
         val isAvailableExtendEpilogue: Boolean,
+        val isAvailableShortenEpilogue: Boolean,
     ) {
         constructor(situation: ParticipantSituation) : this(
             isCreator = situation.creator.isCreator,
@@ -462,6 +463,7 @@ data class ParticipantSituationView(
             isAvailableKick = situation.creator.isAvailableKick,
             isAvailableModifySetting = situation.creator.isAvailableModifySetting,
             isAvailableExtendEpilogue = situation.creator.isAvailableExtendEpilogue,
+            isAvailableShortenEpilogue = situation.creator.isAvailableShortenEpilogue,
         )
     }
 }

--- a/backend/src/main/kotlin/com/ort/app/domain/model/situation/participant/ParticipantCreatorSituation.kt
+++ b/backend/src/main/kotlin/com/ort/app/domain/model/situation/participant/ParticipantCreatorSituation.kt
@@ -7,4 +7,5 @@ data class ParticipantCreatorSituation(
     val isAvailableKick: Boolean,
     val isAvailableModifySetting: Boolean,
     val isAvailableExtendEpilogue: Boolean,
+    val isAvailableShortenEpilogue: Boolean,
 )

--- a/backend/src/main/kotlin/com/ort/app/domain/service/CreatorDomainService.kt
+++ b/backend/src/main/kotlin/com/ort/app/domain/service/CreatorDomainService.kt
@@ -18,6 +18,7 @@ class CreatorDomainService {
             isAvailableKick = isAvailableKick(village, player),
             isAvailableModifySetting = isAvailableModifySetting(village, player),
             isAvailableExtendEpilogue = isAvailableExtendEpilogue(village, player),
+            isAvailableShortenEpilogue = isAvailableShortenEpilogue(village, player),
         )
 
     private fun isCreator(
@@ -49,4 +50,9 @@ class CreatorDomainService {
         village: Village,
         player: Player?,
     ): Boolean = isCreator(village, player) && village.canExtendEpilogue()
+
+    private fun isAvailableShortenEpilogue(
+        village: Village,
+        player: Player?,
+    ): Boolean = isCreator(village, player) && village.canShortenEpilogue()
 }

--- a/backend/src/test/kotlin/com/ort/app/api/village/response/ParticipantSituationViewTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/api/village/response/ParticipantSituationViewTest.kt
@@ -124,6 +124,7 @@ internal class ParticipantSituationViewTest {
                     isAvailableKick = false,
                     isAvailableModifySetting = false,
                     isAvailableExtendEpilogue = false,
+                    isAvailableShortenEpilogue = false,
                 ),
         )
 }

--- a/e2e/tests/village-creator.spec.ts
+++ b/e2e/tests/village-creator.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * 村建て (creator) 機能の e2e。master (ローカル DB の村建てプレイヤー) でログインし、
+ * 進行中の村で村建て発言フローを確認する。kick / 廃村 / エピローグ延長は
+ * 破壊的でフィクスチャ村を壊すため e2e では実行しない (REST 検証は使い捨て村で実施済み)。
+ */
+
+type SimpleVillage = { id: number; name: string };
+
+async function findVillages(page: Page, statuses: string[]): Promise<SimpleVillage[]> {
+  const query = statuses.map((s) => `status=${s}`).join("&");
+  const res = await page.request.get(`/wolf-mansion-api/api/v1/villages?${query}`);
+  expect(res.ok()).toBeTruthy();
+  const body = (await res.json()) as { villages: SimpleVillage[] };
+  return body.villages;
+}
+
+async function login(page: Page, userId: string): Promise<boolean> {
+  const res = await page.request.post(`/wolf-mansion-api/api/v1/auth/login`, {
+    data: { userId, password: "testuser" },
+  });
+  return res.ok();
+}
+
+/** master が村建てした村を探す。 */
+async function findCreatorVillage(page: Page): Promise<number | null> {
+  if (!(await login(page, "master"))) return null;
+  const villages = await findVillages(page, ["IN_PROGRESS"]);
+  for (const village of villages) {
+    const res = await page.request.get(
+      `/wolf-mansion-api/api/v1/villages/${village.id}/situation/me`,
+    );
+    if (!res.ok()) continue;
+    const body = (await res.json()) as { creator: { isCreator: boolean } };
+    if (body.creator.isCreator) return village.id;
+  }
+  return null;
+}
+
+async function dismissInitialSkillModal(page: Page) {
+  const confirm = page.getByRole("button", { name: "確認したので次回以降表示しない" });
+  if ((await confirm.count()) > 0) {
+    await confirm.click();
+  }
+}
+
+test("村建て発言: 入力 → 確認 → 投稿 → ログ反映", async ({ page }) => {
+  const villageId = await findCreatorVillage(page);
+  test.skip(villageId == null, "master が村建てした進行中の村が無い DB のためスキップ");
+  if (villageId == null) return;
+
+  await page.goto(`village/${villageId}`);
+  const sayInput = page.getByLabel("村建て発言");
+  await expect(sayInput).toBeVisible({ timeout: 15000 });
+  await dismissInitialSkillModal(page);
+
+  const text = `e2e 天の声 ${Date.now()}`;
+  await sayInput.fill(text);
+  await expect(page.getByText(/文字数: \d+\/1000/)).toBeVisible();
+
+  // 村建て機能パネルの確認画面へ (発言フォーム等にも同名ボタンがあるため、パネル内に限定)
+  const creatorPanel = page
+    .locator("div")
+    .filter({ hasText: /^村建て機能$/ })
+    .first()
+    .locator("..");
+  await creatorPanel.getByRole("button", { name: "確認画面へ" }).click();
+
+  const confirmArea = page.locator("#message-confirm-area");
+  await expect(confirmArea).toBeVisible();
+  await expect(confirmArea).toContainText(text);
+
+  await confirmArea.getByRole("button", { name: "発言する（村建て）" }).click();
+  await expect(confirmArea).toHaveCount(0);
+  await expect(page.locator(".message").filter({ hasText: text })).toBeVisible({
+    timeout: 15000,
+  });
+});
+
+test("村建てでない参加者には村建て機能パネルが出ない", async ({ page }) => {
+  const ok = await login(page, "testuser01");
+  test.skip(!ok, "testuser01 が存在しない DB のためスキップ");
+  const villages = await findVillages(page, ["IN_PROGRESS"]);
+  test.skip(villages.length === 0, "進行中の村が無い DB のためスキップ");
+
+  await page.goto(`village/${villages[0].id}`);
+  await expect(page.getByRole("button", { name: "更新" })).toBeVisible({ timeout: 15000 });
+  await dismissInitialSkillModal(page);
+  await expect(page.getByText("村建て機能")).toHaveCount(0);
+});

--- a/frontend/app/api/openapi.json
+++ b/frontend/app/api/openapi.json
@@ -2400,6 +2400,9 @@
           "isAvailableModifySetting": {
             "type": "boolean"
           },
+          "isAvailableShortenEpilogue": {
+            "type": "boolean"
+          },
           "isCreator": {
             "type": "boolean"
           }
@@ -2410,6 +2413,7 @@
           "isAvailableExtendEpilogue",
           "isAvailableKick",
           "isAvailableModifySetting",
+          "isAvailableShortenEpilogue",
           "isCreator"
         ]
       },

--- a/frontend/app/api/openapi.json
+++ b/frontend/app/api/openapi.json
@@ -877,6 +877,175 @@
         "tags": ["village-commit-rest-controller"]
       }
     },
+    "/api/v1/villages/{id}/creator/cancel": {
+      "post": {
+        "operationId": "cancelVillage",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": ["village-creator-rest-controller"]
+      }
+    },
+    "/api/v1/villages/{id}/creator/extend-epilogue": {
+      "post": {
+        "operationId": "extendVillageEpilogue",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": ["village-creator-rest-controller"]
+      }
+    },
+    "/api/v1/villages/{id}/creator/kick": {
+      "post": {
+        "operationId": "kickVillageParticipant",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VillageKickRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": ["village-creator-rest-controller"]
+      }
+    },
+    "/api/v1/villages/{id}/creator/say": {
+      "post": {
+        "operationId": "sayVillageCreator",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VillageCreatorSayRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": ["village-creator-rest-controller"]
+      }
+    },
+    "/api/v1/villages/{id}/creator/say-confirm": {
+      "post": {
+        "operationId": "confirmVillageCreatorSay",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VillageCreatorSayRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/VillageSayConfirmContent"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": ["village-creator-rest-controller"]
+      }
+    },
+    "/api/v1/villages/{id}/creator/shorten-epilogue": {
+      "post": {
+        "operationId": "shortenVillageEpilogue",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": ["village-creator-rest-controller"]
+      }
+    },
     "/api/v1/villages/{id}/info": {
       "get": {
         "operationId": "getVillageInfo",
@@ -3601,6 +3770,19 @@
         },
         "required": ["id"]
       },
+      "VillageCreatorSayRequest": {
+        "type": "object",
+        "properties": {
+          "convertDisable": {
+            "type": ["boolean", "null"]
+          },
+          "message": {
+            "type": ["string", "null"],
+            "minLength": 1
+          }
+        },
+        "required": ["message"]
+      },
       "VillageDay": {
         "type": "object",
         "properties": {
@@ -3666,6 +3848,10 @@
       "VillageFilterParticipantContent": {
         "type": "object",
         "properties": {
+          "charaId": {
+            "type": "integer",
+            "format": "int32"
+          },
           "deadStatus": {
             "type": ["string", "null"]
           },
@@ -3688,7 +3874,7 @@
             "type": "string"
           }
         },
-        "required": ["id", "imgHeight", "imgUrl", "imgWidth", "name"]
+        "required": ["charaId", "id", "imgHeight", "imgUrl", "imgWidth", "name"]
       },
       "VillageFootstepContent": {
         "type": "object",
@@ -3702,6 +3888,16 @@
           }
         },
         "required": ["day", "footstep"]
+      },
+      "VillageKickRequest": {
+        "type": "object",
+        "properties": {
+          "charaId": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          }
+        },
+        "required": ["charaId"]
       },
       "VillageLatestMessageDatetimeContent": {
         "type": "object",

--- a/frontend/app/api/types.ts
+++ b/frontend/app/api/types.ts
@@ -387,6 +387,102 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/villages/{id}/creator/cancel": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["cancelVillage"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/villages/{id}/creator/extend-epilogue": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["extendVillageEpilogue"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/villages/{id}/creator/kick": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["kickVillageParticipant"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/villages/{id}/creator/say": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["sayVillageCreator"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/villages/{id}/creator/say-confirm": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["confirmVillageCreatorSay"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/villages/{id}/creator/shorten-epilogue": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["shortenVillageEpilogue"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/villages/{id}/info": {
     parameters: {
       query?: never;
@@ -1275,6 +1371,10 @@ export interface components {
       /** Format: int32 */
       id: number;
     };
+    VillageCreatorSayRequest: {
+      convertDisable?: boolean | null;
+      message: string | null;
+    };
     VillageDay: {
       /** Format: int32 */
       day: number;
@@ -1296,6 +1396,8 @@ export interface components {
       status: components["schemas"]["VillageStatus"];
     };
     VillageFilterParticipantContent: {
+      /** Format: int32 */
+      charaId: number;
       deadStatus?: string | null;
       /** Format: int32 */
       id: number;
@@ -1310,6 +1412,10 @@ export interface components {
       /** Format: int32 */
       day: number;
       footstep: string;
+    };
+    VillageKickRequest: {
+      /** Format: int32 */
+      charaId: number | null;
     };
     VillageLatestMessageDatetimeContent: {
       latestMessageDatetime: string;
@@ -2295,6 +2401,140 @@ export interface operations {
         "application/json": components["schemas"]["VillageCommitRequest"];
       };
     };
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  cancelVillage: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  extendVillageEpilogue: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  kickVillageParticipant: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["VillageKickRequest"];
+      };
+    };
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  sayVillageCreator: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["VillageCreatorSayRequest"];
+      };
+    };
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  confirmVillageCreatorSay: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["VillageCreatorSayRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["VillageSayConfirmContent"];
+        };
+      };
+    };
+  };
+  shortenVillageEpilogue: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
     responses: {
       /** @description No Content */
       204: {

--- a/frontend/app/api/types.ts
+++ b/frontend/app/api/types.ts
@@ -975,6 +975,7 @@ export interface components {
       isAvailableExtendEpilogue: boolean;
       isAvailableKick: boolean;
       isAvailableModifySetting: boolean;
+      isAvailableShortenEpilogue: boolean;
       isCreator: boolean;
     };
     ParticipantSituationViewMyself: {

--- a/frontend/app/features/village/api.ts
+++ b/frontend/app/features/village/api.ts
@@ -316,3 +316,44 @@ export function saveVillageNotificationSetting(
     body: request,
   });
 }
+
+/** 村建て発言のリクエスト。 */
+export type VillageCreatorSayRequest = components["schemas"]["VillageCreatorSayRequest"];
+/** 強制退村のリクエスト。 */
+export type VillageKickRequest = components["schemas"]["VillageKickRequest"];
+
+/** 村建て発言を確認する (プレビュー。まだ保存されない)。要認証。 */
+export function confirmVillageCreatorSay(
+  id: number,
+  request: VillageCreatorSayRequest,
+): Promise<VillageSayConfirmContent> {
+  return apiFetch<VillageSayConfirmContent>(`/api/v1/villages/${id}/creator/say-confirm`, {
+    method: "POST",
+    body: request,
+  });
+}
+
+/** 村建て発言する。要認証 → 204。 */
+export function sayVillageCreator(id: number, request: VillageCreatorSayRequest): Promise<void> {
+  return apiFetch<void>(`/api/v1/villages/${id}/creator/say`, { method: "POST", body: request });
+}
+
+/** 参加者を強制退村させる。要認証 → 204。 */
+export function kickVillageParticipant(id: number, request: VillageKickRequest): Promise<void> {
+  return apiFetch<void>(`/api/v1/villages/${id}/creator/kick`, { method: "POST", body: request });
+}
+
+/** 廃村にする。要認証 → 204。 */
+export function cancelVillage(id: number): Promise<void> {
+  return apiFetch<void>(`/api/v1/villages/${id}/creator/cancel`, { method: "POST" });
+}
+
+/** エピローグを1日延長する。要認証 → 204。 */
+export function extendVillageEpilogue(id: number): Promise<void> {
+  return apiFetch<void>(`/api/v1/villages/${id}/creator/extend-epilogue`, { method: "POST" });
+}
+
+/** エピローグを1日短縮する。要認証 → 204。 */
+export function shortenVillageEpilogue(id: number): Promise<void> {
+  return apiFetch<void>(`/api/v1/villages/${id}/creator/shorten-epilogue`, { method: "POST" });
+}

--- a/frontend/app/routes/village/CreatorPanel.tsx
+++ b/frontend/app/routes/village/CreatorPanel.tsx
@@ -53,8 +53,13 @@ export function CreatorPanel({
           <CancelSection villageId={villageId} onDone={onDone} />
         )}
         {creator.isAvailableCreatorSay && <CreatorSaySection onConfirm={onConfirm} />}
-        {creator.isAvailableExtendEpilogue && (
-          <EpilogueSection villageId={villageId} onDone={onDone} />
+        {(creator.isAvailableExtendEpilogue || creator.isAvailableShortenEpilogue) && (
+          <EpilogueSection
+            villageId={villageId}
+            canExtend={creator.isAvailableExtendEpilogue}
+            canShorten={creator.isAvailableShortenEpilogue}
+            onDone={onDone}
+          />
         )}
       </div>
     </Panel>
@@ -234,9 +239,14 @@ function CreatorSaySection({
 
 function EpilogueSection({
   villageId,
+  canExtend,
+  canShorten,
   onDone,
 }: {
   villageId: number;
+  canExtend: boolean;
+  /** 短縮は残り 1 日を切ると不可になるため、延長と別フラグで出し分ける */
+  canShorten: boolean;
   onDone: () => Promise<unknown>;
 }) {
   const [error, setError] = useState<string | null>(null);
@@ -274,12 +284,16 @@ function EpilogueSection({
     <div>
       {error != null && <p className="text-[#e74c3c]">{error}</p>}
       <div className="flex gap-[5px]">
-        <Button onClick={extend} disabled={submitting}>
-          1日延長する
-        </Button>
-        <Button onClick={shorten} disabled={submitting}>
-          1日短縮する
-        </Button>
+        {canExtend && (
+          <Button onClick={extend} disabled={submitting}>
+            1日延長する
+          </Button>
+        )}
+        {canShorten && (
+          <Button onClick={shorten} disabled={submitting}>
+            1日短縮する
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/frontend/app/routes/village/CreatorPanel.tsx
+++ b/frontend/app/routes/village/CreatorPanel.tsx
@@ -1,0 +1,286 @@
+import { useState } from "react";
+
+import { Button } from "~/components/ui/Button";
+import { Panel } from "~/components/ui/Panel";
+import { selectClass } from "~/components/ui/Input";
+import {
+  cancelVillage,
+  extendVillageEpilogue,
+  kickVillageParticipant,
+  shortenVillageEpilogue,
+  type ParticipantSituationView,
+  type VillageCreatorSayRequest,
+} from "~/features/village/api";
+import { ApiError } from "~/lib/api";
+
+function errorMessage(e: unknown, fallback: string): string {
+  return e instanceof ApiError ? e.detail : fallback;
+}
+
+/** 村建て機能パネル。村建てプレイヤーのみ表示する。 */
+export function CreatorPanel({
+  villageId,
+  mySituation,
+  participants,
+  members,
+  onConfirm,
+  onDone,
+}: {
+  villageId: number;
+  mySituation: ParticipantSituationView;
+  /** 強制退村の選択肢 (charaId と name を持つリスト)。 */
+  participants: { charaId: number; name: string }[];
+  /** 最終アクセス日時テーブル用メンバー一覧。 */
+  members: { charaName: string; lastAccess: string | null }[];
+  /** 村建て発言の確認画面へ進む (プレビュー取得は親が行う)。 */
+  onConfirm: (request: VillageCreatorSayRequest) => Promise<void>;
+  onDone: () => Promise<unknown>;
+}) {
+  const creator = mySituation.creator;
+
+  return (
+    <Panel title="村建て機能">
+      <div className="space-y-[20px] text-[12px]">
+        {creator.isAvailableKick && (
+          <KickSection
+            villageId={villageId}
+            participants={participants}
+            members={members}
+            onDone={onDone}
+          />
+        )}
+        {creator.isAvailableCancelVillage && (
+          <CancelSection villageId={villageId} onDone={onDone} />
+        )}
+        {creator.isAvailableCreatorSay && <CreatorSaySection onConfirm={onConfirm} />}
+        {creator.isAvailableExtendEpilogue && (
+          <EpilogueSection villageId={villageId} onDone={onDone} />
+        )}
+      </div>
+    </Panel>
+  );
+}
+
+function KickSection({
+  villageId,
+  participants,
+  members,
+  onDone,
+}: {
+  villageId: number;
+  participants: { charaId: number; name: string }[];
+  members: { charaName: string; lastAccess: string | null }[];
+  onDone: () => Promise<unknown>;
+}) {
+  const [selectedCharaId, setSelectedCharaId] = useState<string>("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const submit = async () => {
+    if (submitting || selectedCharaId === "") return;
+    if (!window.confirm("本当に退村させてよろしいですか？")) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await kickVillageParticipant(villageId, { charaId: Number(selectedCharaId) });
+      await onDone();
+    } catch (e) {
+      setError(errorMessage(e, "強制退村に失敗しました"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div>
+      <p className="mb-[5px] font-bold">最終アクセス日時</p>
+      {error != null && <p className="text-[#e74c3c]">{error}</p>}
+      <table className="mb-[10px] w-full border-collapse border border-[#464545]">
+        <thead>
+          <tr>
+            <th className="border border-[#464545] px-[8px] py-[4px] text-left">キャラ名</th>
+            <th className="border border-[#464545] px-[8px] py-[4px] text-left">最終アクセス</th>
+          </tr>
+        </thead>
+        <tbody>
+          {members.map((m) => (
+            <tr key={m.charaName}>
+              <td className="border border-[#464545] px-[8px] py-[4px]">{m.charaName}</td>
+              <td className="border border-[#464545] px-[8px] py-[4px]">{m.lastAccess ?? ""}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p className="mb-[5px] font-bold">強制退村</p>
+      <div className="flex flex-wrap items-center gap-[5px]">
+        <select
+          className={selectClass}
+          value={selectedCharaId}
+          onChange={(e) => setSelectedCharaId(e.target.value)}
+          aria-label="退村させる参加者"
+        >
+          <option value="">選択してください</option>
+          {participants.map((p) => (
+            <option key={p.charaId} value={p.charaId}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+        <Button variant="danger" onClick={submit} disabled={submitting || selectedCharaId === ""}>
+          退村させる
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function CancelSection({
+  villageId,
+  onDone,
+}: {
+  villageId: number;
+  onDone: () => Promise<unknown>;
+}) {
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const submit = async () => {
+    if (submitting) return;
+    if (!window.confirm("本当に廃村にしてよろしいですか？")) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await cancelVillage(villageId);
+      await onDone();
+    } catch (e) {
+      setError(errorMessage(e, "廃村に失敗しました"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div>
+      {error != null && <p className="text-[#e74c3c]">{error}</p>}
+      <div className="flex justify-end">
+        <Button variant="danger" onClick={submit} disabled={submitting}>
+          廃村にする
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function CreatorSaySection({
+  onConfirm,
+}: {
+  onConfirm: (request: VillageCreatorSayRequest) => Promise<void>;
+}) {
+  const [message, setMessage] = useState("");
+  const [convertDisable, setConvertDisable] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const length = message.length;
+  const lineCount = message.split("\n").length;
+  const maxLength = 1000;
+  const maxLine = 40;
+  const overLimit = length > maxLength || lineCount > maxLine;
+  const submitDisabled = overLimit || message.trim().length === 0 || submitting;
+
+  const submit = async () => {
+    if (submitDisabled) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onConfirm({ message, convertDisable });
+    } catch (e) {
+      setError(errorMessage(e, "確認に失敗しました"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div>
+      <p className="mb-[5px] font-bold">村建て発言</p>
+      {error != null && <p className="text-[#e74c3c]">{error}</p>}
+      <textarea
+        className="w-full rounded border border-[#464545] bg-white p-[9px] text-[12px] text-[#555]"
+        rows={5}
+        value={message}
+        onChange={(e) => setMessage(e.target.value)}
+        aria-label="村建て発言"
+      />
+      <div className={`mt-[5px] text-[12px] ${overLimit ? "text-[#e74c3c]" : ""}`}>
+        文字数: {length}/{maxLength}, 行数: {lineCount}/{maxLine}
+      </div>
+      <div className="mt-[10px] flex items-center justify-between">
+        <label className="flex cursor-pointer items-center gap-[5px] text-[12px]">
+          <input
+            type="checkbox"
+            checked={convertDisable}
+            onChange={() => setConvertDisable(!convertDisable)}
+          />
+          装飾・変換無効
+        </label>
+        <Button onClick={submit} disabled={submitDisabled}>
+          確認画面へ
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function EpilogueSection({
+  villageId,
+  onDone,
+}: {
+  villageId: number;
+  onDone: () => Promise<unknown>;
+}) {
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const extend = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await extendVillageEpilogue(villageId);
+      await onDone();
+    } catch (e) {
+      setError(errorMessage(e, "エピローグ延長に失敗しました"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const shorten = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await shortenVillageEpilogue(villageId);
+      await onDone();
+    } catch (e) {
+      setError(errorMessage(e, "エピローグ短縮に失敗しました"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div>
+      {error != null && <p className="text-[#e74c3c]">{error}</p>}
+      <div className="flex gap-[5px]">
+        <Button onClick={extend} disabled={submitting}>
+          1日延長する
+        </Button>
+        <Button onClick={shorten} disabled={submitting}>
+          1日短縮する
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -9,9 +9,12 @@ import {
   actionVillage,
   confirmVillageAction,
   confirmVillageSay,
+  confirmVillageCreatorSay,
   participateVillage,
   sayVillage,
+  sayVillageCreator,
   type VillageActionRequest,
+  type VillageCreatorSayRequest,
   type VillageDetailView,
   type VillageMessageContent,
   type VillageMessageListContent,
@@ -40,6 +43,7 @@ import { AbilityPanel } from "./AbilityPanel";
 import { ActionPanel } from "./ActionPanel";
 import { AgeLimitModal } from "./AgeLimitModal";
 import { CommitPanel } from "./CommitPanel";
+import { CreatorPanel } from "./CreatorPanel";
 import { DayList } from "./DayList";
 import { FilterModal } from "./FilterModal";
 import { FooterMenu } from "./FooterMenu";
@@ -168,6 +172,7 @@ export default function Village({ params }: Route.ComponentProps) {
   const [sayPreview, setSayPreview] = useState<
     | { kind: "say"; message: VillageMessageContent; request: VillageSayRequest }
     | { kind: "action"; message: VillageMessageContent; request: VillageActionRequest }
+    | { kind: "creatorSay"; message: VillageMessageContent; request: VillageCreatorSayRequest }
     | null
   >(null);
   const [sayError, setSayError] = useState<string | null>(null);
@@ -208,6 +213,22 @@ export default function Village({ params }: Route.ComponentProps) {
       setSayError(e instanceof ApiError ? e.detail : "アクションの確認に失敗しました");
     }
   };
+  const onCreatorSayConfirm = async (request: VillageCreatorSayRequest) => {
+    setSayError(null);
+    try {
+      const response = await confirmVillageCreatorSay(villageId, request);
+      if (response.message == null) {
+        setSayError("村建て発言の確認に失敗しました");
+        return;
+      }
+      setSayPreview({ kind: "creatorSay", message: response.message, request });
+      requestAnimationFrame(() =>
+        document.getElementById("message-confirm-area")?.scrollIntoView(),
+      );
+    } catch (e) {
+      setSayError(e instanceof ApiError ? e.detail : "村建て発言の確認に失敗しました");
+    }
+  };
   const onSayDetermine = async () => {
     // 非冪等な投稿のため連打をガードする
     if (sayPreview == null || saySubmitting) return;
@@ -216,8 +237,10 @@ export default function Village({ params }: Route.ComponentProps) {
     try {
       if (sayPreview.kind === "say") {
         await sayVillage(villageId, sayPreview.request);
-      } else {
+      } else if (sayPreview.kind === "action") {
         await actionVillage(villageId, sayPreview.request);
+      } else {
+        await sayVillageCreator(villageId, sayPreview.request);
       }
       setSayPreview(null);
       setReply(null);
@@ -355,7 +378,9 @@ export default function Village({ params }: Route.ComponentProps) {
               <Button onClick={onSayDetermine} disabled={saySubmitting}>
                 {sayPreview.kind === "action"
                   ? "アクション"
-                  : sayLabel(sayPreview.request.messageType)}
+                  : sayPreview.kind === "creatorSay"
+                    ? "発言する（村建て）"
+                    : sayLabel(sayPreview.request.messageType)}
               </Button>
             </div>
           </div>
@@ -417,6 +442,20 @@ export default function Village({ params }: Route.ComponentProps) {
           (mySituation.rp.isAvailableChangeName || mySituation.rp.isAvailableMemo) && (
             <RpPanel villageId={villageId} mySituation={mySituation} onDone={invalidate} />
           )}
+
+        {mySituation != null && mySituation.creator.isCreator && (
+          <CreatorPanel
+            villageId={villageId}
+            mySituation={mySituation}
+            participants={(situation?.participantList ?? []).map((p) => ({
+              charaId: p.charaId,
+              name: p.name,
+            }))}
+            members={(situation?.memberList ?? []).flatMap((m) => m.statusMemberList)}
+            onConfirm={onCreatorSayConfirm}
+            onDone={invalidate}
+          />
+        )}
 
         {mySituation != null &&
           !mySituation.participate.isParticipating &&


### PR DESCRIPTION
closes .issues/step-8.15-village-creator.md

## 概要

村建て (creator) 機能を REST + React 化 (village-creator.md が正本)。base は `feature/monorepo-step8`。

## backend

- `VillageCreatorRestController` (`/api/v1/villages/{id}/creator/*`): say-confirm / say / kick / cancel / extend-epilogue / shorten-epilogue の 6 エンドポイント (いずれも要認証)
- **権威検証は `resolveCreatorVillage` で一元化**: `CreatorCoordinator.isCreator` (principal 由来) を全エンドポイントで強制。村建て発言の検証は SSR と共通の `CreatorSayFormValidator` (1000 字 / 40 行) を流用。cancel/extend/shorten の状態検証は既存 coordinator (domain) に委譲
- **kick は SSR が表示制御のみで実行時の状態検証をしていなかったため、サーバ側でもプロローグ検証を追加** (8.12 の方針踏襲)
- `VillageFilterParticipantContent` に `charaId` を追加 (kick の対象選択用。参加者のキャラは公開情報)

## frontend

- `CreatorPanel`「村建て機能」: 強制退村 (最終アクセス日時テーブル + キャラ選択 + window.confirm) / 廃村 (window.confirm) / 村建て発言 (文字数 n/1000・行数 n/40 表示 + 装飾無効 + 確認フロー) / エピローグ 1 日延長・短縮。creator situation のフラグで個別出し分け
- 村建て発言は既存の say 確認フロー (`#message-confirm-area` の MessageCard プレビュー) に `kind: "creatorSay"` として統合。投稿ボタンは「発言する（村建て）」

## 検証

- REST 実測: 村 6 (master=村建て) で say-confirm (CREATOR_SAY プレビュー) → say 204 → ログ反映。**使い捨て村 7 を作成して kick 204 (対象消滅) → cancel 204 (廃村 = 後片付け兼用) を実測**。異常系: 非 creator 400 (「村建てプレイヤーのみ実行できます」) / 未認証 401 / 1001 字 400 / 進行中の kick・cancel 400 / 非エピローグの extend 400
- SPA 実 UI: 村 6 で村建て発言の入力 → 確認 → 投稿 → ログ反映。進行中の村では kick/廃村/延長が非表示になることを確認
- e2e 2 件追加 (村建て発言フロー / 非 creator にパネルが出ない。kick・廃村は破壊的のため e2e では実行しない)。**全 74 件 (73 passed + 1 アクション回数枯渇 skip)**
- backend ktlintCheck/test green。frontend typecheck/lint/format/build green。gen:api 差分込み
- 実装は step-implementer agent への委譲で実施 (調査=Explore / 実行=test-runner、今回から分担ガイド適用)

🤖 Generated with [Claude Code](https://claude.com/claude-code)