### PR TITLE
feat: 村画面の管理者メニューを REST + React 化 (step-8.16)

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/village/VillageAdminRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/VillageAdminRestController.kt
@@ -43,6 +43,8 @@ class VillageAdminRestController(
         @RequestBody @Validated request: VillageAdminLeaveRequest,
     ) {
         val village = resolveAdminVillage(principal, id)
+        // 退村済み (gone) は取得時点で除外されるため、ここに到達するのは在籍中の参加者のみ。
+        // 所属検証は別村の villagePlayerId を弾くためのもの
         val participant =
             villageService.findVillageParticipant(request.villagePlayerId!!)
                 ?: throw WolfMansionBusinessException("村参加者が見つかりません")
@@ -87,6 +89,7 @@ class VillageAdminRestController(
         return AdminVillagePlayersResponse.of(adminVillageService.findVillageCharaPlayers(village.id))
     }
 
+    /** 管理者権限は村単位ではなくシステム全体のもの (村との関係は問わない)。 */
     private fun resolveAdminVillage(
         principal: JwtPrincipal?,
         villageId: Int,

--- a/backend/src/main/kotlin/com/ort/app/api/village/VillageAdminRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/VillageAdminRestController.kt
@@ -1,0 +1,106 @@
+package com.ort.app.api.village
+
+import com.ort.app.api.village.request.VillageAdminLeaveRequest
+import com.ort.app.api.village.response.AdminVillagePlayersResponse
+import com.ort.app.application.coordinator.VillageCoordinator
+import com.ort.app.application.service.AdminVillageService
+import com.ort.app.application.service.PlayerService
+import com.ort.app.application.service.VillageService
+import com.ort.app.domain.model.village.Village
+import com.ort.app.fw.exception.WolfMansionAuthException
+import com.ort.app.fw.exception.WolfMansionBusinessException
+import com.ort.app.fw.security.jwt.JwtPrincipal
+import com.ort.dbflute.allcommon.CDef
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+
+/** 管理者 (admin) 機能の REST。権限検証は resolveAdminVillage で一元化する。 */
+@RestController
+@RequestMapping("/api/v1/villages/{id}/admin")
+class VillageAdminRestController(
+    private val villageService: VillageService,
+    private val villageCoordinator: VillageCoordinator,
+    private val adminVillageService: AdminVillageService,
+    private val playerService: PlayerService,
+) {
+    /** 参加者を強制退村させる。 */
+    @Operation(operationId = "adminLeaveVillageParticipant")
+    @PostMapping("/leave")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun leave(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+        @RequestBody @Validated request: VillageAdminLeaveRequest,
+    ) {
+        val village = resolveAdminVillage(principal, id)
+        val participant =
+            villageService.findVillageParticipant(request.villagePlayerId!!)
+                ?: throw WolfMansionBusinessException("村参加者が見つかりません")
+        if (village.allParticipants().list.none { it.id == participant.id }) {
+            throw WolfMansionBusinessException("この村の参加者ではありません")
+        }
+        villageCoordinator.leave(village, participant)
+    }
+
+    /** 全参加者のアクセス日時を現在日時に更新する。 */
+    @Operation(operationId = "adminUpdateAllAccess")
+    @PostMapping("/access")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun access(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+    ) {
+        val village = resolveAdminVillage(principal, id)
+        adminVillageService.updateAllLastAccessDatetime(village.id)
+    }
+
+    /** 未投票の生存者に自己投票を追加する。 */
+    @Operation(operationId = "adminInsertSelfVotes")
+    @PostMapping("/vote")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun vote(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+    ) {
+        val village = resolveAdminVillage(principal, id)
+        adminVillageService.insertSelfVotesForNonVoters(village.id)
+    }
+
+    /** 村の参加プレイヤー一覧を取得する。 */
+    @Operation(operationId = "getAdminVillagePlayers")
+    @GetMapping("/players")
+    fun players(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+    ): AdminVillagePlayersResponse {
+        val village = resolveAdminVillage(principal, id)
+        return AdminVillagePlayersResponse.of(adminVillageService.findVillageCharaPlayers(village.id))
+    }
+
+    private fun resolveAdminVillage(
+        principal: JwtPrincipal?,
+        villageId: Int,
+    ): Village {
+        // principal は filter chain の authenticated() で保証済み (到達時は非 null)。防御的に確認する
+        principal ?: throw WolfMansionAuthException("ログインしてください")
+        val village =
+            villageService.findVillage(villageId)
+                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "village not found")
+        // 重要操作のため JWT claim でなく DB を再確認して管理者権限を検証する
+        val player = playerService.findPlayer(principal.name)
+        if (player == null || player.authority.toCdef() != CDef.Authority.管理者) {
+            throw WolfMansionBusinessException("管理者のみ実行できます")
+        }
+        return village
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/village/request/VillageAdminLeaveRequest.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/request/VillageAdminLeaveRequest.kt
@@ -1,0 +1,7 @@
+package com.ort.app.api.village.request
+
+import jakarta.validation.constraints.NotNull
+
+data class VillageAdminLeaveRequest(
+    @field:NotNull val villagePlayerId: Int? = null,
+)

--- a/backend/src/main/kotlin/com/ort/app/api/village/response/AdminVillagePlayersResponse.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/response/AdminVillagePlayersResponse.kt
@@ -1,0 +1,21 @@
+package com.ort.app.api.village.response
+
+import com.ort.app.application.service.VillageCharaPlayer
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class AdminVillagePlayersResponse(
+    val players: List<AdminVillageCharaPlayer>,
+) {
+    @Schema(name = "AdminVillageCharaPlayer")
+    data class AdminVillageCharaPlayer(
+        val charaName: String,
+        val playerName: String,
+    )
+
+    companion object {
+        fun of(players: List<VillageCharaPlayer>): AdminVillagePlayersResponse =
+            AdminVillagePlayersResponse(
+                players = players.map { AdminVillageCharaPlayer(charaName = it.charaName, playerName = it.playerName) },
+            )
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/application/service/AdminVillageService.kt
+++ b/backend/src/main/kotlin/com/ort/app/application/service/AdminVillageService.kt
@@ -1,0 +1,83 @@
+package com.ort.app.application.service
+
+import com.ort.dbflute.cbean.VillageDayCB
+import com.ort.dbflute.cbean.VillagePlayerCB
+import com.ort.dbflute.cbean.VoteCB
+import com.ort.dbflute.exbhv.VillageDayBhv
+import com.ort.dbflute.exbhv.VillagePlayerBhv
+import com.ort.dbflute.exbhv.VoteBhv
+import com.ort.dbflute.exentity.VillagePlayer
+import com.ort.dbflute.exentity.Vote
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+import java.util.function.Consumer
+import java.util.stream.Collectors
+
+/**
+ * 管理者操作のうち集計的な一括更新は domain モデルを介さず DB を直接操作する
+ * (AdminController からの移設。ドメインモデル経由に整理する場合は別途検討)。
+ */
+@Service
+class AdminVillageService(
+    private val villageDayBhv: VillageDayBhv,
+    private val villagePlayerBhv: VillagePlayerBhv,
+    private val voteBhv: VoteBhv,
+) {
+    fun updateAllLastAccessDatetime(villageId: Int) {
+        val vp = VillagePlayer()
+        vp.lastAccessDatetime = LocalDateTime.now()
+        villagePlayerBhv.queryUpdate(vp) { cb: VillagePlayerCB ->
+            cb.query().setVillageId_Equal(villageId)
+        }
+    }
+
+    fun insertSelfVotesForNonVoters(villageId: Int) {
+        val latestDay =
+            villageDayBhv
+                .selectEntity { cb: VillageDayCB ->
+                    cb.query().setVillageId_Equal(villageId)
+                    cb.query().addOrderBy_Day_Desc()
+                    cb.fetchFirst(1)
+                }.get()
+                .day
+        val voteCharaIdList =
+            voteBhv
+                .selectList { cb: VoteCB ->
+                    cb.query().setVillageId_Equal(villageId)
+                    cb.query().setDay_Equal(latestDay)
+                }.stream()
+                .map { obj: Vote -> obj.charaId }
+                .collect(Collectors.toList())
+        villagePlayerBhv
+            .selectList { cb: VillagePlayerCB ->
+                cb.query().setVillageId_Equal(villageId)
+                cb.query().setIsGone_Equal_False()
+                cb.query().setIsSpectator_Equal_False()
+                cb.query().setIsDead_Equal_False()
+                if (voteCharaIdList.isNotEmpty()) cb.query().setCharaId_NotInScope(voteCharaIdList)
+            }.forEach(
+                Consumer { vp: VillagePlayer ->
+                    val vote = Vote()
+                    vote.villageId = villageId
+                    vote.day = latestDay
+                    vote.charaId = vp.charaId
+                    vote.voteCharaId = vp.charaId
+                    voteBhv.insert(vote)
+                },
+            )
+    }
+
+    fun findVillageCharaPlayers(villageId: Int): List<VillageCharaPlayer> =
+        villagePlayerBhv
+            .selectList { cb: VillagePlayerCB ->
+                cb.setupSelect_Player()
+                cb.query().setVillageId_Equal(villageId)
+                cb.query().setIsGone_Equal_False()
+                cb.query().addOrderBy_VillagePlayerId_Asc()
+            }.map { VillageCharaPlayer(charaName = it.charaName, playerName = it.player.get().playerName) }
+}
+
+data class VillageCharaPlayer(
+    val charaName: String,
+    val playerName: String,
+)

--- a/e2e/tests/village-admin.spec.ts
+++ b/e2e/tests/village-admin.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * 管理者 (admin) メニューの e2e。master (ローカル DB の管理者 = playerId 1) でログインする。
+ * 強制退村・全員自己投票は破壊的 (フィクスチャの参加者・投票状態を変える) ため実行せず、
+ * 読み取り (参加プレイヤー一覧) と無害な全員アクセスのみ実行する。
+ */
+
+type SimpleVillage = { id: number; name: string };
+
+async function findVillages(page: Page, statuses: string[]): Promise<SimpleVillage[]> {
+  const query = statuses.map((s) => `status=${s}`).join("&");
+  const res = await page.request.get(`/wolf-mansion-api/api/v1/villages?${query}`);
+  expect(res.ok()).toBeTruthy();
+  const body = (await res.json()) as { villages: SimpleVillage[] };
+  return body.villages;
+}
+
+async function login(page: Page, userId: string): Promise<boolean> {
+  const res = await page.request.post(`/wolf-mansion-api/api/v1/auth/login`, {
+    data: { userId, password: "testuser" },
+  });
+  return res.ok();
+}
+
+/** master が参加している村を探す (admin パネルは参加者として表示されるため)。 */
+async function findAdminVillage(page: Page): Promise<number | null> {
+  if (!(await login(page, "master"))) return null;
+  const villages = await findVillages(page, ["IN_PROGRESS"]);
+  for (const village of villages) {
+    const res = await page.request.get(
+      `/wolf-mansion-api/api/v1/villages/${village.id}/situation/me`,
+    );
+    if (!res.ok()) continue;
+    const body = (await res.json()) as { admin: { isAdmin: boolean } };
+    if (body.admin.isAdmin) return village.id;
+  }
+  return null;
+}
+
+async function dismissInitialSkillModal(page: Page) {
+  const confirm = page.getByRole("button", { name: "確認したので次回以降表示しない" });
+  if ((await confirm.count()) > 0) {
+    await confirm.click();
+  }
+}
+
+test("管理者メニュー: 参加プレイヤーのインライン表示と全員アクセス", async ({ page }) => {
+  const villageId = await findAdminVillage(page);
+  test.skip(villageId == null, "master が管理者として参加する進行中の村が無い DB のためスキップ");
+  if (villageId == null) return;
+
+  await page.goto(`village/${villageId}`);
+  await expect(page.getByText("管理者メニュー")).toBeVisible({ timeout: 15000 });
+  await dismissInitialSkillModal(page);
+
+  // 参加プレイヤーがパネル内にインライン表示される (別画面に遷移しない)
+  await page.getByRole("button", { name: "参加プレイヤーを表示" }).click();
+  await expect(page.getByText("master").first()).toBeVisible({ timeout: 15000 });
+  await expect(page).toHaveURL(new RegExp(`/village/${villageId}`));
+
+  // 全員アクセス (lastAccess 更新のみで無害)
+  await page.getByRole("button", { name: "全員アクセス" }).click();
+  await expect(page.getByText(/に失敗しました/)).toHaveCount(0);
+});
+
+test("管理者でない参加者には管理者メニューが出ない", async ({ page }) => {
+  const ok = await login(page, "testuser01");
+  test.skip(!ok, "testuser01 が存在しない DB のためスキップ");
+  const villages = await findVillages(page, ["IN_PROGRESS"]);
+  test.skip(villages.length === 0, "進行中の村が無い DB のためスキップ");
+
+  await page.goto(`village/${villages[0].id}`);
+  await expect(page.getByRole("button", { name: "更新" })).toBeVisible({ timeout: 15000 });
+  await dismissInitialSkillModal(page);
+  await expect(page.getByText("管理者メニュー")).toHaveCount(0);
+});

--- a/frontend/app/api/openapi.json
+++ b/frontend/app/api/openapi.json
@@ -781,6 +781,111 @@
         "tags": ["village-say-rest-controller"]
       }
     },
+    "/api/v1/villages/{id}/admin/access": {
+      "post": {
+        "operationId": "adminUpdateAllAccess",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": ["village-admin-rest-controller"]
+      }
+    },
+    "/api/v1/villages/{id}/admin/leave": {
+      "post": {
+        "operationId": "adminLeaveVillageParticipant",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VillageAdminLeaveRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": ["village-admin-rest-controller"]
+      }
+    },
+    "/api/v1/villages/{id}/admin/players": {
+      "get": {
+        "operationId": "getAdminVillagePlayers",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminVillagePlayersResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": ["village-admin-rest-controller"]
+      }
+    },
+    "/api/v1/villages/{id}/admin/vote": {
+      "post": {
+        "operationId": "adminInsertSelfVotes",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": ["village-admin-rest-controller"]
+      }
+    },
     "/api/v1/villages/{id}/change-name": {
       "post": {
         "operationId": "changeVillageCharaName",
@@ -1851,6 +1956,30 @@
           }
         },
         "required": ["code", "name", "setMessageType"]
+      },
+      "AdminVillageCharaPlayer": {
+        "type": "object",
+        "properties": {
+          "charaName": {
+            "type": "string"
+          },
+          "playerName": {
+            "type": "string"
+          }
+        },
+        "required": ["charaName", "playerName"]
+      },
+      "AdminVillagePlayersResponse": {
+        "type": "object",
+        "properties": {
+          "players": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AdminVillageCharaPlayer"
+            }
+          }
+        },
+        "required": ["players"]
       },
       "Camp": {
         "type": "object",
@@ -3353,6 +3482,16 @@
           }
         },
         "required": ["message", "myself"]
+      },
+      "VillageAdminLeaveRequest": {
+        "type": "object",
+        "properties": {
+          "villagePlayerId": {
+            "type": ["integer", "null"],
+            "format": "int32"
+          }
+        },
+        "required": ["villagePlayerId"]
       },
       "VillageAnchorMessageContent": {
         "type": "object",

--- a/frontend/app/api/types.ts
+++ b/frontend/app/api/types.ts
@@ -339,6 +339,70 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/villages/{id}/admin/access": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["adminUpdateAllAccess"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/villages/{id}/admin/leave": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["adminLeaveVillageParticipant"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/villages/{id}/admin/players": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["getAdminVillagePlayers"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/villages/{id}/admin/vote": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["adminInsertSelfVotes"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/villages/{id}/change-name": {
     parameters: {
       query?: never;
@@ -805,6 +869,13 @@ export interface components {
       name: string;
       setMessageType: components["schemas"]["MessageType"];
     };
+    AdminVillageCharaPlayer: {
+      charaName: string;
+      playerName: string;
+    };
+    AdminVillagePlayersResponse: {
+      players: components["schemas"]["AdminVillageCharaPlayer"][];
+    };
     Camp: {
       code: string;
       isCriminals: boolean;
@@ -1260,6 +1331,10 @@ export interface components {
       message: string | null;
       myself: string | null;
       target?: string | null;
+    };
+    VillageAdminLeaveRequest: {
+      /** Format: int32 */
+      villagePlayerId: number | null;
     };
     VillageAnchorMessageContent: {
       message?: components["schemas"]["VillageMessageContent"] | null;
@@ -2337,6 +2412,92 @@ export interface operations {
         content: {
           "*/*": components["schemas"]["VillageSayConfirmContent"];
         };
+      };
+    };
+  };
+  adminUpdateAllAccess: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  adminLeaveVillageParticipant: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["VillageAdminLeaveRequest"];
+      };
+    };
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  getAdminVillagePlayers: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["AdminVillagePlayersResponse"];
+        };
+      };
+    };
+  };
+  adminInsertSelfVotes: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
     };
   };

--- a/frontend/app/features/village/api.ts
+++ b/frontend/app/features/village/api.ts
@@ -357,3 +357,31 @@ export function extendVillageEpilogue(id: number): Promise<void> {
 export function shortenVillageEpilogue(id: number): Promise<void> {
   return apiFetch<void>(`/api/v1/villages/${id}/creator/shorten-epilogue`, { method: "POST" });
 }
+
+/** 管理者による強制退村のリクエスト。 */
+export type VillageAdminLeaveRequest = components["schemas"]["VillageAdminLeaveRequest"];
+/** 管理者用参加プレイヤー一覧のレスポンス。 */
+export type AdminVillagePlayersResponse = components["schemas"]["AdminVillagePlayersResponse"];
+
+/** 参加者を強制退村させる (管理者専用)。要認証 → 204。 */
+export function adminLeaveVillageParticipant(
+  id: number,
+  request: VillageAdminLeaveRequest,
+): Promise<void> {
+  return apiFetch<void>(`/api/v1/villages/${id}/admin/leave`, { method: "POST", body: request });
+}
+
+/** 全参加者のアクセス日時を現在日時に更新する (管理者専用)。要認証 → 204。 */
+export function adminUpdateAllAccess(id: number): Promise<void> {
+  return apiFetch<void>(`/api/v1/villages/${id}/admin/access`, { method: "POST" });
+}
+
+/** 未投票の生存者に自己投票を追加する (管理者専用)。要認証 → 204。 */
+export function adminInsertSelfVotes(id: number): Promise<void> {
+  return apiFetch<void>(`/api/v1/villages/${id}/admin/vote`, { method: "POST" });
+}
+
+/** 村の参加プレイヤー一覧を取得する (管理者専用)。要認証。 */
+export function fetchAdminVillagePlayers(id: number): Promise<AdminVillagePlayersResponse> {
+  return apiFetch<AdminVillagePlayersResponse>(`/api/v1/villages/${id}/admin/players`);
+}

--- a/frontend/app/routes/village/AdminPanel.tsx
+++ b/frontend/app/routes/village/AdminPanel.tsx
@@ -1,0 +1,202 @@
+import { useState } from "react";
+
+import { Button } from "~/components/ui/Button";
+import { Panel } from "~/components/ui/Panel";
+import { inlineInputClass } from "~/components/ui/Input";
+import {
+  adminInsertSelfVotes,
+  adminLeaveVillageParticipant,
+  adminUpdateAllAccess,
+  fetchAdminVillagePlayers,
+  type AdminVillagePlayersResponse,
+} from "~/features/village/api";
+import { ApiError } from "~/lib/api";
+
+function errorMessage(e: unknown, fallback: string): string {
+  return e instanceof ApiError ? e.detail : fallback;
+}
+
+/** 管理者機能パネル。管理者プレイヤーのみ表示する。 */
+export function AdminPanel({
+  villageId,
+  onDone,
+}: {
+  villageId: number;
+  onDone: () => Promise<unknown>;
+}) {
+  return (
+    <Panel title="管理者メニュー">
+      <div className="space-y-[20px] text-[12px]">
+        <AccessSection villageId={villageId} onDone={onDone} />
+        <SelfVoteSection villageId={villageId} onDone={onDone} />
+        <LeaveSection villageId={villageId} onDone={onDone} />
+        <PlayersSection villageId={villageId} />
+      </div>
+    </Panel>
+  );
+}
+
+function AccessSection({
+  villageId,
+  onDone,
+}: {
+  villageId: number;
+  onDone: () => Promise<unknown>;
+}) {
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const submit = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await adminUpdateAllAccess(villageId);
+      await onDone();
+    } catch (e) {
+      setError(errorMessage(e, "全員アクセスに失敗しました"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div>
+      {error != null && <p className="text-[#e74c3c]">{error}</p>}
+      <Button onClick={submit} disabled={submitting}>
+        全員アクセス
+      </Button>
+    </div>
+  );
+}
+
+function SelfVoteSection({
+  villageId,
+  onDone,
+}: {
+  villageId: number;
+  onDone: () => Promise<unknown>;
+}) {
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const submit = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await adminInsertSelfVotes(villageId);
+      await onDone();
+    } catch (e) {
+      setError(errorMessage(e, "全員自分投票に失敗しました"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div>
+      {error != null && <p className="text-[#e74c3c]">{error}</p>}
+      <Button onClick={submit} disabled={submitting}>
+        全員自分投票
+      </Button>
+    </div>
+  );
+}
+
+function LeaveSection({
+  villageId,
+  onDone,
+}: {
+  villageId: number;
+  onDone: () => Promise<unknown>;
+}) {
+  const [villagePlayerId, setVillagePlayerId] = useState<string>("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const submit = async () => {
+    if (submitting || villagePlayerId === "") return;
+    if (!window.confirm("本当に退村させてよろしいですか？")) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await adminLeaveVillageParticipant(villageId, { villagePlayerId: Number(villagePlayerId) });
+      setVillagePlayerId("");
+      await onDone();
+    } catch (e) {
+      setError(errorMessage(e, "強制退村に失敗しました"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div>
+      <p className="mb-[5px] font-bold">強制退村</p>
+      {error != null && <p className="text-[#e74c3c]">{error}</p>}
+      <div className="flex flex-wrap items-center gap-[5px]">
+        <input
+          type="number"
+          className={inlineInputClass}
+          style={{ width: "100px" }}
+          value={villagePlayerId}
+          onChange={(e) => setVillagePlayerId(e.target.value)}
+          aria-label="村参加者ID"
+          placeholder="村参加者ID"
+        />
+        <Button variant="danger" onClick={submit} disabled={submitting || villagePlayerId === ""}>
+          退村させる
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function PlayersSection({ villageId }: { villageId: number }) {
+  const [players, setPlayers] = useState<AdminVillagePlayersResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const load = async () => {
+    if (loading) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchAdminVillagePlayers(villageId);
+      setPlayers(data);
+    } catch (e) {
+      setError(errorMessage(e, "参加プレイヤーの取得に失敗しました"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <p className="mb-[5px] font-bold">参加プレイヤー確認</p>
+      {error != null && <p className="text-[#e74c3c]">{error}</p>}
+      <Button onClick={load} disabled={loading}>
+        参加プレイヤーを表示
+      </Button>
+      {players != null && (
+        <table className="mt-[10px] w-full border-collapse border border-[#464545]">
+          <thead>
+            <tr>
+              <th className="border border-[#464545] px-[8px] py-[4px] text-left">キャラ名</th>
+              <th className="border border-[#464545] px-[8px] py-[4px] text-left">プレイヤー名</th>
+            </tr>
+          </thead>
+          <tbody>
+            {players.players.map((p) => (
+              <tr key={p.charaName}>
+                <td className="border border-[#464545] px-[8px] py-[4px]">{p.charaName}</td>
+                <td className="border border-[#464545] px-[8px] py-[4px]">{p.playerName}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -41,6 +41,7 @@ import { ApiError } from "~/lib/api";
 import { siteMeta } from "~/lib/meta";
 import { AbilityPanel } from "./AbilityPanel";
 import { ActionPanel } from "./ActionPanel";
+import { AdminPanel } from "./AdminPanel";
 import { AgeLimitModal } from "./AgeLimitModal";
 import { CommitPanel } from "./CommitPanel";
 import { CreatorPanel } from "./CreatorPanel";
@@ -455,6 +456,10 @@ export default function Village({ params }: Route.ComponentProps) {
             onConfirm={onCreatorSayConfirm}
             onDone={invalidate}
           />
+        )}
+
+        {mySituation != null && mySituation.admin.isAdmin && (
+          <AdminPanel villageId={villageId} onDone={invalidate} />
         )}
 
         {mySituation != null &&


### PR DESCRIPTION
closes .issues/step-8.16-village-admin.md

## 概要

管理者 (ROLE_ADMIN = playerId 1) 専用メニューを REST + React 化 (village-admin.md が正本)。base は `feature/monorepo-step8`。

## backend

- `VillageAdminRestController` (`/api/v1/villages/{id}/admin/*`): leave (強制退村) / access (全員アクセス) / vote (全員自己投票) / players (参加プレイヤー一覧) の 4 エンドポイント
- **管理者判定は JWT claim でなく DB を再確認** (`playerService.findPlayer` → `CDef.Authority.管理者`、03-auth の重要操作方針)
- **leave に村所属検証を追加** (SSR には無い。`villagePlayerId` が別村の参加者なら 400「この村の参加者ではありません」— 村跨ぎの誤操作防止)
- SSR `AdminController` の Bhv 直接操作 (全員アクセス・全員自己投票・参加プレイヤー) は `AdminVillageService` (application 層) に移設してロジック同一を維持 (ドメインモデル経由への整理は将来課題としてコメントに明記)

## frontend

- `AdminPanel`「管理者メニュー」: 全員アクセス / 全員自分投票 / 強制退村 (村参加者 ID 入力 + window.confirm) / **参加プレイヤー確認はパネル内インライン表示** (既存の別画面 JSON 表示からの確定済み UI 変更 — village-admin.md 記載のユーザー指示)
- `admin.isAdmin` のときのみ描画

## 検証

- REST 実測 (master・村 6): players (9 名のキャラ名+プレイヤー名) / access 204 / vote 204 (未投票 8 名に自己投票が入ることを DB で確認)。異常系: 非 admin 400 (「管理者のみ実行できます」) / 未認証 401 / 別村の参加者 leave 400 / 存在しない villagePlayerId 400。leave の正常系は進行中フィクスチャを壊すため実測せず (委譲先 `villageCoordinator.leave` は 8.7 退村で実測済み)
- SPA 実 UI: 管理者メニュー表示、参加プレイヤーのインライン表示
- e2e 2 件追加 (読み取り + 無害な全員アクセスのみ。破壊的操作は実行しない)。**全 76 件 (75 passed + 1 アクション回数枯渇 skip)**
- backend ktlintCheck/test green。frontend typecheck/lint/format/build green。gen:api 差分込み

🤖 Generated with [Claude Code](https://claude.com/claude-code)