### PR TITLE
feat: 村切り抜き画面を React 化 (step-8.19)

### DIFF
--- a/e2e/tests/village-scrap.spec.ts
+++ b/e2e/tests/village-scrap.spec.ts
@@ -36,18 +36,20 @@ test("アンカー追加で URL に反映され、全消去で anchors が消え
   await page.goto(`village/${village.id}/scrap`);
   await expect(page.getByRole("heading", { level: 1 })).toBeVisible({ timeout: 15000 });
 
-  // アンカー入力 → 追加
+  // アンカー入力 → 追加 (発言取得 API の完了を待って DOM 反映を検証する)
   await page.getByLabel("アンカー").fill(">>1");
-  await page.getByRole("button", { name: "追加" }).click();
+  const [anchorsRes] = await Promise.all([
+    page.waitForResponse((res) => res.url().includes("/messages/anchors")),
+    page.getByRole("button", { name: "追加" }).click(),
+  ]);
 
   // URL に anchors=n1 が付く
   await expect(page).toHaveURL(/anchors=n1/, { timeout: 5000 });
 
-  // 発言の読み込みを待つ (無ければ 0 件でも URL 反映だけ assert)
-  const messageLocator = page.locator(".message");
-  const count = await messageLocator.count();
-  if (count > 0) {
-    await expect(messageLocator.first()).toBeVisible();
+  // 発言 #1 が存在する村なら、取得された発言が描画される
+  const body = (await anchorsRes.json()) as { messageList?: unknown[] };
+  if ((body.messageList ?? []).length > 0) {
+    await expect(page.locator(".message").first()).toBeVisible({ timeout: 15000 });
   }
 
   // 全消去 → anchors が URL から消える

--- a/e2e/tests/village-scrap.spec.ts
+++ b/e2e/tests/village-scrap.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * 村切り抜き画面 (`/village/{id}/scrap`) e2e。
+ * 村の状態はローカル DB に依存するため、村一覧 API から対象を動的に探し、
+ * 該当する村が無い場合はスキップする。読み取りのみで DB を変更しない。
+ */
+
+type SimpleVillage = { id: number; name: string };
+
+async function findVillages(page: Page, statuses: string[]): Promise<SimpleVillage[]> {
+  const query = statuses.map((s) => `status=${s}`).join("&");
+  const res = await page.request.get(`/wolf-mansion-api/api/v1/villages?${query}`);
+  expect(res.ok()).toBeTruthy();
+  const body = (await res.json()) as { villages: SimpleVillage[] };
+  return body.villages;
+}
+
+test("切り抜き画面が表示され、村タイトルが見える", async ({ page }) => {
+  const villages = await findVillages(page, ["IN_PROGRESS", "COMPLETED"]);
+  test.skip(villages.length === 0, "進行中/終了の村が無い DB のためスキップ");
+  const village = villages[0];
+
+  await page.goto(`village/${village.id}/scrap`);
+
+  await expect(page).toHaveTitle(`WOLF MANSION | ${village.name}`, { timeout: 15000 });
+  const number = String(village.id).padStart(4, "0");
+  await expect(page.getByRole("heading", { name: `${number}. ${village.name}` })).toBeVisible();
+});
+
+test("アンカー追加で URL に反映され、全消去で anchors が消える", async ({ page }) => {
+  const villages = await findVillages(page, ["IN_PROGRESS", "COMPLETED"]);
+  test.skip(villages.length === 0, "進行中/終了の村が無い DB のためスキップ");
+  const village = villages[0];
+
+  await page.goto(`village/${village.id}/scrap`);
+  await expect(page.getByRole("heading", { level: 1 })).toBeVisible({ timeout: 15000 });
+
+  // アンカー入力 → 追加
+  await page.getByLabel("アンカー").fill(">>1");
+  await page.getByRole("button", { name: "追加" }).click();
+
+  // URL に anchors=n1 が付く
+  await expect(page).toHaveURL(/anchors=n1/, { timeout: 5000 });
+
+  // 発言の読み込みを待つ (無ければ 0 件でも URL 反映だけ assert)
+  const messageLocator = page.locator(".message");
+  const count = await messageLocator.count();
+  if (count > 0) {
+    await expect(messageLocator.first()).toBeVisible();
+  }
+
+  // 全消去 → anchors が URL から消える
+  await page.getByRole("button", { name: "全消去" }).click();
+  await expect(page).not.toHaveURL(/anchors/, { timeout: 5000 });
+});

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -9,6 +9,7 @@ export default [
   route("announce", "routes/announce/route.tsx"),
   route("village-list", "routes/village-list/route.tsx"),
   route("village/:villageId/message", "routes/village-message/route.tsx"),
+  route("village/:villageId/scrap", "routes/village-scrap/route.tsx"),
   route("village/:villageId/day?/:day?", "routes/village/route.tsx"),
   route("new-village", "routes/new-village/route.tsx"),
   route("village/:villageId/settings", "routes/village-settings/route.tsx"),

--- a/frontend/app/routes/village-scrap/route.tsx
+++ b/frontend/app/routes/village-scrap/route.tsx
@@ -1,0 +1,145 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef, useState } from "react";
+import { useSearchParams } from "react-router";
+
+import { PageLayout } from "~/components/layout/PageLayout";
+import { Button, LinkButton } from "~/components/ui/Button";
+import { inputClass } from "~/components/ui/Input";
+import { useRandomKeywords } from "~/features/random-keywords/useRandomKeywords";
+import { fetchAnchorMessages } from "~/features/village/api";
+import { useVillage } from "~/features/village/useVillage";
+import { ApiError } from "~/lib/api";
+import { siteMeta } from "~/lib/meta";
+import { AgeLimitModal } from "../village/AgeLimitModal";
+import { MessageCard } from "../village/MessageCard";
+import type { Route } from "./+types/route";
+
+export function meta(_: Route.MetaArgs) {
+  return siteMeta();
+}
+
+/**
+ * アンカー入力を API 用のキー文字列に変換する。
+ * 変換できない場合は null を返す。
+ */
+function parseAnchorInput(input: string): string | null {
+  if (input.startsWith(">>*")) return "w" + input.substring(3);
+  if (input.startsWith(">>#")) return "c" + input.substring(3);
+  if (input.startsWith(">>s")) return "S" + input.substring(3);
+  if (input.startsWith(">>=")) return "m" + input.substring(3);
+  if (input.startsWith(">>?")) return "l" + input.substring(3);
+  if (input.startsWith(">>_")) return "f" + input.substring(3);
+  if (input.startsWith(">>@")) return "s" + input.substring(3);
+  if (input.startsWith(">>-")) return "M" + input.substring(3);
+  if (input.startsWith(">>+")) return "g" + input.substring(3);
+  if (input.startsWith(">>a")) return "a" + input.substring(3);
+  if (input.startsWith(">>")) return "n" + input.substring(2);
+  return null;
+}
+
+export default function VillageScrap({ params }: Route.ComponentProps) {
+  const villageId = Number(params.villageId);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const anchors = searchParams.get("anchors") ?? "";
+  const [anchorInput, setAnchorInput] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const { data: village, error: villageError } = useVillage(villageId);
+  const { data: randomKeywords } = useRandomKeywords();
+  const { data } = useQuery({
+    queryKey: ["village-anchor-messages", villageId, anchors],
+    queryFn: () => fetchAnchorMessages(villageId, anchors),
+    enabled: anchors !== "",
+    retry: false,
+  });
+  const keywordList = (randomKeywords ?? []).map((k) => k.keyword ?? "").filter(Boolean);
+
+  useEffect(() => {
+    if (village != null) document.title = `WOLF MANSION | ${village.name}`;
+  }, [village]);
+
+  const addAnchor = () => {
+    const parsed = parseAnchorInput(anchorInput.trim());
+    if (parsed == null) return;
+    const next = anchors !== "" ? `${anchors}_${parsed}` : parsed;
+    setSearchParams({ anchors: next });
+    setAnchorInput("");
+    inputRef.current?.focus();
+  };
+
+  const clearAnchors = () => {
+    setSearchParams({});
+  };
+
+  if (villageError instanceof ApiError && villageError.status === 404) {
+    return (
+      <PageLayout>
+        <div className="px-[15px] py-[30px]">村が見つかりませんでした。</div>
+      </PageLayout>
+    );
+  }
+
+  const noAd = (village?.setting.tags.list ?? []).some((tag) => tag.code === "R18");
+  const ageLimit = (village?.setting.tags.list ?? []).find(
+    (tag) => tag.code === "R15" || tag.code === "R18",
+  )?.name;
+
+  const messages = data?.messageList ?? [];
+
+  return (
+    <PageLayout noAd={noAd}>
+      <div className="px-[15px] pb-[30px]">
+        {village != null && (
+          <>
+            <h1 className="my-[10.5px] text-[15px] font-normal">
+              {String(village.id).padStart(4, "0")}. {village.name}
+            </h1>
+            <hr className="mt-[5px] mb-[10px] border-[#464545]" />
+          </>
+        )}
+
+        {messages.map((message, index) => (
+          <MessageCard
+            key={`${message.messageType}-${message.messageNumber ?? index}`}
+            villageId={villageId}
+            message={message}
+            randomKeywords={keywordList}
+          />
+        ))}
+
+        <div className="mt-[10px]">
+          <p className="mb-[5px] text-gray-300">
+            アンカーを貼り付けて「追加」すると、発言が読み込まれます（追加も可能です）。
+          </p>
+          <div className="flex gap-[5px]">
+            <input
+              ref={inputRef}
+              type="text"
+              className={inputClass}
+              placeholder=">>1"
+              autoFocus
+              aria-label="アンカー"
+              value={anchorInput}
+              onChange={(e) => setAnchorInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") addAnchor();
+              }}
+            />
+            <Button variant="success" onClick={addAnchor} className="shrink-0">
+              追加
+            </Button>
+          </div>
+          <div className="mt-[10px] flex gap-[10px]">
+            <Button variant="danger" onClick={clearAnchors}>
+              全消去
+            </Button>
+            <LinkButton to={`/village/${villageId}`} variant="default">
+              村へ
+            </LinkButton>
+          </div>
+        </div>
+      </div>
+      {ageLimit != null && <AgeLimitModal villageId={villageId} ageLimit={ageLimit} />}
+    </PageLayout>
+  );
+}


### PR DESCRIPTION
closes .issues/step-8.19-village-scrap.md

## 概要

村切り抜き画面 `/village/{id}/scrap` を React 化 (village-scrap.md が正本)。Step 8 最後のサブ step。base は `feature/monorepo-step8`。

## 実装

- **backend 変更なし**: 既存の複数アンカー取得 REST (`GET /api/v1/villages/{id}/messages/anchors`、8.2 で実装済み) をそのまま使う。発言可視性は通常のメッセージマスクに従う
- frontend `/village/:villageId/scrap`:
  - **切り抜き対象は searchParams `anchors` が正本** (例 `n1_n2_w3`。共有 URL で再現できる、legacy parity)
  - アンカー入力 (`>>1` `>>*5` 等) → legacy `loadAnchor` と同じ接頭辞変換で追加。Enter でも追加可
  - メッセージ表示は村画面と同じ `MessageCard` 基盤 (返信/秘話リンクは出さない)
  - 全消去 / 村へ戻る。R18 村は noAd、R15/R18 は AgeLimitModal
  - 進行中でも開ける現状仕様 (SSR の isSettled コメントアウト) を維持

## 検証

- SPA 実 UI (村 6): `>>1` 追加 → `?anchors=n1` + 発言 1 件表示 → 全消去 → param 消滅
- e2e 2 件追加 (表示 / アンカー追加 → URL 反映 → 全消去。読み取りのみで DB 非汚染)。初回実行時に e2e 環境のコールドスタートで 1 件 flaky → 再実行で安定して pass。**全 81 件 (80 passed + 1 skip)**
- frontend typecheck/lint/format/build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)