### PR TITLE
feat: 表情差分 REST 化 (step-8.12.1)

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/village/VillageRpRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/VillageRpRestController.kt
@@ -85,7 +85,8 @@ class VillageRpRestController(
         if (!rpSituation(village, myself).canAddImage) {
             throw WolfMansionBusinessException("表情差分を追加できません")
         }
-        validateImageSize(image)
+        validateFaceTypeName(faceTypeName)
+        validateImage(image)
         charaService.registerOriginalCharaImage(
             village.setting.chara.charachipIds
                 .first(),
@@ -123,9 +124,18 @@ class VillageRpRestController(
         }
     }
 
-    private fun validateImageSize(image: MultipartFile) {
+    private fun validateFaceTypeName(name: String) {
+        if (name.isBlank() || name.length > 5) {
+            throw WolfMansionBusinessException("表情差分名は1～5文字で入力してください")
+        }
+    }
+
+    private fun validateImage(image: MultipartFile) {
         if (image.isEmpty || image.size > 100_000L) {
             throw WolfMansionBusinessException("画像は100KB以下のファイルを指定してください")
+        }
+        if (image.contentType?.startsWith("image/") != true) {
+            throw WolfMansionBusinessException("画像ファイルを指定してください")
         }
     }
 

--- a/backend/src/main/kotlin/com/ort/app/api/village/VillageRpRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/VillageRpRestController.kt
@@ -2,6 +2,7 @@ package com.ort.app.api.village
 
 import com.ort.app.api.village.request.VillageChangeNameRequest
 import com.ort.app.api.village.request.VillageMemoRequest
+import com.ort.app.api.village.request.VillageModifyFaceTypesRequest
 import com.ort.app.application.coordinator.VillageCoordinator
 import com.ort.app.application.service.CharaService
 import com.ort.app.application.service.VillageService
@@ -17,10 +18,13 @@ import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.server.ResponseStatusException
 
 /**
@@ -65,6 +69,64 @@ class VillageRpRestController(
             throw WolfMansionBusinessException("簡易メモを変更できません")
         }
         villageService.changeMemo(myself, request.memo!!)
+    }
+
+    /** 表情差分を追加する（原画村限定）。 */
+    @Operation(operationId = "addVillageFaceType")
+    @PostMapping("/face-types", consumes = ["multipart/form-data"])
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun addFaceType(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+        @RequestPart faceTypeName: String,
+        @RequestPart image: MultipartFile,
+    ) {
+        val (village, myself) = resolveParticipant(principal, id)
+        if (!rpSituation(village, myself).canAddImage) {
+            throw WolfMansionBusinessException("表情差分を追加できません")
+        }
+        validateImageSize(image)
+        charaService.registerOriginalCharaImage(
+            village.setting.chara.charachipIds
+                .first(),
+            myself.charaId,
+            faceTypeName,
+            image,
+        )
+    }
+
+    /** 表情差分を一括編集する（原画村限定）。 */
+    @Operation(operationId = "modifyVillageFaceTypes")
+    @PutMapping("/face-types")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun modifyFaceTypes(
+        @AuthenticationPrincipal principal: JwtPrincipal?,
+        @PathVariable id: Int,
+        @RequestBody @Valid request: VillageModifyFaceTypesRequest,
+    ) {
+        val (village, myself) = resolveParticipant(principal, id)
+        if (!rpSituation(village, myself).canAddImage) {
+            throw WolfMansionBusinessException("表情差分を編集できません")
+        }
+        val chara =
+            charaService.findChara(myself.charaId, true)
+                ?: throw WolfMansionBusinessException("キャラクターが見つかりません")
+        val ownCodes =
+            chara.images.list
+                .map { it.faceType.code }
+                .toSet()
+        request.list!!.forEach { item ->
+            if (item.code!! !in ownCodes) {
+                throw WolfMansionBusinessException("自分のキャラの表情差分のみ編集できます")
+            }
+            charaService.updateOriginalCharaImage(item.code, item.name!!, item.isDisplay!!)
+        }
+    }
+
+    private fun validateImageSize(image: MultipartFile) {
+        if (image.isEmpty || image.size > 100_000L) {
+            throw WolfMansionBusinessException("画像は100KB以下のファイルを指定してください")
+        }
     }
 
     private fun rpSituation(

--- a/backend/src/main/kotlin/com/ort/app/api/village/request/VillageModifyFaceTypesRequest.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/request/VillageModifyFaceTypesRequest.kt
@@ -1,0 +1,24 @@
+package com.ort.app.api.village.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+
+data class VillageModifyFaceTypesRequest(
+    @field:Valid
+    @field:NotNull
+    val list: List<FaceTypeModifyItem>? = null,
+) {
+    @Schema(name = "VillageModifyFaceTypesRequestItem")
+    data class FaceTypeModifyItem(
+        @field:NotBlank
+        val code: String? = null,
+        @field:NotBlank
+        @field:Size(min = 1, max = 5)
+        val name: String? = null,
+        @field:NotNull
+        val isDisplay: Boolean? = null,
+    )
+}

--- a/frontend/app/api/openapi.json
+++ b/frontend/app/api/openapi.json
@@ -1342,6 +1342,77 @@
         "tags": ["village-debug-rest-controller"]
       }
     },
+    "/api/v1/villages/{id}/face-types": {
+      "post": {
+        "operationId": "addVillageFaceType",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "faceTypeName": {
+                    "type": "string"
+                  },
+                  "image": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                },
+                "required": ["faceTypeName", "image"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": ["village-rp-rest-controller"]
+      },
+      "put": {
+        "operationId": "modifyVillageFaceTypes",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VillageModifyFaceTypesRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "tags": ["village-rp-rest-controller"]
+      }
+    },
     "/api/v1/villages/{id}/info": {
       "get": {
         "operationId": "getVillageInfo",
@@ -4775,6 +4846,36 @@
           "messageList",
           "pageNumList"
         ]
+      },
+      "VillageModifyFaceTypesRequest": {
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": ["array", "null"],
+            "items": {
+              "$ref": "#/components/schemas/VillageModifyFaceTypesRequestItem"
+            }
+          }
+        },
+        "required": ["list"]
+      },
+      "VillageModifyFaceTypesRequestItem": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": ["string", "null"],
+            "minLength": 1
+          },
+          "isDisplay": {
+            "type": ["boolean", "null"]
+          },
+          "name": {
+            "type": ["string", "null"],
+            "maxLength": 5,
+            "minLength": 1
+          }
+        },
+        "required": ["code", "isDisplay", "name"]
       },
       "VillageNotificationRequest": {
         "type": "object",

--- a/frontend/app/api/types.ts
+++ b/frontend/app/api/types.ts
@@ -643,6 +643,22 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/villages/{id}/face-types": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put: operations["modifyVillageFaceTypes"];
+    post: operations["addVillageFaceType"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/villages/{id}/info": {
     parameters: {
       query?: never;
@@ -1737,6 +1753,14 @@ export interface components {
       pageNumList: number[];
       suddenlyDeathMessage?: string | null;
       villageStatusMessage?: string | null;
+    };
+    VillageModifyFaceTypesRequest: {
+      list: components["schemas"]["VillageModifyFaceTypesRequestItem"][] | null;
+    };
+    VillageModifyFaceTypesRequestItem: {
+      code: string | null;
+      isDisplay: boolean | null;
+      name: string | null;
     };
     VillageNotificationRequest: {
       abilitySay?: boolean | null;
@@ -3104,6 +3128,58 @@ export interface operations {
       cookie?: never;
     };
     requestBody?: never;
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  modifyVillageFaceTypes: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["VillageModifyFaceTypesRequest"];
+      };
+    };
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  addVillageFaceType: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "multipart/form-data": {
+          faceTypeName: string;
+          /** Format: binary */
+          image: string;
+        };
+      };
+    };
     responses: {
       /** @description No Content */
       204: {

--- a/frontend/app/features/village/api.ts
+++ b/frontend/app/features/village/api.ts
@@ -289,11 +289,7 @@ export function changeVillageMemo(id: number, request: VillageMemoRequest): Prom
 }
 
 /** 表情差分を追加する（原画村限定）。要認証 → 204。 */
-export function addVillageFaceType(
-  id: number,
-  faceTypeName: string,
-  image: File,
-): Promise<void> {
+export function addVillageFaceType(id: number, faceTypeName: string, image: File): Promise<void> {
   const form = new FormData();
   form.append("faceTypeName", faceTypeName);
   form.append("image", image);

--- a/frontend/app/features/village/api.ts
+++ b/frontend/app/features/village/api.ts
@@ -288,6 +288,26 @@ export function changeVillageMemo(id: number, request: VillageMemoRequest): Prom
   return apiFetch<void>(`/api/v1/villages/${id}/memo`, { method: "POST", body: request });
 }
 
+/** 表情差分を追加する（原画村限定）。要認証 → 204。 */
+export function addVillageFaceType(
+  id: number,
+  faceTypeName: string,
+  image: File,
+): Promise<void> {
+  const form = new FormData();
+  form.append("faceTypeName", faceTypeName);
+  form.append("image", image);
+  return apiFetch<void>(`/api/v1/villages/${id}/face-types`, { method: "POST", body: form });
+}
+
+/** 表情差分を一括編集する（原画村限定）。要認証 → 204。 */
+export function modifyVillageFaceTypes(
+  id: number,
+  list: { code: string; name: string; isDisplay: boolean }[],
+): Promise<void> {
+  return apiFetch<void>(`/api/v1/villages/${id}/face-types`, { method: "PUT", body: { list } });
+}
+
 /** 村情報モーダル用の設定表示 (表示ラベル組み立て・マスク済み)。 */
 export type VillageSettingsContent = components["schemas"]["VillageSettingsContent"];
 

--- a/frontend/app/features/village/components/action/FaceTypePanel.tsx
+++ b/frontend/app/features/village/components/action/FaceTypePanel.tsx
@@ -1,8 +1,9 @@
-import { useRef, useState } from "react";
+import { useState } from "react";
 
 import { AlertList, ErrorMessage } from "~/components/ui/Alert";
 import { Button } from "~/components/ui/Button";
 import { ButtonRadioGroup } from "~/components/ui/ButtonRadioGroup";
+import { FileUpload } from "~/components/ui/FileUpload";
 import { VillageFormRow } from "~/components/ui/Form";
 import { inputClass } from "~/components/ui/Input";
 import { Panel } from "~/components/ui/Panel";
@@ -136,7 +137,7 @@ function AddFaceTypeForm({
 }) {
   const [faceTypeName, setFaceTypeName] = useState("");
   const [imageFile, setImageFile] = useState<File | null>(null);
-  const fileRef = useRef<HTMLInputElement>(null);
+  const [uploadKey, setUploadKey] = useState(0);
   const showToast = useToast((s) => s.show);
   const { error, submitting, execute } = useAsyncAction();
 
@@ -146,7 +147,7 @@ function AddFaceTypeForm({
       showToast("表情差分を追加しました");
       setFaceTypeName("");
       setImageFile(null);
-      if (fileRef.current) fileRef.current.value = "";
+      setUploadKey((k) => k + 1);
       await onDone();
     }, "表情差分の追加に失敗しました");
 
@@ -172,12 +173,12 @@ function AddFaceTypeForm({
         />
       </VillageFormRow>
       <VillageFormRow label="画像">
-        <input
-          ref={fileRef}
-          type="file"
+        <FileUpload
+          key={uploadKey}
           accept="image/*"
-          onChange={(e) => setImageFile(e.target.files?.[0] ?? null)}
-          aria-label="表情差分画像"
+          maxSizeBytes={100_000}
+          imagePreviewSize={60}
+          onSelect={setImageFile}
         />
       </VillageFormRow>
       <div className="flex justify-end">

--- a/frontend/app/features/village/components/action/FaceTypePanel.tsx
+++ b/frontend/app/features/village/components/action/FaceTypePanel.tsx
@@ -1,0 +1,189 @@
+import { useRef, useState } from "react";
+
+import { AlertList, ErrorMessage } from "~/components/ui/Alert";
+import { Button } from "~/components/ui/Button";
+import { VillageFormRow } from "~/components/ui/Form";
+import { inputClass } from "~/components/ui/Input";
+import { Panel } from "~/components/ui/Panel";
+import { useToast } from "~/components/ui/Toast";
+import {
+  addVillageFaceType,
+  modifyVillageFaceTypes,
+  type ParticipantSituationView,
+} from "~/features/village/api";
+import { useAsyncAction } from "~/lib/useAsyncAction";
+
+export function FaceTypePanel({
+  villageId,
+  mySituation,
+  onDone,
+}: {
+  villageId: number;
+  mySituation: ParticipantSituationView;
+  onDone: () => Promise<unknown>;
+}) {
+  const images = mySituation.myself?.chara.images.list ?? [];
+  return (
+    <Panel title="表情差分" storageKey="facetypeform" fixable>
+      <div className="space-y-[15px]">
+        {images.length > 0 && (
+          <ModifyFaceTypesForm villageId={villageId} images={images} onDone={onDone} />
+        )}
+        <AddFaceTypeForm villageId={villageId} onDone={onDone} />
+      </div>
+    </Panel>
+  );
+}
+
+type CharaImage = {
+  faceType: { code: string; name: string };
+  url: string;
+  isDisplay: boolean;
+};
+
+function ModifyFaceTypesForm({
+  villageId,
+  images,
+  onDone,
+}: {
+  villageId: number;
+  images: CharaImage[];
+  onDone: () => Promise<unknown>;
+}) {
+  const [items, setItems] = useState(() =>
+    images.map((img) => ({
+      code: img.faceType.code,
+      name: img.faceType.name,
+      isDisplay: img.isDisplay,
+      url: img.url,
+    })),
+  );
+  const showToast = useToast((s) => s.show);
+  const { error, submitting, execute } = useAsyncAction();
+
+  const updateItem = (index: number, patch: Partial<(typeof items)[0]>) => {
+    setItems((prev) => prev.map((item, i) => (i === index ? { ...item, ...patch } : item)));
+  };
+
+  const submit = () =>
+    execute(async () => {
+      await modifyVillageFaceTypes(
+        villageId,
+        items.map((item) => ({ code: item.code, name: item.name, isDisplay: item.isDisplay })),
+      );
+      showToast("表情差分を更新しました");
+      await onDone();
+    }, "表情差分の更新に失敗しました");
+
+  return (
+    <div className="space-y-[10px]">
+      <strong>表情差分編集</strong>
+      <AlertList>
+        <li>表情差分名は1～5文字で入力してください。</li>
+        <li>非表示にした表情差分は発言欄の候補に出てこなくなります（過去の発言の画像は消えません）。</li>
+      </AlertList>
+      <ErrorMessage error={error} />
+      <div className="grid grid-cols-1 gap-[10px] sm:grid-cols-2 lg:grid-cols-3">
+        {items.map((item, index) => (
+          <div key={item.code} className="flex gap-[5px]">
+            <img src={item.url} alt={item.name} width={60} height={60} className="shrink-0" />
+            <div className="flex flex-1 flex-col gap-[3px]">
+              <input
+                type="text"
+                className={inputClass}
+                value={item.name}
+                maxLength={5}
+                onChange={(e) => updateItem(index, { name: e.target.value })}
+                aria-label={`表情差分名 ${item.code}`}
+              />
+              <div className="flex gap-[3px]">
+                <button
+                  type="button"
+                  className={`rounded border px-[8px] py-[2px] text-sm ${item.isDisplay ? "border-green-700 bg-green-700 text-white" : "border-gray-400 text-gray-500"}`}
+                  onClick={() => updateItem(index, { isDisplay: true })}
+                >
+                  表示
+                </button>
+                <button
+                  type="button"
+                  className={`rounded border px-[8px] py-[2px] text-sm ${!item.isDisplay ? "border-green-700 bg-green-700 text-white" : "border-gray-400 text-gray-500"}`}
+                  onClick={() => updateItem(index, { isDisplay: false })}
+                >
+                  非表示
+                </button>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="flex justify-end">
+        <Button onClick={submit} disabled={submitting || items.some((item) => item.name === "")}>
+          表情差分を更新する
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function AddFaceTypeForm({
+  villageId,
+  onDone,
+}: {
+  villageId: number;
+  onDone: () => Promise<unknown>;
+}) {
+  const [faceTypeName, setFaceTypeName] = useState("");
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+  const showToast = useToast((s) => s.show);
+  const { error, submitting, execute } = useAsyncAction();
+
+  const submit = () =>
+    execute(async () => {
+      await addVillageFaceType(villageId, faceTypeName, imageFile!);
+      showToast("表情差分を追加しました");
+      setFaceTypeName("");
+      setImageFile(null);
+      if (fileRef.current) fileRef.current.value = "";
+      await onDone();
+    }, "表情差分の追加に失敗しました");
+
+  return (
+    <div className="space-y-[10px]">
+      <strong>表情差分追加</strong>
+      <AlertList>
+        <li>表情差分名は1～5文字で入力してください。</li>
+        <li>画像は60x60pxで表示されるため、解像度は60x60や120x120など60の倍数の大きさとすることを推奨します。</li>
+        <li>100kByteを超える画像はアップロードできません。</li>
+      </AlertList>
+      <ErrorMessage error={error} />
+      <VillageFormRow label="表情差分名">
+        <input
+          type="text"
+          className={inputClass}
+          value={faceTypeName}
+          maxLength={5}
+          onChange={(e) => setFaceTypeName(e.target.value)}
+          aria-label="表情差分名"
+        />
+      </VillageFormRow>
+      <VillageFormRow label="画像">
+        <input
+          ref={fileRef}
+          type="file"
+          accept="image/*"
+          onChange={(e) => setImageFile(e.target.files?.[0] ?? null)}
+          aria-label="表情差分画像"
+        />
+      </VillageFormRow>
+      <div className="flex justify-end">
+        <Button
+          onClick={submit}
+          disabled={submitting || faceTypeName === "" || imageFile == null}
+        >
+          表情差分を追加する
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/features/village/components/action/FaceTypePanel.tsx
+++ b/frontend/app/features/village/components/action/FaceTypePanel.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from "react";
 
 import { AlertList, ErrorMessage } from "~/components/ui/Alert";
 import { Button } from "~/components/ui/Button";
+import { ButtonRadioGroup } from "~/components/ui/ButtonRadioGroup";
 import { VillageFormRow } from "~/components/ui/Form";
 import { inputClass } from "~/components/ui/Input";
 import { Panel } from "~/components/ui/Panel";
@@ -103,22 +104,16 @@ function ModifyFaceTypesForm({
                 onChange={(e) => updateItem(index, { name: e.target.value })}
                 aria-label={`表情差分名 ${item.code}`}
               />
-              <div className="flex gap-[3px]">
-                <button
-                  type="button"
-                  className={`rounded border px-[8px] py-[2px] text-sm ${item.isDisplay ? "border-green-700 bg-green-700 text-white" : "border-gray-400 text-gray-500"}`}
-                  onClick={() => updateItem(index, { isDisplay: true })}
-                >
-                  表示
-                </button>
-                <button
-                  type="button"
-                  className={`rounded border px-[8px] py-[2px] text-sm ${!item.isDisplay ? "border-green-700 bg-green-700 text-white" : "border-gray-400 text-gray-500"}`}
-                  onClick={() => updateItem(index, { isDisplay: false })}
-                >
-                  非表示
-                </button>
-              </div>
+              <ButtonRadioGroup
+                options={[
+                  { value: true, label: "表示" },
+                  { value: false, label: "非表示" },
+                ]}
+                value={item.isDisplay}
+                onChange={(v) => updateItem(index, { isDisplay: v })}
+                ariaLabel={`表示切替 ${item.code}`}
+                variant="outline"
+              />
             </div>
           </div>
         ))}

--- a/frontend/app/features/village/components/action/FaceTypePanel.tsx
+++ b/frontend/app/features/village/components/action/FaceTypePanel.tsx
@@ -27,7 +27,12 @@ export function FaceTypePanel({
     <Panel title="表情差分" storageKey="facetypeform" fixable>
       <div className="space-y-[15px]">
         {images.length > 0 && (
-          <ModifyFaceTypesForm villageId={villageId} images={images} onDone={onDone} />
+          <ModifyFaceTypesForm
+            key={images.length}
+            villageId={villageId}
+            images={images}
+            onDone={onDone}
+          />
         )}
         <AddFaceTypeForm villageId={villageId} onDone={onDone} />
       </div>
@@ -80,7 +85,9 @@ function ModifyFaceTypesForm({
       <strong>表情差分編集</strong>
       <AlertList>
         <li>表情差分名は1～5文字で入力してください。</li>
-        <li>非表示にした表情差分は発言欄の候補に出てこなくなります（過去の発言の画像は消えません）。</li>
+        <li>
+          非表示にした表情差分は発言欄の候補に出てこなくなります（過去の発言の画像は消えません）。
+        </li>
       </AlertList>
       <ErrorMessage error={error} />
       <div className="grid grid-cols-1 gap-[10px] sm:grid-cols-2 lg:grid-cols-3">
@@ -153,7 +160,9 @@ function AddFaceTypeForm({
       <strong>表情差分追加</strong>
       <AlertList>
         <li>表情差分名は1～5文字で入力してください。</li>
-        <li>画像は60x60pxで表示されるため、解像度は60x60や120x120など60の倍数の大きさとすることを推奨します。</li>
+        <li>
+          画像は60x60pxで表示されるため、解像度は60x60や120x120など60の倍数の大きさとすることを推奨します。
+        </li>
         <li>100kByteを超える画像はアップロードできません。</li>
       </AlertList>
       <ErrorMessage error={error} />
@@ -177,10 +186,7 @@ function AddFaceTypeForm({
         />
       </VillageFormRow>
       <div className="flex justify-end">
-        <Button
-          onClick={submit}
-          disabled={submitting || faceTypeName === "" || imageFile == null}
-        >
+        <Button onClick={submit} disabled={submitting || faceTypeName === "" || imageFile == null}>
           表情差分を追加する
         </Button>
       </div>

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -426,14 +426,7 @@ export default function Village({ params }: Route.ComponentProps) {
 
         {mySituation != null &&
           (mySituation.rp.isAvailableChangeName || mySituation.rp.isAvailableMemo) && (
-            <RpPanel
-              villageId={villageId}
-              mySituation={mySituation}
-              onDone={async () => {
-                await invalidate();
-                requestAnimationFrame(() => scrollToBottom());
-              }}
-            />
+            <RpPanel villageId={villageId} mySituation={mySituation} onDone={invalidate} />
           )}
 
         {mySituation != null && mySituation.rp.canAddImage && (

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -521,7 +521,9 @@ export default function Village({ params }: Route.ComponentProps) {
         filter={filter}
         participants={situation?.participantList ?? []}
         myselfId={mySituation?.myself?.id ?? null}
-        notificationKeyword={mySituation?.myself?.notification?.message?.keywords?.join("\n") ?? null}
+        notificationKeyword={
+          mySituation?.myself?.notification?.message?.keywords?.join("\n") ?? null
+        }
         onApply={applyFilter}
         onApplyNewTab={applyFilterNewTab}
       />

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -33,6 +33,7 @@ import { siteMeta } from "~/lib/meta";
 import { AbilityPanel } from "~/features/village/components/action/AbilityPanel";
 import { ActionPanel } from "~/features/village/components/action/ActionPanel";
 import { CommitPanel } from "~/features/village/components/action/CommitPanel";
+import { FaceTypePanel } from "~/features/village/components/action/FaceTypePanel";
 import { RpPanel } from "~/features/village/components/action/RpPanel";
 import { SayPanel } from "~/features/village/components/action/SayPanel";
 import { VotePanel } from "~/features/village/components/action/VotePanel";
@@ -434,6 +435,17 @@ export default function Village({ params }: Route.ComponentProps) {
               }}
             />
           )}
+
+        {mySituation != null && mySituation.rp.canAddImage && (
+          <FaceTypePanel
+            villageId={villageId}
+            mySituation={mySituation}
+            onDone={async () => {
+              await invalidate();
+              requestAnimationFrame(() => scrollToBottom());
+            }}
+          />
+        )}
 
         {mySituation != null && mySituation.creator.isCreator && (
           <CreatorPanel

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -437,14 +437,7 @@ export default function Village({ params }: Route.ComponentProps) {
           )}
 
         {mySituation != null && mySituation.rp.canAddImage && (
-          <FaceTypePanel
-            villageId={villageId}
-            mySituation={mySituation}
-            onDone={async () => {
-              await invalidate();
-              requestAnimationFrame(() => scrollToBottom());
-            }}
-          />
+          <FaceTypePanel villageId={villageId} mySituation={mySituation} onDone={invalidate} />
         )}
 
         {mySituation != null && mySituation.creator.isCreator && (


### PR DESCRIPTION
closes .issues/step-8.12.1-face-type-rest.md

## Summary

- 原画村限定の表情差分追加 (`POST /api/v1/villages/{id}/face-types`, multipart/form-data) と一括編集 (`PUT /api/v1/villages/{id}/face-types`, JSON) を VillageRpRestController に追加
- SSR 版に欠如していた所有者検証を実装（自分のキャラの表情差分のみ操作可能）
- `canAddImage` situation フラグで可否検証 + 画像サイズバリデーション (100KB以下)
- FaceTypePanel コンポーネントで編集 UI (名前変更・表示/非表示トグル) + 追加 UI (画像アップロード + 名前入力) を実装
- OpenAPI spec 更新 (`pnpm gen:api`)

## Test plan

- [ ] 原画村でログイン → 表情差分パネルが表示される
- [ ] 表情差分追加: 画像 + 名前入力 → 成功 → 発言フォームの表情選択に反映
- [ ] 表情差分編集: 名前変更 → 更新成功
- [ ] 表情差分編集: 非表示切り替え → 発言フォームの選択肢から消える
- [ ] 非原画村ではパネル非表示
- [ ] 未ログインでは API が 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QgarCVmjuZJR5RDwLs72B