### PR TITLE
refactor: MessageCard分離・発言種別定数化・村設定画面の不足項目復元

### DIFF
--- a/frontend/app/features/village-form/CharaChipSection.tsx
+++ b/frontend/app/features/village-form/CharaChipSection.tsx
@@ -1,0 +1,58 @@
+import { useFormContext } from "react-hook-form";
+
+import { fieldErrorClass, FormRow } from "~/components/ui/Form";
+import { textareaClass } from "~/components/ui/Input";
+import { RequiredAfterCreationMark, SettingSection } from "./fields";
+import type { NewVillageFormInput } from "./schema";
+
+/**
+ * キャラチップ設定。キャラセット・ダミーキャラは村作成後に変更不可のため読み取り表示のみ。
+ * ダミーキャラの1日目発言は編集可能。
+ */
+export function CharaChipSection({
+  charachipNames,
+  dummyCharaName,
+}: {
+  charachipNames: string[];
+  dummyCharaName: string;
+}) {
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext<NewVillageFormInput>();
+
+  return (
+    <SettingSection title="キャラチップ設定">
+      <FormRow
+        label={
+          <>
+            キャラセット <RequiredAfterCreationMark />
+          </>
+        }
+        labelWidth="wide"
+      >
+        <p className="pt-[5px]">{charachipNames.join("、")}</p>
+      </FormRow>
+      <FormRow
+        label={
+          <>
+            ダミーキャラ <RequiredAfterCreationMark />
+          </>
+        }
+        labelWidth="wide"
+      >
+        <p className="pt-[5px]">{dummyCharaName}</p>
+      </FormRow>
+      <FormRow label="ダミーキャラの1日目発言" htmlFor="dummyDay1Message" labelWidth="wide">
+        <textarea
+          id="dummyDay1Message"
+          className={`${textareaClass} min-h-[77px]`}
+          {...register("dummyDay1Message")}
+        />
+        {errors.dummyDay1Message && (
+          <p className={fieldErrorClass}>{errors.dummyDay1Message.message}</p>
+        )}
+      </FormRow>
+    </SettingSection>
+  );
+}

--- a/frontend/app/features/village-form/DetailRuleSection.tsx
+++ b/frontend/app/features/village-form/DetailRuleSection.tsx
@@ -47,6 +47,7 @@ export function DetailRuleSection({
               役職希望 <RequiredAfterCreationMark />
             </>
           }
+          labelWidth="wide"
         >
           <p className="pt-[5px]">{fixedSkillRequest ? "有効" : "無効"}</p>
         </FormRow>

--- a/frontend/app/features/village-form/OtherSections.tsx
+++ b/frontend/app/features/village-form/OtherSections.tsx
@@ -55,6 +55,7 @@ export function SpectateSection({
               プロデューサー機能 <RequiredAfterCreationMark />
             </>
           }
+          labelWidth="wide"
         >
           <p className="pt-[5px]">{fixedCreatorIsProducer ? "あり" : "なし"}</p>
         </FormRow>

--- a/frontend/app/features/village-form/schema.ts
+++ b/frontend/app/features/village-form/schema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import type { SimpleSkillView } from "~/features/skills/api";
+import { MessageType } from "~/features/village/components/message/messageType";
 import { addPersonCountPrefix, DEFAULT_FIXED_ORGANIZATION } from "./organization";
 
 /**
@@ -271,14 +272,14 @@ export type CampAllocationInput = NewVillageFormInput["campAllocationList"][numb
 
 /** 発言制限の対象 (発言種別)。正本は backend `NewVillageForm.initialize` の対象種別。 */
 export const SKILL_SAY_MESSAGE_TYPES = [
-  { messageTypeCode: "WEREWOLF_SAY", messageTypeName: "人狼の囁き" },
-  { messageTypeCode: "MASON_SAY", messageTypeName: "共鳴発言" },
-  { messageTypeCode: "LOVERS_SAY", messageTypeName: "恋人発言" },
-  { messageTypeCode: "TELEPATHY", messageTypeName: "念話" },
+  { messageTypeCode: MessageType.WEREWOLF_SAY, messageTypeName: "人狼の囁き" },
+  { messageTypeCode: MessageType.MASON_SAY, messageTypeName: "共鳴発言" },
+  { messageTypeCode: MessageType.LOVERS_SAY, messageTypeName: "恋人発言" },
+  { messageTypeCode: MessageType.TELEPATHY, messageTypeName: "念話" },
 ] as const;
 
 export const RP_SAY_MESSAGE_TYPES = [
-  { messageTypeCode: "ACTION", messageTypeName: "アクション" },
+  { messageTypeCode: MessageType.ACTION, messageTypeName: "アクション" },
 ] as const;
 
 type MessageTypeRef = { messageTypeCode: string; messageTypeName: string };

--- a/frontend/app/features/village/components/action/ActionPanel.tsx
+++ b/frontend/app/features/village/components/action/ActionPanel.tsx
@@ -9,6 +9,7 @@ import type {
   VillageActionRequest,
   VillageFilterParticipantContent,
 } from "~/features/village/api";
+import { MessageType } from "~/features/village/components/message/messageType";
 
 /**
  * アクション発言フォーム (発言とは別パネル)。「{自分}は、{対象}{本文}」を結合して投稿する。
@@ -27,7 +28,7 @@ export function ActionPanel({
 }) {
   const myself = mySituation.myself;
   const restrict = mySituation.say.selectableMessageTypeList?.find(
-    (t) => t.messageType.code === "ACTION",
+    (t) => t.messageType.code === MessageType.ACTION,
   )?.restrict;
 
   const [target, setTarget] = useState("");

--- a/frontend/app/features/village/components/action/SayPanel.tsx
+++ b/frontend/app/features/village/components/action/SayPanel.tsx
@@ -13,45 +13,46 @@ import type {
 } from "~/features/village/api";
 import { resolveParticipantName } from "~/features/village/participants";
 import { useDisplaySettings } from "~/features/village/displaySettings";
+import { MessageType } from "~/features/village/components/message/messageType";
 import { MessageCard, type ReplyDraft } from "../message/MessageCard";
 export type { ReplyDraft };
 
 /** 発言種別ラジオの表示順とラベル (フォーム上の並び)。 */
 const SAY_TYPE_ORDER: { code: string; label: string }[] = [
-  { code: "WEREWOLF_SAY", label: "囁き" },
-  { code: "MASON_SAY", label: "共鳴" },
-  { code: "LOVERS_SAY", label: "恋人" },
-  { code: "TELEPATHY", label: "念話" },
-  { code: "NORMAL_SAY", label: "通常" },
-  { code: "GRAVE_SAY", label: "呻き" },
-  { code: "SPECTATE_SAY", label: "見学" },
-  { code: "MONOLOGUE_SAY", label: "独り言" },
-  { code: "SECRET_SAY", label: "秘話" },
+  { code: MessageType.WEREWOLF_SAY, label: "囁き" },
+  { code: MessageType.MASON_SAY, label: "共鳴" },
+  { code: MessageType.LOVERS_SAY, label: "恋人" },
+  { code: MessageType.TELEPATHY, label: "念話" },
+  { code: MessageType.NORMAL_SAY, label: "通常" },
+  { code: MessageType.GRAVE_SAY, label: "呻き" },
+  { code: MessageType.SPECTATE_SAY, label: "見学" },
+  { code: MessageType.MONOLOGUE_SAY, label: "独り言" },
+  { code: MessageType.SECRET_SAY, label: "秘話" },
 ];
 
 /** 発言種別 → textarea の背景色 (吹き出しと同じ配色)。 */
 const TYPE_TO_STYLE_KEY: Record<string, string> = {
-  WEREWOLF_SAY: "message-werewolf",
-  MASON_SAY: "message-mason",
-  LOVERS_SAY: "message-lover",
-  TELEPATHY: "message-telepathy",
-  MONOLOGUE_SAY: "message-monologue",
-  SECRET_SAY: "message-secret",
-  GRAVE_SAY: "message-grave",
-  SPECTATE_SAY: "message-spectate",
+  [MessageType.WEREWOLF_SAY]: "message-werewolf",
+  [MessageType.MASON_SAY]: "message-mason",
+  [MessageType.LOVERS_SAY]: "message-lover",
+  [MessageType.TELEPATHY]: "message-telepathy",
+  [MessageType.MONOLOGUE_SAY]: "message-monologue",
+  [MessageType.SECRET_SAY]: "message-secret",
+  [MessageType.GRAVE_SAY]: "message-grave",
+  [MessageType.SPECTATE_SAY]: "message-spectate",
 };
 
 /** 発言種別 → 既定の表情種別コード。 */
 const TYPE_TO_FACE: Record<string, string> = {
-  NORMAL_SAY: "NORMAL",
-  WEREWOLF_SAY: "WEREWOLF",
-  MASON_SAY: "MASON",
-  LOVERS_SAY: "LOVER",
-  TELEPATHY: "SECRET",
-  MONOLOGUE_SAY: "MONOLOGUE",
-  SECRET_SAY: "SECRET",
-  GRAVE_SAY: "GRAVE",
-  SPECTATE_SAY: "NORMAL",
+  [MessageType.NORMAL_SAY]: "NORMAL",
+  [MessageType.WEREWOLF_SAY]: "WEREWOLF",
+  [MessageType.MASON_SAY]: "MASON",
+  [MessageType.LOVERS_SAY]: "LOVER",
+  [MessageType.TELEPATHY]: "SECRET",
+  [MessageType.MONOLOGUE_SAY]: "MONOLOGUE",
+  [MessageType.SECRET_SAY]: "SECRET",
+  [MessageType.GRAVE_SAY]: "GRAVE",
+  [MessageType.SPECTATE_SAY]: "NORMAL",
 };
 
 /** 装飾タグ (選択範囲を囲む)。 */
@@ -105,7 +106,7 @@ export function SayPanel({
 
   const displayImages = images.filter((i) => i.isDisplay);
   const defaultType =
-    say.defaultMessageType?.code ?? selectable[0]?.messageType.code ?? "NORMAL_SAY";
+    say.defaultMessageType?.code ?? selectable[0]?.messageType.code ?? MessageType.NORMAL_SAY;
   const [messageType, setMessageType] = useState(defaultType);
   const [message, setMessage] = useState("");
   registerOnDone("say", () => setMessage(""));
@@ -127,7 +128,7 @@ export function SayPanel({
   useEffect(() => {
     if (reply == null) return;
     if (reply.secretTargetCharaId != null) {
-      changeType("SECRET_SAY");
+      changeType(MessageType.SECRET_SAY);
       setSecretTargetCharaId(String(reply.secretTargetCharaId));
     } else if (reply.anchorText != null) {
       insertAtCursor(`${reply.anchorText}\n`);
@@ -138,7 +139,7 @@ export function SayPanel({
   const current = selectable.find((t) => t.messageType.code === messageType);
   const restrict = current?.restrict;
   const secretTargetCharaIds =
-    selectable.find((t) => t.messageType.code === "SECRET_SAY")?.targetCharaIds ?? [];
+    selectable.find((t) => t.messageType.code === MessageType.SECRET_SAY)?.targetCharaIds ?? [];
 
   const length = message.length;
   const lineCount = message.split("\n").length;
@@ -152,7 +153,7 @@ export function SayPanel({
   const submitDisabled =
     overLimit ||
     message.trim().length === 0 ||
-    (messageType === "SECRET_SAY" && secretTargetCharaId === "");
+    (messageType === MessageType.SECRET_SAY && secretTargetCharaId === "");
 
   function faceTypeFor(type: string, codes: string[]): string | null {
     const candidate = TYPE_TO_FACE[type];
@@ -209,7 +210,7 @@ export function SayPanel({
       faceType,
       convertDisable,
       secretSayTargetCharaId:
-        messageType === "SECRET_SAY" && secretTargetCharaId !== ""
+        messageType === MessageType.SECRET_SAY && secretTargetCharaId !== ""
           ? Number(secretTargetCharaId)
           : null,
     });
@@ -274,7 +275,7 @@ export function SayPanel({
         </div>
 
         {/* 秘話相手 */}
-        {messageType === "SECRET_SAY" && (
+        {messageType === MessageType.SECRET_SAY && (
           <div className="mt-[10px]">
             <select
               className={selectClass}

--- a/frontend/app/features/village/components/message/MessageCard.tsx
+++ b/frontend/app/features/village/components/message/MessageCard.tsx
@@ -1,74 +1,15 @@
-import { type MouseEvent, useEffect, useMemo, useRef, useState } from "react";
-import { Link } from "react-router";
+import { type MouseEvent, useMemo, useState } from "react";
 
 import type { components } from "~/api/types";
-import { DEFAULT_MESSAGE_STYLE, MESSAGE_STYLES } from "~/components/ui/messageStyles";
 import { fetchAnchorMessage, type VillageMessageContent } from "~/features/village/api";
 import { useDisplaySettings } from "~/features/village/displaySettings";
-import { formatMessageTime, replaceIdLink, toMessageHtml } from "./messageHtml";
-import { ParticipantsTable } from "../info/ParticipantsTable";
+import { SAY_TYPES, SPOILED_TYPES } from "./messageType";
+import { type ReplyDraft, replaceIdLink, toMessageHtml } from "./message";
+import { SayMessage } from "./SayMessage";
+import { SystemMessage } from "./SystemMessage";
 
-/** 発言系メッセージの種別ごとの表示定義。アンカー接頭辞と装飾 (拡声/虹塗り) の対象か。 */
-const SAY_VARIANTS: Record<
-  string,
-  { anchorPrefix: string; styleKey: string; decoratable: boolean }
-> = {
-  NORMAL_SAY: { anchorPrefix: ">>", styleKey: "message-normal", decoratable: true },
-  WEREWOLF_SAY: { anchorPrefix: ">>*", styleKey: "message-werewolf", decoratable: true },
-  MONOLOGUE_SAY: { anchorPrefix: ">>-", styleKey: "message-monologue", decoratable: false },
-  SECRET_SAY: { anchorPrefix: ">>s", styleKey: "message-secret", decoratable: false },
-  MASON_SAY: { anchorPrefix: ">>=", styleKey: "message-mason", decoratable: true },
-  LOVERS_SAY: { anchorPrefix: ">>?", styleKey: "message-lover", decoratable: true },
-  TELEPATHY: { anchorPrefix: ">>_", styleKey: "message-telepathy", decoratable: true },
-  GRAVE_SAY: { anchorPrefix: ">>+", styleKey: "message-grave", decoratable: true },
-  SPECTATE_SAY: { anchorPrefix: ">>@", styleKey: "message-spectate", decoratable: false },
-};
-
-/** システム系メッセージの種別 → 配色キー。 */
-const SYSTEM_VARIANTS: Record<string, string> = {
-  PUBLIC_SYSTEM: "message-public-system",
-  PRIVATE_SYSTEM: "message-private-system",
-  PRIVATE_SEER: "message-private-seer",
-  PRIVATE_WISE: "message-private-seer",
-  PRIVATE_PSYCHIC: "message-private-psychic",
-  PRIVATE_GURU: "message-private-psychic",
-  PRIVATE_CORONER: "message-private-psychic",
-  PRIVATE_INVESTIGATE: "message-private-investigate",
-  PRIVATE_WEREWOLF: "message-private-werewolf",
-  PRIVATE_LOVER: "message-private-lover",
-  PRIVATE_FOX: "message-private-fox",
-  PRIVATE_ABILITY: "message-private-ability",
-};
-
-/** ネタバレ防止の対象種別 (エピローグ前は見えなかったもの)。 */
-const SPOILED_TYPES = new Set([
-  "WEREWOLF_SAY",
-  "MONOLOGUE_SAY",
-  "SECRET_SAY",
-  "MASON_SAY",
-  "LOVERS_SAY",
-  "TELEPATHY",
-  "GRAVE_SAY",
-  "SPECTATE_SAY",
-  "PRIVATE_SYSTEM",
-  "PRIVATE_SEER",
-  "PRIVATE_WISE",
-  "PRIVATE_PSYCHIC",
-  "PRIVATE_GURU",
-  "PRIVATE_CORONER",
-  "PRIVATE_INVESTIGATE",
-  "PRIVATE_WEREWOLF",
-  "PRIVATE_LOVER",
-  "PRIVATE_FOX",
-  "PRIVATE_ABILITY",
-]);
-
-const bubbleBaseClass = "message rounded-[5px] border p-[9px] break-words";
-
-// 種別クラス (message-normal 等) も付ける。本文内リンクの色分け CSS が参照する
-function bubbleClass(styleKey: string): string {
-  return `${bubbleBaseClass} ${styleKey} ${MESSAGE_STYLES[styleKey] ?? DEFAULT_MESSAGE_STYLE}`;
-}
+export type { ReplyDraft } from "./message";
+export { UserPageLink } from "./UserPageLink";
 
 type ExpandedAnchor = {
   key: string;
@@ -76,33 +17,6 @@ type ExpandedAnchor = {
   visible: boolean;
 };
 
-/** 返信・秘話返信で発言フォームへ引き継ぐ内容。 */
-export type ReplyDraft = {
-  /** 本文へ挿入するアンカー (秘話返信は null) */
-  anchorText: string | null;
-  /** 秘話返信なら宛先のキャラ ID */
-  secretTargetCharaId: number | null;
-  /** 引用表示する元発言 */
-  message: VillageMessageContent;
-};
-
-/** プレイヤーのプロフィールページへの別タブリンク。 */
-export function UserPageLink({ name }: { name: string }) {
-  return (
-    <Link
-      to={`/user/${encodeURIComponent(name)}`}
-      target="_blank"
-      className="text-wm-accent cursor-pointer hover:underline"
-    >
-      {name}
-    </Link>
-  );
-}
-
-/**
- * 発言ログの 1 メッセージ。本文中のアンカークリックで該当発言をこのカードの直下に
- * インライン展開する (展開済みは表示/非表示のトグル)。
- */
 export function MessageCard({
   villageId,
   message,
@@ -116,14 +30,10 @@ export function MessageCard({
   villageId: number;
   message: VillageMessageContent;
   randomKeywords: string[];
-  /** ネタバレ防止 (エピローグ前同等の表示)。対象種別の発言とプレイヤー名を隠す */
   spoiled?: boolean;
-  /** 参加者+見学者の全員リスト (参加者正体一覧の表示用) */
   allParticipants?: components["schemas"]["VillageParticipantView"][];
   onHashtagClick?: (tag: string) => void;
-  /** 返信 (アンカー挿入 + 引用)。未指定なら返信リンクを出さない */
   onReply?: (reply: ReplyDraft) => void;
-  /** 秘話返信 (宛先セット + 引用)。未指定なら秘話リンクを出さない */
   onSecret?: (reply: ReplyDraft) => void;
 }) {
   const [expandedAnchors, setExpandedAnchors] = useState<ExpandedAnchor[]>([]);
@@ -158,7 +68,6 @@ export function MessageCard({
     }
   };
 
-  // 生成 HTML 内のリンク/装飾はイベント委譲で扱う (アンカー展開・ハッシュタグ抽出・伏せ字解除)
   const onContentClick = (e: MouseEvent<HTMLDivElement>) => {
     const target = e.target as HTMLElement;
     const anchor = target.closest("[data-anchor-type]") as HTMLElement | null;
@@ -187,23 +96,30 @@ export function MessageCard({
     navigator.clipboard.writeText(text).then(() => alert(`コピーしました： ${text}`));
   };
 
-  // ネタバレ防止中はスポイラー対象の発言そのものを出さない
   if (spoiled && (message.isBigEars || SPOILED_TYPES.has(message.messageType))) {
     return null;
   }
 
-  const body = renderBody(
-    message,
-    html,
-    onContentClick,
-    copyAnchor,
-    villageId,
-    spoiled,
-    imageScale,
-    allParticipants,
-    onReply,
-    onSecret,
-  );
+  const body =
+    message.isBigEars || SAY_TYPES.has(message.messageType) ? (
+      <SayMessage
+        message={message}
+        html={html}
+        onContentClick={onContentClick}
+        copyAnchor={copyAnchor}
+        spoiled={spoiled}
+        imageScale={imageScale}
+        onReply={onReply}
+        onSecret={onSecret}
+      />
+    ) : (
+      <SystemMessage
+        message={message}
+        html={html}
+        onContentClick={onContentClick}
+        allParticipants={allParticipants}
+      />
+    );
 
   return (
     <div>
@@ -239,233 +155,4 @@ export function MessageCard({
         ))}
     </div>
   );
-}
-
-function renderBody(
-  message: VillageMessageContent,
-  html: string,
-  onContentClick: (e: MouseEvent<HTMLDivElement>) => void,
-  copyAnchor: (text: string) => void,
-  villageId: number,
-  spoiled: boolean,
-  imageScale: number,
-  allParticipants?: components["schemas"]["VillageParticipantView"][],
-  onReply?: (reply: ReplyDraft) => void,
-  onSecret?: (reply: ReplyDraft) => void,
-) {
-  const type = message.messageType;
-
-  // 梟の地獄耳: 発言者を伏せた特殊表示
-  if (message.isBigEars) {
-    return (
-      <div className="mb-[15px]">
-        <div className="text-village-sm">
-          <span>地獄耳</span>
-          <span className="ml-[5px]">{formatMessageTime(message.messageDatetime)}</span>
-        </div>
-        <div className="flex">
-          <div className="h-[77px] w-[50px] rounded-[5px] border border-white" />
-          <StableHtml
-            className={`ml-[5px] flex-1 ${bubbleClass("message-owl")}`}
-            onClick={onContentClick}
-            html={html}
-          />
-        </div>
-      </div>
-    );
-  }
-
-  const sayVariant = SAY_VARIANTS[type];
-  if (sayVariant != null) {
-    const alwaysShowAnchor = type !== "MONOLOGUE_SAY" && type !== "SECRET_SAY";
-    const anchorText =
-      message.messageNumber != null
-        ? `${sayVariant.anchorPrefix}${message.messageNumber}`
-        : alwaysShowAnchor
-          ? sayVariant.anchorPrefix
-          : null;
-    const loud = sayVariant.decoratable && message.isLoud;
-    const rainbow = sayVariant.decoratable && message.isRainbow;
-    const hasButtons =
-      (message.canReply && onReply != null) ||
-      (message.canSecret && onSecret != null && message.characterId != null);
-    return (
-      <div className={hasButtons ? "" : "mb-[20px]"}>
-        <div className="text-village-sm">
-          <span>
-            {anchorText != null && (
-              <>
-                <button
-                  type="button"
-                  className="text-wm-accent cursor-pointer hover:underline"
-                  onClick={() => copyAnchor(anchorText)}
-                >
-                  {anchorText}
-                </button>
-                .&nbsp;
-              </>
-            )}
-            {message.characterName}
-            {type === "SECRET_SAY" && ` → ${message.targetCharacterName ?? ""}`}
-            {message.playerName != null && !spoiled && (
-              <span>
-                &nbsp;[
-                <UserPageLink name={message.playerName} />]
-              </span>
-            )}
-          </span>
-          <span>&nbsp;{formatMessageTime(message.messageDatetime)}</span>
-        </div>
-        <div className="flex">
-          <div>
-            {message.characterImageUrl != null && (
-              <img
-                src={message.characterImageUrl}
-                width={message.width != null ? message.width * imageScale : undefined}
-                height={message.height != null ? message.height * imageScale : undefined}
-                alt={message.characterName ?? ""}
-              />
-            )}
-          </div>
-          <div
-            className={`ml-[5px] flex-1 ${bubbleClass(sayVariant.styleKey)} ${loud ? "loud" : ""}`}
-            onClick={onContentClick}
-          >
-            {rainbow ? <StableHtml className="rainbow" html={html} /> : <StableHtml html={html} />}
-          </div>
-        </div>
-        {(message.canReply || message.canSecret) && (onReply != null || onSecret != null) && (
-          <div className="flex justify-end gap-[10px]">
-            {message.canReply && onReply != null && (
-              <button
-                type="button"
-                className="text-wm-accent cursor-pointer hover:underline"
-                onClick={() =>
-                  onReply(
-                    type === "SECRET_SAY"
-                      ? {
-                          anchorText: null,
-                          secretTargetCharaId: message.characterId ?? null,
-                          message,
-                        }
-                      : { anchorText: anchorText ?? "", secretTargetCharaId: null, message },
-                  )
-                }
-              >
-                &gt;&gt;返信
-              </button>
-            )}
-            {message.canSecret && onSecret != null && message.characterId != null && (
-              <button
-                type="button"
-                className="text-wm-accent cursor-pointer hover:underline"
-                onClick={() =>
-                  onSecret({
-                    anchorText: null,
-                    secretTargetCharaId: message.characterId ?? null,
-                    message,
-                  })
-                }
-              >
-                &gt;&gt;秘話
-              </button>
-            )}
-          </div>
-        )}
-      </div>
-    );
-  }
-
-  if (type === "CREATOR_SAY") {
-    const creatorAnchorText = message.messageNumber != null ? `>>#${message.messageNumber}` : ">>#";
-    return (
-      <div>
-        <div className="text-village-sm">
-          <span>
-            <button
-              type="button"
-              className="text-wm-accent cursor-pointer hover:underline"
-              onClick={() => copyAnchor(creatorAnchorText)}
-            >
-              {creatorAnchorText}
-            </button>
-            .&nbsp;天からのお告げ
-          </span>
-          <span className="ml-[5px]">{formatMessageTime(message.messageDatetime)}</span>
-        </div>
-        <StableHtml
-          className={`mb-[20px] ${bubbleClass("message-creator")}`}
-          onClick={onContentClick}
-          html={html}
-        />
-      </div>
-    );
-  }
-
-  if (type === "ACTION") {
-    const actionAnchorText = message.messageNumber != null ? `>>a${message.messageNumber}` : ">>a";
-    return (
-      <div>
-        <div className="text-village-sm">
-          <span>
-            <button
-              type="button"
-              className="text-wm-accent cursor-pointer hover:underline"
-              onClick={() => copyAnchor(actionAnchorText)}
-            >
-              {actionAnchorText}
-            </button>
-            .
-            {message.playerName != null && !spoiled && (
-              <span>
-                &nbsp;[
-                <UserPageLink name={message.playerName} />]
-              </span>
-            )}
-          </span>
-          <span className="ml-[5px]">{formatMessageTime(message.messageDatetime)}</span>
-        </div>
-        <StableHtml
-          className={`mb-[20px] ${bubbleClass("message-action")}`}
-          onClick={onContentClick}
-          html={html}
-        />
-      </div>
-    );
-  }
-
-  if (type === "PARTICIPANTS" && allParticipants != null) {
-    return (
-      <div className={`mb-[20px] ${bubbleClass("message-public-system")}`}>
-        <ParticipantsTable participants={allParticipants} />
-      </div>
-    );
-  }
-
-  const systemStyleKey = SYSTEM_VARIANTS[type] ?? "message-public-system";
-  return (
-    <StableHtml
-      className={`mb-[20px] ${bubbleClass(systemStyleKey)}`}
-      onClick={onContentClick}
-      html={html}
-    />
-  );
-}
-
-// dangerouslySetInnerHTMLではなくref経由でDOMを直接設定する。
-// [[cw]]/[[netabare]]タグのクリックでclass除去した状態がReact再レンダリングで復元されるのを防ぐため。
-function StableHtml({
-  html,
-  className,
-  onClick,
-}: {
-  html: string;
-  className?: string;
-  onClick?: (e: MouseEvent<HTMLDivElement>) => void;
-}) {
-  const ref = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    if (ref.current) ref.current.innerHTML = html;
-  }, [html]);
-  return <div ref={ref} className={className} onClick={onClick} />;
 }

--- a/frontend/app/features/village/components/message/SayMessage.tsx
+++ b/frontend/app/features/village/components/message/SayMessage.tsx
@@ -1,0 +1,300 @@
+import type { MouseEvent } from "react";
+
+import type { VillageMessageContent } from "~/features/village/api";
+import { MessageType } from "./messageType";
+import { type ReplyDraft, SAY_VARIANTS, bubbleClass, formatMessageTime } from "./message";
+import { StableHtml } from "./StableHtml";
+import { UserPageLink } from "./UserPageLink";
+
+export function SayMessage({
+  message,
+  html,
+  onContentClick,
+  copyAnchor,
+  spoiled,
+  imageScale,
+  onReply,
+  onSecret,
+}: {
+  message: VillageMessageContent;
+  html: string;
+  onContentClick: (e: MouseEvent<HTMLDivElement>) => void;
+  copyAnchor: (text: string) => void;
+  spoiled: boolean;
+  imageScale: number;
+  onReply?: (reply: ReplyDraft) => void;
+  onSecret?: (reply: ReplyDraft) => void;
+}) {
+  const type = message.messageType;
+
+  if (message.isBigEars) {
+    return <BigEarsMessage message={message} html={html} onContentClick={onContentClick} />;
+  }
+
+  const sayVariant = SAY_VARIANTS[type];
+  if (sayVariant != null) {
+    return (
+      <SayBubble
+        message={message}
+        html={html}
+        sayVariant={sayVariant}
+        onContentClick={onContentClick}
+        copyAnchor={copyAnchor}
+        spoiled={spoiled}
+        imageScale={imageScale}
+        onReply={onReply}
+        onSecret={onSecret}
+      />
+    );
+  }
+
+  if (type === MessageType.CREATOR_SAY) {
+    return (
+      <CreatorSayMessage
+        message={message}
+        html={html}
+        onContentClick={onContentClick}
+        copyAnchor={copyAnchor}
+      />
+    );
+  }
+
+  return (
+    <ActionMessage
+      message={message}
+      html={html}
+      onContentClick={onContentClick}
+      copyAnchor={copyAnchor}
+      spoiled={spoiled}
+    />
+  );
+}
+
+function BigEarsMessage({
+  message,
+  html,
+  onContentClick,
+}: {
+  message: VillageMessageContent;
+  html: string;
+  onContentClick: (e: MouseEvent<HTMLDivElement>) => void;
+}) {
+  return (
+    <div className="mb-[15px]">
+      <div className="text-village-sm">
+        <span>地獄耳</span>
+        <span className="ml-[5px]">{formatMessageTime(message.messageDatetime)}</span>
+      </div>
+      <div className="flex">
+        <div className="h-[77px] w-[50px] rounded-[5px] border border-white" />
+        <StableHtml
+          className={`ml-[5px] flex-1 ${bubbleClass("message-owl")}`}
+          onClick={onContentClick}
+          html={html}
+        />
+      </div>
+    </div>
+  );
+}
+
+function CreatorSayMessage({
+  message,
+  html,
+  onContentClick,
+  copyAnchor,
+}: {
+  message: VillageMessageContent;
+  html: string;
+  onContentClick: (e: MouseEvent<HTMLDivElement>) => void;
+  copyAnchor: (text: string) => void;
+}) {
+  const anchorText = message.messageNumber != null ? `>>#${message.messageNumber}` : ">>#";
+  return (
+    <div>
+      <div className="text-village-sm">
+        <span>
+          <button
+            type="button"
+            className="text-wm-accent cursor-pointer hover:underline"
+            onClick={() => copyAnchor(anchorText)}
+          >
+            {anchorText}
+          </button>
+          .&nbsp;天からのお告げ
+        </span>
+        <span className="ml-[5px]">{formatMessageTime(message.messageDatetime)}</span>
+      </div>
+      <StableHtml
+        className={`mb-[20px] ${bubbleClass("message-creator")}`}
+        onClick={onContentClick}
+        html={html}
+      />
+    </div>
+  );
+}
+
+function ActionMessage({
+  message,
+  html,
+  onContentClick,
+  copyAnchor,
+  spoiled,
+}: {
+  message: VillageMessageContent;
+  html: string;
+  onContentClick: (e: MouseEvent<HTMLDivElement>) => void;
+  copyAnchor: (text: string) => void;
+  spoiled: boolean;
+}) {
+  const anchorText = message.messageNumber != null ? `>>a${message.messageNumber}` : ">>a";
+  return (
+    <div>
+      <div className="text-village-sm">
+        <span>
+          <button
+            type="button"
+            className="text-wm-accent cursor-pointer hover:underline"
+            onClick={() => copyAnchor(anchorText)}
+          >
+            {anchorText}
+          </button>
+          .
+          {message.playerName != null && !spoiled && (
+            <span>
+              &nbsp;[
+              <UserPageLink name={message.playerName} />]
+            </span>
+          )}
+        </span>
+        <span className="ml-[5px]">{formatMessageTime(message.messageDatetime)}</span>
+      </div>
+      <StableHtml
+        className={`mb-[20px] ${bubbleClass("message-action")}`}
+        onClick={onContentClick}
+        html={html}
+      />
+    </div>
+  );
+}
+
+function SayBubble({
+  message,
+  html,
+  sayVariant,
+  onContentClick,
+  copyAnchor,
+  spoiled,
+  imageScale,
+  onReply,
+  onSecret,
+}: {
+  message: VillageMessageContent;
+  html: string;
+  sayVariant: { anchorPrefix: string; styleKey: string; decoratable: boolean };
+  onContentClick: (e: MouseEvent<HTMLDivElement>) => void;
+  copyAnchor: (text: string) => void;
+  spoiled: boolean;
+  imageScale: number;
+  onReply?: (reply: ReplyDraft) => void;
+  onSecret?: (reply: ReplyDraft) => void;
+}) {
+  const type = message.messageType;
+  const alwaysShowAnchor = type !== MessageType.MONOLOGUE_SAY && type !== MessageType.SECRET_SAY;
+  const anchorText =
+    message.messageNumber != null
+      ? `${sayVariant.anchorPrefix}${message.messageNumber}`
+      : alwaysShowAnchor
+        ? sayVariant.anchorPrefix
+        : null;
+  const loud = sayVariant.decoratable && message.isLoud;
+  const rainbow = sayVariant.decoratable && message.isRainbow;
+  const hasButtons =
+    (message.canReply && onReply != null) ||
+    (message.canSecret && onSecret != null && message.characterId != null);
+
+  return (
+    <div className={hasButtons ? "" : "mb-[20px]"}>
+      <div className="text-village-sm">
+        <span>
+          {anchorText != null && (
+            <>
+              <button
+                type="button"
+                className="text-wm-accent cursor-pointer hover:underline"
+                onClick={() => copyAnchor(anchorText)}
+              >
+                {anchorText}
+              </button>
+              .&nbsp;
+            </>
+          )}
+          {message.characterName}
+          {type === MessageType.SECRET_SAY && ` → ${message.targetCharacterName ?? ""}`}
+          {message.playerName != null && !spoiled && (
+            <span>
+              &nbsp;[
+              <UserPageLink name={message.playerName} />]
+            </span>
+          )}
+        </span>
+        <span>&nbsp;{formatMessageTime(message.messageDatetime)}</span>
+      </div>
+      <div className="flex">
+        <div>
+          {message.characterImageUrl != null && (
+            <img
+              src={message.characterImageUrl}
+              width={message.width != null ? message.width * imageScale : undefined}
+              height={message.height != null ? message.height * imageScale : undefined}
+              alt={message.characterName ?? ""}
+            />
+          )}
+        </div>
+        <div
+          className={`ml-[5px] flex-1 ${bubbleClass(sayVariant.styleKey)} ${loud ? "loud" : ""}`}
+          onClick={onContentClick}
+        >
+          {rainbow ? <StableHtml className="rainbow" html={html} /> : <StableHtml html={html} />}
+        </div>
+      </div>
+      {(message.canReply || message.canSecret) && (onReply != null || onSecret != null) && (
+        <div className="flex justify-end gap-[10px]">
+          {message.canReply && onReply != null && (
+            <button
+              type="button"
+              className="text-wm-accent cursor-pointer hover:underline"
+              onClick={() =>
+                onReply(
+                  type === MessageType.SECRET_SAY
+                    ? {
+                        anchorText: null,
+                        secretTargetCharaId: message.characterId ?? null,
+                        message,
+                      }
+                    : { anchorText: anchorText ?? "", secretTargetCharaId: null, message },
+                )
+              }
+            >
+              &gt;&gt;返信
+            </button>
+          )}
+          {message.canSecret && onSecret != null && message.characterId != null && (
+            <button
+              type="button"
+              className="text-wm-accent cursor-pointer hover:underline"
+              onClick={() =>
+                onSecret({
+                  anchorText: null,
+                  secretTargetCharaId: message.characterId ?? null,
+                  message,
+                })
+              }
+            >
+              &gt;&gt;秘話
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/features/village/components/message/StableHtml.tsx
+++ b/frontend/app/features/village/components/message/StableHtml.tsx
@@ -1,0 +1,19 @@
+import { type MouseEvent, useEffect, useRef } from "react";
+
+// dangerouslySetInnerHTMLではなくref経由でDOMを直接設定する。
+// [[cw]]/[[netabare]]タグのクリックでclass除去した状態がReact再レンダリングで復元されるのを防ぐため。
+export function StableHtml({
+  html,
+  className,
+  onClick,
+}: {
+  html: string;
+  className?: string;
+  onClick?: (e: MouseEvent<HTMLDivElement>) => void;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (ref.current) ref.current.innerHTML = html;
+  }, [html]);
+  return <div ref={ref} className={className} onClick={onClick} />;
+}

--- a/frontend/app/features/village/components/message/SystemMessage.tsx
+++ b/frontend/app/features/village/components/message/SystemMessage.tsx
@@ -1,0 +1,37 @@
+import type { MouseEvent } from "react";
+
+import type { components } from "~/api/types";
+import type { VillageMessageContent } from "~/features/village/api";
+import { ParticipantsTable } from "../info/ParticipantsTable";
+import { MessageType } from "./messageType";
+import { SYSTEM_VARIANTS, bubbleClass } from "./message";
+import { StableHtml } from "./StableHtml";
+
+export function SystemMessage({
+  message,
+  html,
+  onContentClick,
+  allParticipants,
+}: {
+  message: VillageMessageContent;
+  html: string;
+  onContentClick: (e: MouseEvent<HTMLDivElement>) => void;
+  allParticipants?: components["schemas"]["VillageParticipantView"][];
+}) {
+  if (message.messageType === MessageType.PARTICIPANTS && allParticipants != null) {
+    return (
+      <div className={`mb-[20px] ${bubbleClass("message-public-system")}`}>
+        <ParticipantsTable participants={allParticipants} />
+      </div>
+    );
+  }
+
+  const systemStyleKey = SYSTEM_VARIANTS[message.messageType] ?? "message-public-system";
+  return (
+    <StableHtml
+      className={`mb-[20px] ${bubbleClass(systemStyleKey)}`}
+      onClick={onContentClick}
+      html={html}
+    />
+  );
+}

--- a/frontend/app/features/village/components/message/UserPageLink.tsx
+++ b/frontend/app/features/village/components/message/UserPageLink.tsx
@@ -1,0 +1,13 @@
+import { Link } from "react-router";
+
+export function UserPageLink({ name }: { name: string }) {
+  return (
+    <Link
+      to={`/user/${encodeURIComponent(name)}`}
+      target="_blank"
+      className="text-wm-accent cursor-pointer hover:underline"
+    >
+      {name}
+    </Link>
+  );
+}

--- a/frontend/app/features/village/components/message/message.ts
+++ b/frontend/app/features/village/components/message/message.ts
@@ -1,19 +1,78 @@
-/**
- * 発言本文 (生テキスト) を表示用 HTML へ変換する。サーバは本文を生のまま返し、
- * エスケープ・装飾・アンカーのリンク化はクライアントの責務 (発言保存時も生のまま)。
- *
- * 変換順序が安全性に直結する: 先に HTML エスケープし、その後で許可した装飾だけを
- * 信頼できる固定マークアップに置換する。
- */
+import { DEFAULT_MESSAGE_STYLE, MESSAGE_STYLES } from "~/components/ui/messageStyles";
+import type { VillageMessageContent } from "~/features/village/api";
+import { MessageType } from "./messageType";
 
-// ランダム表記 (展開済みの注釈を小さく出す)
+/** 発言系メッセージの種別ごとの表示定義。アンカー接頭辞と装飾 (拡声/虹塗り) の対象か。 */
+export const SAY_VARIANTS: Record<
+  string,
+  { anchorPrefix: string; styleKey: string; decoratable: boolean }
+> = {
+  [MessageType.NORMAL_SAY]: { anchorPrefix: ">>", styleKey: "message-normal", decoratable: true },
+  [MessageType.WEREWOLF_SAY]: {
+    anchorPrefix: ">>*",
+    styleKey: "message-werewolf",
+    decoratable: true,
+  },
+  [MessageType.MONOLOGUE_SAY]: {
+    anchorPrefix: ">>-",
+    styleKey: "message-monologue",
+    decoratable: false,
+  },
+  [MessageType.SECRET_SAY]: { anchorPrefix: ">>s", styleKey: "message-secret", decoratable: false },
+  [MessageType.MASON_SAY]: { anchorPrefix: ">>=", styleKey: "message-mason", decoratable: true },
+  [MessageType.LOVERS_SAY]: { anchorPrefix: ">>?", styleKey: "message-lover", decoratable: true },
+  [MessageType.TELEPATHY]: {
+    anchorPrefix: ">>_",
+    styleKey: "message-telepathy",
+    decoratable: true,
+  },
+  [MessageType.GRAVE_SAY]: { anchorPrefix: ">>+", styleKey: "message-grave", decoratable: true },
+  [MessageType.SPECTATE_SAY]: {
+    anchorPrefix: ">>@",
+    styleKey: "message-spectate",
+    decoratable: false,
+  },
+};
+
+/** システム系メッセージの種別 → 配色キー。 */
+export const SYSTEM_VARIANTS: Record<string, string> = {
+  [MessageType.PUBLIC_SYSTEM]: "message-public-system",
+  [MessageType.PRIVATE_SYSTEM]: "message-private-system",
+  [MessageType.PRIVATE_SEER]: "message-private-seer",
+  [MessageType.PRIVATE_WISE]: "message-private-seer",
+  [MessageType.PRIVATE_PSYCHIC]: "message-private-psychic",
+  [MessageType.PRIVATE_GURU]: "message-private-psychic",
+  [MessageType.PRIVATE_CORONER]: "message-private-psychic",
+  [MessageType.PRIVATE_INVESTIGATE]: "message-private-investigate",
+  [MessageType.PRIVATE_WEREWOLF]: "message-private-werewolf",
+  [MessageType.PRIVATE_LOVER]: "message-private-lover",
+  [MessageType.PRIVATE_FOX]: "message-private-fox",
+  [MessageType.PRIVATE_ABILITY]: "message-private-ability",
+};
+
+const bubbleBaseClass = "message rounded-[5px] border p-[9px] break-words";
+
+export function bubbleClass(styleKey: string): string {
+  return `${bubbleBaseClass} ${styleKey} ${MESSAGE_STYLES[styleKey] ?? DEFAULT_MESSAGE_STYLE}`;
+}
+
+/** 返信・秘話返信で発言フォームへ引き継ぐ内容。 */
+export type ReplyDraft = {
+  anchorText: string | null;
+  secretTargetCharaId: number | null;
+  message: VillageMessageContent;
+};
+
+// ---------------------------------------------------------------------------
+// 本文テキスト → 表示用 HTML 変換
+// ---------------------------------------------------------------------------
+
 const diceRegex = /(\[\[\d{1}d\d{1,5}\]\]?)/g;
 const fortuneRegex = /(\[\[fortune\]\])/g;
 const orRegex = /(?!\[\[fortune\]\])(\[\[[^\]]*or.*?\]\])/g;
 const whoRegex = /(?!\[\[allwho\]\])(\[\[who\]\])/g;
 const allWhoRegex = /(\[\[allwho\]\])/g;
 const gwhoRegex = /(\[\[gwho\]\])/g;
-// 文字装飾
 const colorRegex = /\[\[(#[0-9a-fA-F]{6})\]\](.*?)\[\[\/#\]\]/g;
 const boldRegex = /\[\[b\]\](.*?)\[\[\/b\]\]/g;
 const strikeRegex = /\[\[s\]\](.*?)\[\[\/s\]\]/g;
@@ -24,28 +83,24 @@ const netabareRegex = /\[\[netabare\]\](.*?)\[\[\/netabare\]\]/g;
 const cwRegex = /\[\[cw\]\](.*?)\[\[\/cw\]\]/g;
 const transparencyRegex = /\[\[tp\]\](.*?)\[\[\/tp\]\]/g;
 
-/** アンカー記法 → クリック用 data 属性 (messageType を data-anchor-type に持つ)。 */
 const ANCHOR_RULES: { regex: RegExp; type: string; prefix: string }[] = [
-  { regex: /&gt;&gt;(\d{1,5})/g, type: "NORMAL_SAY", prefix: "&gt;&gt;" },
-  { regex: /&gt;&gt;\+(\d{1,5})/g, type: "GRAVE_SAY", prefix: "&gt;&gt;+" },
-  { regex: /&gt;&gt;=(\d{1,5})/g, type: "MASON_SAY", prefix: "&gt;&gt;=" },
-  { regex: /&gt;&gt;\?(\d{1,5})/g, type: "LOVERS_SAY", prefix: "&gt;&gt;?" },
-  { regex: /&gt;&gt;_(\d{1,5})/g, type: "TELEPATHY", prefix: "&gt;&gt;_" },
-  { regex: /&gt;&gt;@(\d{1,5})/g, type: "SPECTATE_SAY", prefix: "&gt;&gt;@" },
-  { regex: /&gt;&gt;-(\d{1,5})/g, type: "MONOLOGUE_SAY", prefix: "&gt;&gt;-" },
-  { regex: /&gt;&gt;\*(\d{1,5})/g, type: "WEREWOLF_SAY", prefix: "&gt;&gt;*" },
-  { regex: /&gt;&gt;#(\d{1,5})/g, type: "CREATOR_SAY", prefix: "&gt;&gt;#" },
-  { regex: /&gt;&gt;a(\d{1,5})/g, type: "ACTION", prefix: "&gt;&gt;a" },
-  { regex: /&gt;&gt;s(\d{1,5})/g, type: "SECRET_SAY", prefix: "&gt;&gt;s" },
+  { regex: /&gt;&gt;(\d{1,5})/g, type: MessageType.NORMAL_SAY, prefix: "&gt;&gt;" },
+  { regex: /&gt;&gt;\+(\d{1,5})/g, type: MessageType.GRAVE_SAY, prefix: "&gt;&gt;+" },
+  { regex: /&gt;&gt;=(\d{1,5})/g, type: MessageType.MASON_SAY, prefix: "&gt;&gt;=" },
+  { regex: /&gt;&gt;\?(\d{1,5})/g, type: MessageType.LOVERS_SAY, prefix: "&gt;&gt;?" },
+  { regex: /&gt;&gt;_(\d{1,5})/g, type: MessageType.TELEPATHY, prefix: "&gt;&gt;_" },
+  { regex: /&gt;&gt;@(\d{1,5})/g, type: MessageType.SPECTATE_SAY, prefix: "&gt;&gt;@" },
+  { regex: /&gt;&gt;-(\d{1,5})/g, type: MessageType.MONOLOGUE_SAY, prefix: "&gt;&gt;-" },
+  { regex: /&gt;&gt;\*(\d{1,5})/g, type: MessageType.WEREWOLF_SAY, prefix: "&gt;&gt;*" },
+  { regex: /&gt;&gt;#(\d{1,5})/g, type: MessageType.CREATOR_SAY, prefix: "&gt;&gt;#" },
+  { regex: /&gt;&gt;a(\d{1,5})/g, type: MessageType.ACTION, prefix: "&gt;&gt;a" },
+  { regex: /&gt;&gt;s(\d{1,5})/g, type: MessageType.SECRET_SAY, prefix: "&gt;&gt;s" },
 ];
 
 function escapeRegExp(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-/**
- * 1 行ぶんの変換。エスケープ → ランダム表記 → ハッシュタグ → アンカーの順。
- */
 function convertLine(line: string, isConvertDisable: boolean, randomKeywords: string[]): string {
   let item = line
     .replace(/&/g, "&amp;")
@@ -64,7 +119,6 @@ function convertLine(line: string, isConvertDisable: boolean, randomKeywords: st
       item = item.replace(regex, '<span class="msg-extra-small">$1</span>');
     }
   }
-  // ハッシュタグ (アンカー記法・装飾タグの直後の # は対象外。否定後読みの非対応ブラウザ向け実装を踏襲)
   const hashArray = item.split("#");
   item = hashArray
     .map((str, index) => {
@@ -79,7 +133,6 @@ function convertLine(line: string, isConvertDisable: boolean, randomKeywords: st
       );
     })
     .join("");
-  // シングルクォートはハッシュタグより後で変換する
   item = item.replace(/'/g, "&#39;");
   for (const rule of ANCHOR_RULES) {
     item = item.replace(
@@ -90,7 +143,6 @@ function convertLine(line: string, isConvertDisable: boolean, randomKeywords: st
   return item;
 }
 
-/** 本文全体を表示用 HTML にする。 */
 export function toMessageHtml(
   content: string,
   isConvertDisable: boolean,
@@ -115,12 +167,8 @@ export function toMessageHtml(
   return mes;
 }
 
-/**
- * 死亡時の公開システムメッセージ中のユーザ ID をプロフィールリンクにする。
- * リンク先は SPA の `/user/{name}` (リンク規約: 未移行ページも SPA URL を指す)。
- */
 export function replaceIdLink(messageType: string, html: string): string {
-  if (messageType === "PUBLIC_SYSTEM" && html.includes("(master)、死亡")) {
+  if (messageType === MessageType.PUBLIC_SYSTEM && html.includes("(master)、死亡")) {
     const base = import.meta.env.BASE_URL.replace(/\/$/, "");
     return html.replace(
       / \(([^(]*)\)、/g,
@@ -131,7 +179,6 @@ export function replaceIdLink(messageType: string, html: string): string {
   return html;
 }
 
-/** ISO 日時 → `yyyy/MM/dd HH:mm:ss` 表示 (小数秒は落とす)。 */
 export function formatMessageTime(iso: string): string {
   return iso.split(".")[0].replace("T", " ").replace(/-/g, "/");
 }

--- a/frontend/app/features/village/components/message/messageType.ts
+++ b/frontend/app/features/village/components/message/messageType.ts
@@ -1,0 +1,67 @@
+export const MessageType = {
+  // 発言系
+  NORMAL_SAY: "NORMAL_SAY",
+  WEREWOLF_SAY: "WEREWOLF_SAY",
+  MONOLOGUE_SAY: "MONOLOGUE_SAY",
+  SECRET_SAY: "SECRET_SAY",
+  MASON_SAY: "MASON_SAY",
+  LOVERS_SAY: "LOVERS_SAY",
+  TELEPATHY: "TELEPATHY",
+  GRAVE_SAY: "GRAVE_SAY",
+  SPECTATE_SAY: "SPECTATE_SAY",
+  CREATOR_SAY: "CREATOR_SAY",
+  ACTION: "ACTION",
+  // システム系
+  PUBLIC_SYSTEM: "PUBLIC_SYSTEM",
+  PRIVATE_SYSTEM: "PRIVATE_SYSTEM",
+  PRIVATE_SEER: "PRIVATE_SEER",
+  PRIVATE_WISE: "PRIVATE_WISE",
+  PRIVATE_PSYCHIC: "PRIVATE_PSYCHIC",
+  PRIVATE_GURU: "PRIVATE_GURU",
+  PRIVATE_CORONER: "PRIVATE_CORONER",
+  PRIVATE_INVESTIGATE: "PRIVATE_INVESTIGATE",
+  PRIVATE_WEREWOLF: "PRIVATE_WEREWOLF",
+  PRIVATE_LOVER: "PRIVATE_LOVER",
+  PRIVATE_FOX: "PRIVATE_FOX",
+  PRIVATE_ABILITY: "PRIVATE_ABILITY",
+  // 特殊
+  PARTICIPANTS: "PARTICIPANTS",
+} as const;
+
+/** ネタバレ防止の対象種別 (エピローグ前は見えなかったもの)。 */
+export const SPOILED_TYPES: Set<string> = new Set([
+  MessageType.WEREWOLF_SAY,
+  MessageType.MONOLOGUE_SAY,
+  MessageType.SECRET_SAY,
+  MessageType.MASON_SAY,
+  MessageType.LOVERS_SAY,
+  MessageType.TELEPATHY,
+  MessageType.GRAVE_SAY,
+  MessageType.SPECTATE_SAY,
+  MessageType.PRIVATE_SYSTEM,
+  MessageType.PRIVATE_SEER,
+  MessageType.PRIVATE_WISE,
+  MessageType.PRIVATE_PSYCHIC,
+  MessageType.PRIVATE_GURU,
+  MessageType.PRIVATE_CORONER,
+  MessageType.PRIVATE_INVESTIGATE,
+  MessageType.PRIVATE_WEREWOLF,
+  MessageType.PRIVATE_LOVER,
+  MessageType.PRIVATE_FOX,
+  MessageType.PRIVATE_ABILITY,
+]);
+
+/** 発言系メッセージの種別。SayMessage で描画する対象の判定に使う。 */
+export const SAY_TYPES: Set<string> = new Set([
+  MessageType.NORMAL_SAY,
+  MessageType.WEREWOLF_SAY,
+  MessageType.MONOLOGUE_SAY,
+  MessageType.SECRET_SAY,
+  MessageType.MASON_SAY,
+  MessageType.LOVERS_SAY,
+  MessageType.TELEPATHY,
+  MessageType.GRAVE_SAY,
+  MessageType.SPECTATE_SAY,
+  MessageType.CREATOR_SAY,
+  MessageType.ACTION,
+]);

--- a/frontend/app/features/village/components/modal/FilterModal.tsx
+++ b/frontend/app/features/village/components/modal/FilterModal.tsx
@@ -7,6 +7,7 @@ import { Modal } from "~/components/ui/Modal";
 import { TextButton } from "~/components/ui/TextButton";
 import type { VillageFilterParticipantContent } from "~/features/village/api";
 import { EMPTY_FILTER, FILTER_TYPES, type MessageFilter } from "~/features/village/filter";
+import { MessageType } from "~/features/village/components/message/messageType";
 
 const ALL_TYPE_VALUES = FILTER_TYPES.map((t) => t.value);
 
@@ -166,13 +167,13 @@ export function FilterModal({
         <div>
           <strong>ショートカット機能</strong>
           <div className="mt-[10px]">
-            <TextButton onClick={() => sayShortcut("WEREWOLF_SAY")}>囁き</TextButton>
+            <TextButton onClick={() => sayShortcut(MessageType.WEREWOLF_SAY)}>囁き</TextButton>
             &nbsp;/&nbsp;
-            <TextButton onClick={() => sayShortcut("MASON_SAY")}>共鳴</TextButton>
+            <TextButton onClick={() => sayShortcut(MessageType.MASON_SAY)}>共鳴</TextButton>
             &nbsp;/&nbsp;
-            <TextButton onClick={() => sayShortcut("LOVERS_SAY")}>恋人</TextButton>
+            <TextButton onClick={() => sayShortcut(MessageType.LOVERS_SAY)}>恋人</TextButton>
             &nbsp;/&nbsp;
-            <TextButton onClick={() => sayShortcut("TELEPATHY")}>念話</TextButton>
+            <TextButton onClick={() => sayShortcut(MessageType.TELEPATHY)}>念話</TextButton>
             {myselfId != null && (
               <>
                 &nbsp;/&nbsp;

--- a/frontend/app/features/village/components/participate/ParticipatePanel.tsx
+++ b/frontend/app/features/village/components/participate/ParticipatePanel.tsx
@@ -13,7 +13,7 @@ import {
   type VillageParticipateRequest,
 } from "~/features/village/api";
 import { ApiError } from "~/lib/api";
-import { toMessageHtml } from "../message/messageHtml";
+import { toMessageHtml } from "../message/message";
 
 const OMAKASE = "LEFTOVER";
 

--- a/frontend/app/features/village/filter.ts
+++ b/frontend/app/features/village/filter.ts
@@ -3,20 +3,22 @@
  * パラメータ名は既存 (`fpid`/`typ`/`kwd`/`tpid`/`spl`) を踏襲する。
  */
 
+import { MessageType } from "~/features/village/components/message/messageType";
+
 /** 抽出モーダルの発言種別 (チェックボックスの並び順)。 */
 export const FILTER_TYPES: { value: string; label: string }[] = [
-  { value: "NORMAL_SAY", label: "通常" },
+  { value: MessageType.NORMAL_SAY, label: "通常" },
   { value: "GRAVE_SPECTATE_SAY", label: "墓下見学" },
-  { value: "MONOLOGUE_SAY", label: "独り言" },
-  { value: "CREATOR_SAY", label: "村建て発言" },
-  { value: "WEREWOLF_SAY", label: "囁き" },
-  { value: "MASON_SAY", label: "共鳴" },
-  { value: "LOVERS_SAY", label: "恋人" },
-  { value: "TELEPATHY", label: "念話" },
-  { value: "SECRET_SAY", label: "秘話" },
-  { value: "ACTION", label: "アクション" },
-  { value: "PUBLIC_SYSTEM", label: "公開シスメ" },
-  { value: "PRIVATE_SYSTEM", label: "非公開シスメ" },
+  { value: MessageType.MONOLOGUE_SAY, label: "独り言" },
+  { value: MessageType.CREATOR_SAY, label: "村建て発言" },
+  { value: MessageType.WEREWOLF_SAY, label: "囁き" },
+  { value: MessageType.MASON_SAY, label: "共鳴" },
+  { value: MessageType.LOVERS_SAY, label: "恋人" },
+  { value: MessageType.TELEPATHY, label: "念話" },
+  { value: MessageType.SECRET_SAY, label: "秘話" },
+  { value: MessageType.ACTION, label: "アクション" },
+  { value: MessageType.PUBLIC_SYSTEM, label: "公開シスメ" },
+  { value: MessageType.PRIVATE_SYSTEM, label: "非公開シスメ" },
 ];
 
 export type MessageFilter = {

--- a/frontend/app/routes/village-settings/route.tsx
+++ b/frontend/app/routes/village-settings/route.tsx
@@ -12,9 +12,14 @@ import { PageLayout } from "~/components/layout/PageLayout";
 import { RequireAuth } from "~/features/auth/RequireAuth";
 import type { SimpleSkillView } from "~/features/skills/api";
 import { useSkillList } from "~/features/skills/useSkillList";
-import { fetchVillageSettingForUpdate, updateVillageSetting } from "~/features/village/api";
+import {
+  fetchVillageInfo,
+  fetchVillageSettingForUpdate,
+  updateVillageSetting,
+} from "~/features/village/api";
 import { fetchVillageSetting } from "~/features/villages/api";
 import { BasicSection } from "~/features/village-form/BasicSection";
+import { CharaChipSection } from "~/features/village-form/CharaChipSection";
 import { DetailRuleSection } from "~/features/village-form/DetailRuleSection";
 import { RequiredAfterCreationMark } from "~/features/village-form/fields";
 import {
@@ -55,6 +60,11 @@ function VillageSettingsPage({ villageId }: { villageId: number }) {
     queryFn: () => fetchVillageSetting(villageId),
     retry: false,
   });
+  const { data: villageInfo } = useQuery({
+    queryKey: ["village-info", villageId],
+    queryFn: () => fetchVillageInfo(villageId),
+    retry: false,
+  });
 
   if (skillsLoading || settingLoading) {
     return (
@@ -92,6 +102,8 @@ function VillageSettingsPage({ villageId }: { villageId: number }) {
       fixedSkillRequest={publicSetting?.rule.isPossibleSkillRequest ?? true}
       fixedCreatorIsProducer={publicSetting?.rule.isCreatorIsProducer ?? false}
       isOriginalCharachip={publicSetting?.chara.isOriginalCharachip ?? false}
+      charachipNames={villageInfo?.charachips?.map((c) => c.name) ?? []}
+      dummyCharaName={villageInfo?.dummyCharaName ?? ""}
     />
   );
 }
@@ -103,6 +115,8 @@ function VillageSettingsForm({
   fixedSkillRequest,
   fixedCreatorIsProducer,
   isOriginalCharachip,
+  charachipNames,
+  dummyCharaName,
 }: {
   villageId: number;
   skills: SimpleSkillView[];
@@ -110,6 +124,8 @@ function VillageSettingsForm({
   fixedSkillRequest: boolean;
   fixedCreatorIsProducer: boolean;
   isOriginalCharachip: boolean;
+  charachipNames: string[];
+  dummyCharaName: string;
 }) {
   const navigate = useNavigate();
   const nowYear = useMemo(() => new Date().getFullYear(), []);
@@ -155,6 +171,7 @@ function VillageSettingsForm({
         <FormProvider {...form}>
           <form noValidate onSubmit={onSubmit}>
             <BasicSection nowYear={nowYear} />
+            <CharaChipSection charachipNames={charachipNames} dummyCharaName={dummyCharaName} />
             <DetailRuleSection
               skills={skills}
               defaultCamps={defaultCamps}
@@ -170,7 +187,7 @@ function VillageSettingsForm({
               <LinkButton variant="default" to={`/village/${villageId}`}>
                 村画面へ戻る
               </LinkButton>
-              <Button type="submit" disabled={saving}>
+              <Button type="submit" disabled={saving} className="ml-[10px]">
                 {saving ? "変更中..." : "変更する"}
               </Button>
             </FormActions>

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -28,6 +28,7 @@ import {
   useVillagePolling,
   useVillageSituation,
 } from "~/features/village/useVillage";
+import { MessageType } from "~/features/village/components/message/messageType";
 import { ApiError } from "~/lib/api";
 import { siteMeta } from "~/lib/meta";
 import { AbilityPanel } from "~/features/village/components/action/AbilityPanel";
@@ -79,19 +80,19 @@ function villageNumber(id: number): string {
 /** 確認画面の投稿ボタンのラベル (発言種別ごと)。 */
 function sayLabel(messageType: string | null | undefined): string {
   switch (messageType) {
-    case "WEREWOLF_SAY":
+    case MessageType.WEREWOLF_SAY:
       return "発言する（囁き）";
-    case "MASON_SAY":
+    case MessageType.MASON_SAY:
       return "発言する（共鳴）";
-    case "LOVERS_SAY":
+    case MessageType.LOVERS_SAY:
       return "発言する（恋人）";
-    case "TELEPATHY":
+    case MessageType.TELEPATHY:
       return "発言する（念話）";
-    case "MONOLOGUE_SAY":
+    case MessageType.MONOLOGUE_SAY:
       return "発言する（独り言）";
-    case "SECRET_SAY":
+    case MessageType.SECRET_SAY:
       return "発言する（秘話）";
-    case "GRAVE_SAY":
+    case MessageType.GRAVE_SAY:
       return "呻く";
     default:
       return "発言する";
@@ -144,11 +145,13 @@ export default function Village({ params }: Route.ComponentProps) {
   const invalidate = useInvalidateVillage(villageId);
   const keywordList = (randomKeywords ?? []).map((k) => k.keyword ?? "").filter(Boolean);
   const canAction =
-    mySituation?.say.selectableMessageTypeList?.some((t) => t.messageType.code === "ACTION") ??
-    false;
+    mySituation?.say.selectableMessageTypeList?.some(
+      (t) => t.messageType.code === MessageType.ACTION,
+    ) ?? false;
   const canSecretReply =
-    mySituation?.say.selectableMessageTypeList?.some((t) => t.messageType.code === "SECRET_SAY") ??
-    false;
+    mySituation?.say.selectableMessageTypeList?.some(
+      (t) => t.messageType.code === MessageType.SECRET_SAY,
+    ) ?? false;
 
   const {
     reply,


### PR DESCRIPTION
## Summary
- MessageCard を SayMessage / SystemMessage に分離し、StableHtml・UserPageLink を独立コンポーネント化
- messageHtml.ts を message.ts に統合、発言種別の文字列リテラルを messageType.ts で定数管理（MessageType / SPOILED_TYPES / SAY_TYPES）
- 村設定変更画面にキャラチップ設定セクション（キャラセット名・ダミーキャラ名・1日目発言）を復元
- 役職希望・プロデューサー機能の読み取り表示ラベル幅を他項目と統一

## Test plan
- [ ] 村画面で各種メッセージ（通常発言・囁き・システム・アクション・村建て発言・地獄耳）が正しく表示されること
- [ ] アンカークリックでの展開・折りたたみが動作すること
- [ ] 村設定変更画面でキャラチップ設定セクションが表示されること
- [ ] ダミーキャラの1日目発言が編集・保存できること
- [ ] 役職希望・プロデューサー機能のラベルが他項目と同じ幅で右揃えされていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QgarCVmjuZJR5RDwLs72B