### PR TITLE
fix: メッセージバブルのフォントを sans-serif に変更して既存と太さを統一

### DIFF
--- a/frontend/app/features/village/components/action/SayPanel.tsx
+++ b/frontend/app/features/village/components/action/SayPanel.tsx
@@ -354,7 +354,7 @@ export function SayPanel({
           </div>
           <textarea
             ref={textareaRef}
-            className={`ml-[5px] min-h-[150px] flex-1 rounded border border-[#464545] p-[9px] ${textareaStyle}`}
+            className={`ml-[5px] min-h-[150px] flex-1 rounded border border-[#464545] p-[9px] font-[sans-serif] ${textareaStyle}`}
             value={message}
             onChange={(e) => setMessage(e.target.value)}
             aria-label="発言"

--- a/frontend/app/features/village/components/admin/CreatorPanel.tsx
+++ b/frontend/app/features/village/components/admin/CreatorPanel.tsx
@@ -206,7 +206,7 @@ function CreatorSaySection({
       <ErrorMessage error={error} />
       <VillageFormRow label="村建て発言" align="start">
         <textarea
-          className="min-h-[77px] w-full rounded border border-[#464545] bg-white p-[9px] text-[#555]"
+          className="min-h-[77px] w-full rounded border border-[#464545] bg-white p-[9px] font-[sans-serif] text-[#555]"
           rows={5}
           value={message}
           onChange={(e) => setMessage(e.target.value)}

--- a/frontend/app/features/village/components/message/message.ts
+++ b/frontend/app/features/village/components/message/message.ts
@@ -50,7 +50,7 @@ export const SYSTEM_VARIANTS: Record<string, string> = {
   [MessageType.PRIVATE_ABILITY]: "message-private-ability",
 };
 
-const bubbleBaseClass = "message rounded-[5px] border p-[9px] break-words";
+const bubbleBaseClass = "message font-sans rounded-[5px] border p-[9px] break-words";
 
 export function bubbleClass(styleKey: string): string {
   return `${bubbleBaseClass} ${styleKey} ${MESSAGE_STYLES[styleKey] ?? DEFAULT_MESSAGE_STYLE}`;

--- a/frontend/app/features/village/components/message/message.ts
+++ b/frontend/app/features/village/components/message/message.ts
@@ -50,7 +50,7 @@ export const SYSTEM_VARIANTS: Record<string, string> = {
   [MessageType.PRIVATE_ABILITY]: "message-private-ability",
 };
 
-const bubbleBaseClass = "message font-sans rounded-[5px] border p-[9px] break-words";
+const bubbleBaseClass = "message rounded-[5px] border p-[9px] break-words font-[sans-serif]";
 
 export function bubbleClass(styleKey: string): string {
   return `${bubbleBaseClass} ${styleKey} ${MESSAGE_STYLES[styleKey] ?? DEFAULT_MESSAGE_STYLE}`;


### PR DESCRIPTION
closes .issues/fix-message-font-weight.md

## Summary

- 既存は `.message { font-family: sans-serif }` でメッセージにシステムフォントを使用
- 新 frontend では `M PLUS Rounded 1c` が継承されており、同じ weight 400 でもストロークが細く見えていた
- メッセージバブルの base class に `font-sans` (Tailwind) を追加し、既存と同じシステム sans-serif を使用するように修正

## Test plan

- [ ] 村画面でメッセージ表示を確認し、既存と同等の太さで表示されること
- [ ] rule ページの発言種別説明も同様に反映されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QgarCVmjuZJR5RDwLs72B