### PR TITLE
fix: 発言パネル固定表示時の不要スクロールを抑制し、リニューアルお知らせを追加

### DIFF
--- a/frontend/app/features/village/useSayFlow.ts
+++ b/frontend/app/features/village/useSayFlow.ts
@@ -15,6 +15,20 @@ import {
 import type { ReplyDraft } from "~/features/village/components/message/MessageCard";
 import { ApiError } from "~/lib/api";
 
+function isSayPanelFixed(): boolean {
+  try {
+    return localStorage.getItem("village_panel_bottom_fix") === "sayform";
+  } catch {
+    return false;
+  }
+}
+
+function scrollToSayPanel() {
+  if (!isSayPanelFixed()) {
+    document.getElementById("say-panel")?.scrollIntoView({ behavior: "smooth", block: "end" });
+  }
+}
+
 type SayPreview =
   | { kind: "say"; message: VillageMessageContent; request: VillageSayRequest }
   | { kind: "action"; message: VillageMessageContent; request: VillageActionRequest }
@@ -35,7 +49,7 @@ export function useSayFlow(
 
   const onReply = useCallback((draft: ReplyDraft) => {
     setReply(draft);
-    document.getElementById("say-panel")?.scrollIntoView({ behavior: "smooth", block: "end" });
+    scrollToSayPanel();
   }, []);
 
   const clearReply = useCallback(() => setReply(null), []);
@@ -116,7 +130,7 @@ export function useSayFlow(
 
   const onSayCancel = () => {
     setSayPreview(null);
-    document.getElementById("say-panel")?.scrollIntoView({ behavior: "smooth", block: "end" });
+    scrollToSayPanel();
   };
 
   return {

--- a/frontend/app/routes/announce/releases.ts
+++ b/frontend/app/routes/announce/releases.ts
@@ -12,6 +12,10 @@ export interface Release {
 
 export const releases: Release[] = [
   {
+    lead: ["2026/06/27 サイトをリニューアルしました。"],
+    items: [],
+  },
+  {
     lead: ["2026/06/11 以下を変更しました。"],
     items: [
       [


### PR DESCRIPTION
closes .issues/fix-reply-scroll-when-pinned.md

## Summary

- 発言パネルがピン留め（固定表示）されている場合、「>>返信」「>>秘話」クリックや確認キャンセル時の `scrollIntoView` をスキップするよう修正
- `/announce` に 2026/06/27 サイトリニューアルのお知らせを追加

## 変更内容

### スクロール修正 (`useSayFlow.ts`)
- `isSayPanelFixed()`: localStorage の `village_panel_bottom_fix === "sayform"` でピン留め状態を判定
- `scrollToSayPanel()`: 固定表示でない場合のみスクロールを実行
- `onReply` / `onSayCancel` で上記関数を使用

### お知らせ追加 (`releases.ts`)
- 先頭に「2026/06/27 サイトをリニューアルしました。」を追加

## Test plan
- [ ] 進行中の村で発言パネルを固定表示に設定し、「>>返信」「>>秘話」クリック時にスクロールが発生しないことを確認
- [ ] 固定表示を解除した状態では従来どおりスクロールすることを確認
- [ ] `/announce` ページにリニューアルお知らせが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QgarCVmjuZJR5RDwLs72B