### PR TITLE
fix: 投票テーブルで「投票者」クリック時に名前順でソートされるよう修正

### DIFF
--- a/frontend/app/features/village/components/info/VoteTab.tsx
+++ b/frontend/app/features/village/components/info/VoteTab.tsx
@@ -23,7 +23,9 @@ export function VoteTab({
 
   const sortedList = useMemo(() => {
     const voteList = vote.voteList ?? [];
-    if (sortDayIndex === 0) return voteList;
+    if (sortDayIndex === 0) {
+      return [...voteList].sort((a, b) => (a.charaName ?? "").localeCompare(b.charaName ?? ""));
+    }
     // クリックした日の投票先 (なし = 末尾) で並べ替える
     const targetIndex = sortDayIndex - 1;
     return [...voteList].sort((a, b) => {


### PR DESCRIPTION
closes .issues/fix-vote-sort-by-voter.md

## Summary

- 状況欄の投票テーブルで「投票者」列ヘッダーをクリックしても未ソートのまま返していたバグを修正
- `sortDayIndex === 0` のとき `charaName` の `localeCompare` でソートするよう変更

## Test plan
- [ ] 進行中の村で状況欄 → 投票を表示
- [ ] 「投票者」列ヘッダーをクリックして投票者名順にソートされることを確認
- [ ] 日付列のソートが従来どおり動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QgarCVmjuZJR5RDwLs72B