### PR TITLE
fix: ユーザー一覧のページングデザインを村画面に合わせる

### DIFF
--- a/frontend/app/components/ui/Pagination.tsx
+++ b/frontend/app/components/ui/Pagination.tsx
@@ -1,0 +1,87 @@
+import type { ReactNode } from "react";
+
+const itemBaseClass =
+  "-ml-px rounded-none border border-transparent px-[14px] py-[2px] text-white border-l-[#009c6c] mb-[2px]";
+
+export const paginationStyles = {
+  enabled: `${itemBaseClass} cursor-pointer bg-[#00bc8c] hover:bg-[#00dba3]`,
+  active: `${itemBaseClass} bg-[#00dba3]`,
+  disabled: `${itemBaseClass} cursor-not-allowed bg-[#007053]`,
+};
+
+export function Pagination({
+  currentPage,
+  allPageCount,
+  pageNums,
+  hasPrev,
+  hasNext,
+  onPage,
+  children,
+}: {
+  currentPage: number;
+  allPageCount: number;
+  pageNums: number[];
+  hasPrev: boolean;
+  hasNext: boolean;
+  onPage: (page: number) => void;
+  children?: ReactNode;
+}) {
+  return (
+    <div className="flex justify-end">
+      <ul className="my-[10px] flex [&>li:first-child>button]:ml-0 [&>li:first-child>button]:rounded-l-[4px] [&>li:last-child>button]:rounded-r-[4px]">
+        <li>
+          <button
+            type="button"
+            className={hasPrev ? paginationStyles.enabled : paginationStyles.disabled}
+            disabled={!hasPrev}
+            onClick={() => onPage(1)}
+          >
+            &lt;&lt;
+          </button>
+        </li>
+        <li>
+          <button
+            type="button"
+            className={hasPrev ? paginationStyles.enabled : paginationStyles.disabled}
+            disabled={!hasPrev}
+            onClick={() => onPage(currentPage - 1)}
+          >
+            &lt;
+          </button>
+        </li>
+        {pageNums.map((n) => (
+          <li key={n}>
+            <button
+              type="button"
+              className={n === currentPage ? paginationStyles.active : paginationStyles.enabled}
+              onClick={() => onPage(n)}
+            >
+              {n}
+            </button>
+          </li>
+        ))}
+        <li>
+          <button
+            type="button"
+            className={hasNext ? paginationStyles.enabled : paginationStyles.disabled}
+            disabled={!hasNext}
+            onClick={() => onPage(currentPage + 1)}
+          >
+            &gt;
+          </button>
+        </li>
+        <li>
+          <button
+            type="button"
+            className={hasNext ? paginationStyles.enabled : paginationStyles.disabled}
+            disabled={!hasNext}
+            onClick={() => onPage(allPageCount)}
+          >
+            &gt;&gt;
+          </button>
+        </li>
+        {children}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/app/features/village/components/message/MessagePagination.tsx
+++ b/frontend/app/features/village/components/message/MessagePagination.tsx
@@ -1,3 +1,4 @@
+import { Pagination, paginationStyles } from "~/components/ui/Pagination";
 import type { VillageMessageListContent } from "~/features/village/api";
 
 export type PageState = {
@@ -5,16 +6,6 @@ export type PageState = {
   isDispLatest: boolean;
 };
 
-const itemBaseClass =
-  "-ml-px rounded-none border border-transparent px-[14px] py-[2px] text-white border-l-[#009c6c] mb-[2px]";
-const enabledClass = `${itemBaseClass} cursor-pointer bg-[#00bc8c] hover:bg-[#00dba3]`;
-const activeClass = `${itemBaseClass} bg-[#00dba3]`;
-const disabledClass = `${itemBaseClass} cursor-not-allowed bg-[#007053]`;
-
-/**
- * 発言一覧のページング (1 ページのみの日は出さない)。
- * 先頭/前/番号/次/末尾/最新。「最新」は最終ページを最新発言が下になる向きで表示する。
- */
 export function MessagePagination({
   content,
   onChange,
@@ -24,73 +15,27 @@ export function MessagePagination({
 }) {
   if (content.allPageCount === 1) return null;
 
-  const currentPageNum = content.currentPageNum;
+  const currentPageNum = content.currentPageNum ?? 0;
   const goto = (pageNum: number) => onChange({ pageNum, isDispLatest: false });
 
   return (
-    <div className="flex justify-end">
-      <ul className="my-[10px] flex [&>li:first-child>button]:ml-0 [&>li:first-child>button]:rounded-l-[4px] [&>li:last-child>button]:rounded-r-[4px]">
-        <li>
-          <button
-            type="button"
-            className={content.isExistPrePage ? enabledClass : disabledClass}
-            disabled={!content.isExistPrePage}
-            onClick={() => goto(1)}
-          >
-            &lt;&lt;
-          </button>
-        </li>
-        <li>
-          <button
-            type="button"
-            className={content.isExistPrePage ? enabledClass : disabledClass}
-            disabled={!content.isExistPrePage || currentPageNum == null}
-            onClick={() => currentPageNum != null && goto(currentPageNum - 1)}
-          >
-            &lt;
-          </button>
-        </li>
-        {(content.pageNumList ?? []).map((pageNum) => (
-          <li key={pageNum}>
-            <button
-              type="button"
-              className={pageNum === currentPageNum ? activeClass : enabledClass}
-              onClick={() => goto(pageNum)}
-            >
-              {pageNum}
-            </button>
-          </li>
-        ))}
-        <li>
-          <button
-            type="button"
-            className={content.isExistNextPage ? enabledClass : disabledClass}
-            disabled={!content.isExistNextPage || currentPageNum == null}
-            onClick={() => currentPageNum != null && goto(currentPageNum + 1)}
-          >
-            &gt;
-          </button>
-        </li>
-        <li>
-          <button
-            type="button"
-            className={content.isExistNextPage ? enabledClass : disabledClass}
-            disabled={!content.isExistNextPage}
-            onClick={() => goto(content.allPageCount)}
-          >
-            &gt;&gt;
-          </button>
-        </li>
-        <li>
-          <button
-            type="button"
-            className={content.isDispLatest ? activeClass : enabledClass}
-            onClick={() => onChange({ pageNum: 1, isDispLatest: true })}
-          >
-            最新
-          </button>
-        </li>
-      </ul>
-    </div>
+    <Pagination
+      currentPage={currentPageNum}
+      allPageCount={content.allPageCount}
+      pageNums={content.pageNumList ?? []}
+      hasPrev={content.isExistPrePage}
+      hasNext={content.isExistNextPage}
+      onPage={goto}
+    >
+      <li>
+        <button
+          type="button"
+          className={content.isDispLatest ? paginationStyles.active : paginationStyles.enabled}
+          onClick={() => onChange({ pageNum: 1, isDispLatest: true })}
+        >
+          最新
+        </button>
+      </li>
+    </Pagination>
   );
 }

--- a/frontend/app/features/village/components/message/MessagePagination.tsx
+++ b/frontend/app/features/village/components/message/MessagePagination.tsx
@@ -16,7 +16,10 @@ export function MessagePagination({
   if (content.allPageCount === 1) return null;
 
   const currentPageNum = content.currentPageNum ?? 0;
-  const goto = (pageNum: number) => onChange({ pageNum, isDispLatest: false });
+  const goto = (pageNum: number) => {
+    if (pageNum < 1) return;
+    onChange({ pageNum, isDispLatest: false });
+  };
 
   return (
     <Pagination

--- a/frontend/app/routes/user-list/route.tsx
+++ b/frontend/app/routes/user-list/route.tsx
@@ -1,6 +1,7 @@
 import { Link, useSearchParams } from "react-router";
 
 import { Heading } from "~/components/ui/Heading";
+import { Pagination } from "~/components/ui/Pagination";
 import { PageLayout } from "~/components/layout/PageLayout";
 import { usePlayers } from "~/features/player/usePlayer";
 import { siteMeta } from "~/lib/meta";
@@ -31,7 +32,14 @@ export default function UserList() {
         <Heading>ユーザー一覧</Heading>
 
         {allPageCount > 1 && (
-          <Pagination currentPage={pageNum} allPageCount={allPageCount} onPage={goToPage} />
+          <Pagination
+            currentPage={pageNum}
+            allPageCount={allPageCount}
+            pageNums={calcPageNums(pageNum, allPageCount)}
+            hasPrev={pageNum > 1}
+            hasNext={pageNum < allPageCount}
+            onPage={goToPage}
+          />
         )}
 
         {players.length > 0 && (
@@ -60,72 +68,17 @@ export default function UserList() {
         )}
 
         {allPageCount > 1 && (
-          <Pagination currentPage={pageNum} allPageCount={allPageCount} onPage={goToPage} />
+          <Pagination
+            currentPage={pageNum}
+            allPageCount={allPageCount}
+            pageNums={calcPageNums(pageNum, allPageCount)}
+            hasPrev={pageNum > 1}
+            hasNext={pageNum < allPageCount}
+            onPage={goToPage}
+          />
         )}
       </div>
     </PageLayout>
-  );
-}
-
-function Pagination({
-  currentPage,
-  allPageCount,
-  onPage,
-}: {
-  currentPage: number;
-  allPageCount: number;
-  onPage: (page: number) => void;
-}) {
-  const pageNums = calcPageNums(currentPage, allPageCount);
-  const hasPrev = currentPage > 1;
-  const hasNext = currentPage < allPageCount;
-
-  const btn = "px-[8px] py-[4px] border border-[#464545] text-[10.5px]";
-  const disabled = `${btn} text-gray-600 cursor-default`;
-  const active = `${btn} bg-wm-accent text-black`;
-  const normal = `${btn} text-wm-accent hover:underline cursor-pointer`;
-
-  return (
-    <div className="my-[10px] flex justify-end gap-[2px]">
-      <button
-        type="button"
-        className={hasPrev ? normal : disabled}
-        onClick={() => hasPrev && onPage(1)}
-      >
-        &laquo;
-      </button>
-      <button
-        type="button"
-        className={hasPrev ? normal : disabled}
-        onClick={() => hasPrev && onPage(currentPage - 1)}
-      >
-        &lsaquo;
-      </button>
-      {pageNums.map((n) => (
-        <button
-          key={n}
-          type="button"
-          className={n === currentPage ? active : normal}
-          onClick={() => onPage(n)}
-        >
-          {n}
-        </button>
-      ))}
-      <button
-        type="button"
-        className={hasNext ? normal : disabled}
-        onClick={() => hasNext && onPage(currentPage + 1)}
-      >
-        &rsaquo;
-      </button>
-      <button
-        type="button"
-        className={hasNext ? normal : disabled}
-        onClick={() => hasNext && onPage(allPageCount)}
-      >
-        &raquo;
-      </button>
-    </div>
   );
 }
 


### PR DESCRIPTION
closes .issues/fix-player-list-paging-design.md

## Summary

- 共通 `Pagination` コンポーネントを `components/ui/Pagination.tsx` に抽出
- ユーザー一覧のインライン Pagination を共通コンポーネントに置き換え（緑ボタングループスタイルに統一）
- 村画面の `MessagePagination` も共通コンポーネントを内部で利用するようリファクタリング（「最新」ボタンは `children` で追加）

## Test plan
- [ ] ユーザー一覧ページのページングが村画面と同じ緑ボタングループデザインになっていることを確認
- [ ] ユーザー一覧のページ遷移が正常に動作することを確認
- [ ] 村画面のメッセージページングが従来どおり動作することを確認（「最新」ボタン含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QgarCVmjuZJR5RDwLs72B