### PR TITLE
fix: 年齢制限確認モーダルの「表示せず戻る」ボタンの色を統一

### DIFF
--- a/frontend/app/features/village/components/modal/AgeLimitModal.tsx
+++ b/frontend/app/features/village/components/modal/AgeLimitModal.tsx
@@ -61,7 +61,7 @@ export function AgeLimitModal({
           暴力表現や性描写などが含まれる可能性があります。
         </p>
         <div className="flex justify-end gap-[10px] text-[12px]">
-          <LinkButton to="/" variant="info">
+          <LinkButton to="/" variant="default">
             表示せず戻る
           </LinkButton>
           <Button onClick={confirm}>表示する</Button>


### PR DESCRIPTION
closes .issues/fix-age-modal-button-color.md

## Summary

- 年齢制限確認モーダルの「表示せず戻る」ボタンの variant を `info` → `default` に変更
- 他の閉じる・戻る系ボタンはすべて `variant="default"` を使用しており、それに統一

## Test plan
- [ ] 年齢制限付きの村を表示し、モーダルの「表示せず戻る」ボタンの色が他の閉じる・戻るボタンと同じであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QgarCVmjuZJR5RDwLs72B