### PR TITLE
fix: rule ページのバブル min-height とフォントを修正

### DIFF
--- a/frontend/app/components/ui/SkillMessage.tsx
+++ b/frontend/app/components/ui/SkillMessage.tsx
@@ -1,7 +1,7 @@
 import { DEFAULT_MESSAGE_STYLE, MESSAGE_STYLES } from "./messageStyles";
 
 const bubbleStyle = (styleKey: string) =>
-  `rounded-[5px] border p-[9px] break-words ${MESSAGE_STYLES[styleKey] ?? DEFAULT_MESSAGE_STYLE}`;
+  `rounded-[5px] border p-[9px] break-words font-[sans-serif] ${MESSAGE_STYLES[styleKey] ?? DEFAULT_MESSAGE_STYLE}`;
 
 export function SkillMessage({ messageType, content }: { messageType: string; content: string }) {
   return (

--- a/frontend/app/routes/rule/sections/OtherSection.tsx
+++ b/frontend/app/routes/rule/sections/OtherSection.tsx
@@ -189,7 +189,7 @@ function MessageTypeExample({
             }}
           />
         )}
-        <div className={hasImage ? "ml-[5px] min-h-[77px] flex-1" : "w-full"}>
+        <div className={hasImage ? "ml-[5px] min-h-[77px] flex-1 [&>div]:min-h-[77px]" : "w-full"}>
           <SkillMessage messageType={messageType} content={text} />
         </div>
       </div>


### PR DESCRIPTION
closes .issues/fix-rule-message-bubble-min-height.md

## Summary

- `SkillMessage` の `bubbleStyle` に `font-[sans-serif]` を追加（SayMessage の `bubbleClass` と統一）
- rule ページの `MessageTypeExample` でバブル div 自体に `min-h-[77px]` が適用されるよう `[&>div]:min-h-[77px]` を追加

## Test plan
- [ ] rule ページの発言種別説明でバブルがキャラ画像の高さ (77px) と揃っていることを確認
- [ ] rule ページのバブルフォントが村画面の発言と同じ sans-serif であることを確認
- [ ] 村画面のメッセージ表示に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QgarCVmjuZJR5RDwLs72B