### PR TITLE
fix: 部屋割グリッドのフォントサイズを rem 指定に変更し大きい文字設定時のはみ出しを防止

### DIFF
--- a/frontend/app/features/village/components/info/RoomAssignedTab.tsx
+++ b/frontend/app/features/village/components/info/RoomAssignedTab.tsx
@@ -25,7 +25,7 @@ export function RoomAssignedTab({
     <div className="pt-[10px] pb-[10px]">
       <div className="overflow-x-auto">
         <table
-          className={`${cellBorderClass} border-collapse text-village-sm`}
+          className={`${cellBorderClass} border-collapse text-[0.75rem]`}
           style={{ tableLayout: "fixed" }}
         >
           <tbody>


### PR DESCRIPTION
closes .issues/fix-room-image-text-overflow.md

## Summary

- 部屋割グリッドのフォントサイズを `text-village-sm` (`0.75em`) から `text-[0.75rem]` に変更
- `em` は親要素の `text-[150%]`（大きい文字設定）に乗じて拡大されるが、`rem` はルート基準のため影響を受けない
- 固定ピクセルサイズのセル内でテキストがはみ出す問題を解消
- 下部の日別状況テーブルは固定サイズセルではないため `text-village-sm` のまま維持

## Test plan
- [ ] 大きい文字設定で部屋割画像を表示し、名前・生存状況・ダミー等がセル内に収まることを確認
- [ ] 通常の文字サイズ設定でも表示が崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QgarCVmjuZJR5RDwLs72B