### PR TITLE
fix: select/input の高さを min-h に変更し大きい文字設定時の文字切れを防止

### DIFF
--- a/frontend/app/components/ui/Input.tsx
+++ b/frontend/app/components/ui/Input.tsx
@@ -6,13 +6,13 @@
 const baseClass = "rounded border border-gray-400 bg-white px-[10px] py-[5px] text-[#555555]";
 
 /** 1 行テキスト入力 (フォーム行いっぱいに広げる)。 */
-export const inputClass = `h-[30px] w-full ${baseClass}`;
+export const inputClass = `min-h-[30px] w-full ${baseClass}`;
 
 /** 1 行テキスト入力 (インライン配置用。幅は内容・呼び出し側に任せる)。 */
-export const inlineInputClass = `h-[30px] ${baseClass}`;
+export const inlineInputClass = `min-h-[30px] ${baseClass}`;
 
 /** 複数行テキスト入力。 */
 export const textareaClass = `w-full ${baseClass}`;
 
 /** セレクトボックス (フォーム行いっぱいに広げる)。 */
-export const selectClass = `h-[30px] w-full ${baseClass}`;
+export const selectClass = `min-h-[30px] w-full ${baseClass}`;


### PR DESCRIPTION
closes .issues/fix-input-height-large-font.md

## Summary

- `inputClass`/`inlineInputClass`/`selectClass` の `h-[30px]`（固定高さ）を `min-h-[30px]`（最小高さ）に変更
- 村画面の `text-[150%]`（大きい文字設定）適用時にフォントサイズに応じて要素が自然に伸びるようになり、文字切れを防止
- 通常サイズ時は padding + line-height で 30px 程度を維持するため見た目の変化なし

## Test plan
- [ ] 大きい文字設定で村画面の発言フォーム・アクション欄の select/input で文字切れがないことを確認
- [ ] 通常の文字サイズ設定でも select/input の見た目が崩れないことを確認
- [ ] 村作成画面等の select/input にも影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QgarCVmjuZJR5RDwLs72B