### PR TITLE
fix: スマホで部屋割セルタップ時に参加者名を表示する

### DIFF
--- a/frontend/app/features/village/components/info/RoomAssignedTab.tsx
+++ b/frontend/app/features/village/components/info/RoomAssignedTab.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { VillageRoomAssignedRow, VillageSituationContent } from "~/features/village/api";
 import { deadMark } from "./dead";
 
@@ -21,6 +22,8 @@ export function RoomAssignedTab({
   /** ネタバレ防止 (役職名を隠す) */
   spoiled?: boolean;
 }) {
+  const [selectedCharaName, setSelectedCharaName] = useState<string | null>(null);
+
   return (
     <div className="pt-[10px] pb-[10px]">
       <div className="overflow-x-auto">
@@ -34,12 +37,13 @@ export function RoomAssignedTab({
                 {(row.roomAssignedList ?? []).map((room) => (
                   <td
                     key={room.roomNumber}
-                    className={`${cellBorderClass} relative p-0 text-center align-middle`}
+                    className={`${cellBorderClass} relative p-0 text-center align-middle cursor-pointer`}
                     style={{
                       width: room.maxWidth ?? undefined,
                       minWidth: room.maxWidth ?? undefined,
                       height: room.maxHeight ?? undefined,
                     }}
+                    onClick={() => setSelectedCharaName(room.charaName ?? null)}
                   >
                     <div
                       title={room.charaName ?? undefined}
@@ -87,6 +91,7 @@ export function RoomAssignedTab({
           </tbody>
         </table>
       </div>
+      {selectedCharaName != null && <p className="mt-1 text-village-sm">{selectedCharaName}</p>}
       {situationList.length > 0 && (
         <div className="mt-[10px]">
           <table className={`${cellBorderClass} border-collapse text-village-sm`}>

--- a/frontend/app/features/village/components/info/RoomAssignedTab.tsx
+++ b/frontend/app/features/village/components/info/RoomAssignedTab.tsx
@@ -9,8 +9,6 @@ function shortenSkillName(skillName: string): string {
   return skillName.length > 5 ? `${skillName.slice(0, 4)}...` : skillName;
 }
 
-const TOOLTIP_MARGIN = 8;
-
 /** 部屋割りグリッド + 日別状況テーブル。 */
 export function RoomAssignedTab({
   rows,
@@ -25,40 +23,35 @@ export function RoomAssignedTab({
   spoiled?: boolean;
 }) {
   const [tooltip, setTooltip] = useState<{ name: string; top: number; left: number } | null>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
 
   const handleCellClick = (
     e: React.MouseEvent<HTMLTableCellElement>,
     charaName: string | null | undefined,
   ) => {
-    if (!charaName) {
+    if (!charaName || !wrapperRef.current) {
       setTooltip(null);
       return;
     }
+    const wrapperRect = wrapperRef.current.getBoundingClientRect();
     const cellRect = e.currentTarget.getBoundingClientRect();
-    const rawLeft = cellRect.left + cellRect.width / 2;
     setTooltip({
       name: charaName,
-      top: cellRect.top - 4,
-      left: rawLeft,
+      top: cellRect.top - wrapperRect.top,
+      left: cellRect.left - wrapperRect.left + cellRect.width / 2,
     });
   };
 
   useEffect(() => {
-    if (!tooltip || !tooltipRef.current) return;
+    if (!tooltip || !tooltipRef.current || !wrapperRef.current) return;
     const el = tooltipRef.current;
-    const elRect = el.getBoundingClientRect();
-    let clamped = false;
-    if (elRect.left < TOOLTIP_MARGIN) {
-      el.style.left = `${TOOLTIP_MARGIN + elRect.width / 2}px`;
-      clamped = true;
-    } else if (elRect.right > window.innerWidth - TOOLTIP_MARGIN) {
-      el.style.left = `${window.innerWidth - TOOLTIP_MARGIN - elRect.width / 2}px`;
-      clamped = true;
-    }
-    if (!clamped) {
-      el.style.left = `${tooltip.left}px`;
-    }
+    const elWidth = el.offsetWidth;
+    const wrapperWidth = wrapperRef.current.offsetWidth;
+    const minLeft = elWidth / 2;
+    const maxLeft = wrapperWidth - elWidth / 2;
+    const clamped = Math.max(minLeft, Math.min(tooltip.left, maxLeft));
+    el.style.left = `${clamped}px`;
   }, [tooltip]);
 
   useEffect(() => {
@@ -72,7 +65,7 @@ export function RoomAssignedTab({
   }, [tooltip]);
 
   return (
-    <div className="pt-[10px] pb-[10px]">
+    <div ref={wrapperRef} className="relative pt-[10px] pb-[10px]">
       <div className="overflow-x-auto">
         <table
           className={`${cellBorderClass} border-collapse text-[0.75rem]`}
@@ -141,9 +134,9 @@ export function RoomAssignedTab({
       {tooltip && (
         <div
           ref={tooltipRef}
-          className="fixed z-50 rounded bg-gray-800 px-2 py-1 text-village-sm text-white whitespace-nowrap"
+          className="absolute z-10 rounded bg-gray-800 px-2 py-1 text-village-sm text-white whitespace-nowrap"
           style={{
-            top: tooltip.top,
+            top: tooltip.top - 4,
             left: tooltip.left,
             transform: "translate(-50%, -100%)",
           }}

--- a/frontend/app/features/village/components/info/RoomAssignedTab.tsx
+++ b/frontend/app/features/village/components/info/RoomAssignedTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import type { VillageRoomAssignedRow, VillageSituationContent } from "~/features/village/api";
 import { deadMark } from "./dead";
 
@@ -22,11 +22,35 @@ export function RoomAssignedTab({
   /** ネタバレ防止 (役職名を隠す) */
   spoiled?: boolean;
 }) {
-  const [selectedCharaName, setSelectedCharaName] = useState<string | null>(null);
+  const [tooltip, setTooltip] = useState<{ name: string; top: number; left: number } | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleCellClick = (
+    e: React.MouseEvent<HTMLTableCellElement>,
+    charaName: string | null | undefined,
+  ) => {
+    if (!charaName || !containerRef.current) {
+      setTooltip(null);
+      return;
+    }
+    const containerRect = containerRef.current.getBoundingClientRect();
+    const cellRect = e.currentTarget.getBoundingClientRect();
+    setTooltip({
+      name: charaName,
+      top: cellRect.top - containerRect.top,
+      left: cellRect.left - containerRect.left + cellRect.width / 2,
+    });
+  };
 
   return (
     <div className="pt-[10px] pb-[10px]">
-      <div className="overflow-x-auto">
+      <div
+        ref={containerRef}
+        className="overflow-x-auto relative"
+        onClick={(e) => {
+          if (e.target === e.currentTarget) setTooltip(null);
+        }}
+      >
         <table
           className={`${cellBorderClass} border-collapse text-[0.75rem]`}
           style={{ tableLayout: "fixed" }}
@@ -43,7 +67,7 @@ export function RoomAssignedTab({
                       minWidth: room.maxWidth ?? undefined,
                       height: room.maxHeight ?? undefined,
                     }}
-                    onClick={() => setSelectedCharaName(room.charaName ?? null)}
+                    onClick={(e) => handleCellClick(e, room.charaName)}
                   >
                     <div
                       title={room.charaName ?? undefined}
@@ -90,8 +114,19 @@ export function RoomAssignedTab({
             ))}
           </tbody>
         </table>
+        {tooltip && (
+          <div
+            className="absolute z-10 rounded bg-gray-800 px-2 py-1 text-village-sm text-white whitespace-nowrap"
+            style={{
+              top: tooltip.top - 4,
+              left: tooltip.left,
+              transform: "translate(-50%, -100%)",
+            }}
+          >
+            {tooltip.name}
+          </div>
+        )}
       </div>
-      {selectedCharaName != null && <p className="mt-1 text-village-sm">{selectedCharaName}</p>}
       {situationList.length > 0 && (
         <div className="mt-[10px]">
           <table className={`${cellBorderClass} border-collapse text-village-sm`}>

--- a/frontend/app/features/village/components/info/RoomAssignedTab.tsx
+++ b/frontend/app/features/village/components/info/RoomAssignedTab.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { VillageRoomAssignedRow, VillageSituationContent } from "~/features/village/api";
 import { deadMark } from "./dead";
 
@@ -8,6 +8,8 @@ const cellBorderClass = "border border-[#464545]";
 function shortenSkillName(skillName: string): string {
   return skillName.length > 5 ? `${skillName.slice(0, 4)}...` : skillName;
 }
+
+const TOOLTIP_MARGIN = 8;
 
 /** 部屋割りグリッド + 日別状況テーブル。 */
 export function RoomAssignedTab({
@@ -23,34 +25,55 @@ export function RoomAssignedTab({
   spoiled?: boolean;
 }) {
   const [tooltip, setTooltip] = useState<{ name: string; top: number; left: number } | null>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
 
   const handleCellClick = (
     e: React.MouseEvent<HTMLTableCellElement>,
     charaName: string | null | undefined,
   ) => {
-    if (!charaName || !containerRef.current) {
+    if (!charaName) {
       setTooltip(null);
       return;
     }
-    const containerRect = containerRef.current.getBoundingClientRect();
     const cellRect = e.currentTarget.getBoundingClientRect();
+    const rawLeft = cellRect.left + cellRect.width / 2;
     setTooltip({
       name: charaName,
-      top: cellRect.top - containerRect.top,
-      left: cellRect.left - containerRect.left + cellRect.width / 2,
+      top: cellRect.top - 4,
+      left: rawLeft,
     });
   };
 
+  useEffect(() => {
+    if (!tooltip || !tooltipRef.current) return;
+    const el = tooltipRef.current;
+    const elRect = el.getBoundingClientRect();
+    let clamped = false;
+    if (elRect.left < TOOLTIP_MARGIN) {
+      el.style.left = `${TOOLTIP_MARGIN + elRect.width / 2}px`;
+      clamped = true;
+    } else if (elRect.right > window.innerWidth - TOOLTIP_MARGIN) {
+      el.style.left = `${window.innerWidth - TOOLTIP_MARGIN - elRect.width / 2}px`;
+      clamped = true;
+    }
+    if (!clamped) {
+      el.style.left = `${tooltip.left}px`;
+    }
+  }, [tooltip]);
+
+  useEffect(() => {
+    if (!tooltip) return;
+    const dismiss = (e: PointerEvent) => {
+      if (tooltipRef.current?.contains(e.target as Node)) return;
+      setTooltip(null);
+    };
+    document.addEventListener("pointerdown", dismiss);
+    return () => document.removeEventListener("pointerdown", dismiss);
+  }, [tooltip]);
+
   return (
     <div className="pt-[10px] pb-[10px]">
-      <div
-        ref={containerRef}
-        className="overflow-x-auto relative"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setTooltip(null);
-        }}
-      >
+      <div className="overflow-x-auto">
         <table
           className={`${cellBorderClass} border-collapse text-[0.75rem]`}
           style={{ tableLayout: "fixed" }}
@@ -114,19 +137,20 @@ export function RoomAssignedTab({
             ))}
           </tbody>
         </table>
-        {tooltip && (
-          <div
-            className="absolute z-10 rounded bg-gray-800 px-2 py-1 text-village-sm text-white whitespace-nowrap"
-            style={{
-              top: tooltip.top - 4,
-              left: tooltip.left,
-              transform: "translate(-50%, -100%)",
-            }}
-          >
-            {tooltip.name}
-          </div>
-        )}
       </div>
+      {tooltip && (
+        <div
+          ref={tooltipRef}
+          className="fixed z-50 rounded bg-gray-800 px-2 py-1 text-village-sm text-white whitespace-nowrap"
+          style={{
+            top: tooltip.top,
+            left: tooltip.left,
+            transform: "translate(-50%, -100%)",
+          }}
+        >
+          {tooltip.name}
+        </div>
+      )}
       {situationList.length > 0 && (
         <div className="mt-[10px]">
           <table className={`${cellBorderClass} border-collapse text-village-sm`}>


### PR DESCRIPTION
closes .issues/fix-room-tap-participant-name.md

## Summary

- 部屋割グリッドの `<td>` セルに `onClick` ハンドラを追加し、タップした部屋の参加者名（`charaName`）を `useState` で保持
- グリッド直下に選択された参加者名を表示
- PC の hover tooltip（`title` 属性）はそのまま維持

## Test plan

- [ ] `pnpm dev` で起動し、進行中の村の部屋割表示をスマホ幅で確認
- [ ] 部屋セルをタップ → グリッド下部に参加者名が表示されること
- [ ] PC 幅で部屋セルを hover → 従来通り tooltip で参加者名が表示されること
- [ ] 空き部屋セルをタップ → 参加者名表示が消えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sk7uQeAKGhvKJTzq9G6s4u