### PR TITLE
fix: AbilityPanel に key={currentDay} を追加し日付変更時に再マウントさせる

### DIFF
--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -383,6 +383,7 @@ export default function Village({ params }: Route.ComponentProps) {
 
         {mySituation != null && mySituation.myself?.skill != null && (
           <AbilityPanel
+            key={currentDay}
             villageId={villageId}
             village={village}
             mySituation={mySituation}


### PR DESCRIPTION
closes .issues/fix-daychange-situation-refresh.md

## Summary

- AbilityPanel の `useState` 初期値と `useEffect([])` が `ability` prop の変更に追従しないため、日付更新後も古い能力対象が表示される問題を修正
- `key={currentDay}` を追加し、日付変更時にコンポーネントを再マウントさせることで state をリセット

## Test plan

- [ ] 進行中の村でデバッグモードから日付更新を実行
- [ ] footer「更新」ボタンを押す → 役職欄の能力候補・対象候補が新しい日付に基づいて更新されること
- [ ] 日別ページ間を遷移（DayList）しても能力候補が正しく切り替わること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sk7uQeAKGhvKJTzq9G6s4u