### PR TITLE
fix: 日付更新時にパネル状態を再初期化し役職欄を正しく表示する

### DIFF
--- a/frontend/app/features/village/components/action/AbilityPanel.tsx
+++ b/frontend/app/features/village/components/action/AbilityPanel.tsx
@@ -15,7 +15,7 @@ import {
 } from "~/features/village/api";
 import { resolveParticipantName } from "~/features/village/participants";
 import { useAsyncAction } from "~/lib/useAsyncAction";
-import type { useAbilityState } from "./useAbilityState";
+import { useAbilityState } from "./useAbilityState";
 
 const NO_FOOTSTEP = "なし";
 
@@ -29,14 +29,12 @@ export function AbilityPanel({
   village,
   mySituation,
   roomAssignedRows,
-  abilityState,
   onDone,
 }: {
   villageId: number;
   village: VillageDetailView;
   mySituation: ParticipantSituationView;
   roomAssignedRows: VillageRoomAssignedRow[] | null | undefined;
-  abilityState: ReturnType<typeof useAbilityState>;
   onDone: () => Promise<unknown>;
 }) {
   const ability = mySituation.ability;
@@ -56,7 +54,7 @@ export function AbilityPanel({
     footstepOptions,
     onAttackerChange,
     onTargetChange,
-  } = abilityState;
+  } = useAbilityState(villageId, village, ability, skill);
 
   const showToast = useToast((s) => s.show);
   const { error, submitting, execute } = useAsyncAction();

--- a/frontend/app/features/village/components/action/AbilityPanel.tsx
+++ b/frontend/app/features/village/components/action/AbilityPanel.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { Link } from "react-router";
 
 import { Alert, AlertList, ErrorMessage } from "~/components/ui/Alert";
@@ -8,8 +7,6 @@ import { selectClass } from "~/components/ui/Input";
 import { Panel } from "~/components/ui/Panel";
 import { useToast } from "~/components/ui/Toast";
 import {
-  fetchAbilityFootsteps,
-  fetchAttackTargets,
   setVillageAbility,
   type ParticipantSituationView,
   type VillageAbilityRequest,
@@ -18,6 +15,7 @@ import {
 } from "~/features/village/api";
 import { resolveParticipantName } from "~/features/village/participants";
 import { useAsyncAction } from "~/lib/useAsyncAction";
+import type { useAbilityState } from "./useAbilityState";
 
 const NO_FOOTSTEP = "なし";
 
@@ -31,113 +29,37 @@ export function AbilityPanel({
   village,
   mySituation,
   roomAssignedRows,
+  abilityState,
   onDone,
 }: {
   villageId: number;
   village: VillageDetailView;
   mySituation: ParticipantSituationView;
   roomAssignedRows: VillageRoomAssignedRow[] | null | undefined;
+  abilityState: ReturnType<typeof useAbilityState>;
   onDone: () => Promise<unknown>;
 }) {
   const ability = mySituation.ability;
   const skill = mySituation.myself?.skill;
 
-  const isAttack = ability.attackerCharaIds.length > 0;
-  const isInvestigate = skill?.hasInvestigateAbility ?? false;
-  const isDisturb = (skill?.hasDisturbAbility ?? false) && ability.targetCharaIds.length === 0;
+  const {
+    isAttack,
+    isInvestigate,
+    isDisturb,
+    attackerCharaId,
+    targetCharaId,
+    footstep,
+    setFootstep,
+    disturbRooms,
+    setDisturbRooms,
+    targets,
+    footstepOptions,
+    onAttackerChange,
+    onTargetChange,
+  } = abilityState;
 
-  const [attackerCharaId, setAttackerCharaId] = useState<string>(
-    ability.attackerCharaId != null ? String(ability.attackerCharaId) : "",
-  );
-  const [targetCharaId, setTargetCharaId] = useState<string>(
-    ability.targetCharaId != null ? String(ability.targetCharaId) : "",
-  );
-  const [footstep, setFootstep] = useState<string>(
-    ability.targetFootstep ?? ability.footstep ?? ability.targetFootstepList?.[0] ?? "",
-  );
-  // 徘徊の通過部屋 (CSV をトグル選択で組み立てる)
-  const [disturbRooms, setDisturbRooms] = useState<string[]>(() => {
-    const current = ability.footstep;
-    return current == null || current === NO_FOOTSTEP ? [] : current.split(",");
-  });
-  const [targets, setTargets] = useState<{ charaId: number; name: string }[]>(
-    ability.targetCharaIds.map((id) => ({
-      charaId: id,
-      name: resolveParticipantName(village, id),
-    })),
-  );
-  const [footstepOptions, setFootstepOptions] = useState<string[]>(
-    ability.targetFootstepList ?? [],
-  );
   const showToast = useToast((s) => s.show);
   const { error, submitting, execute } = useAsyncAction();
-
-  // 襲撃の対象候補と現在対象の足音候補は situation に含まれないため、初期表示時に取得する
-  useEffect(() => {
-    if (!ability.canUseAbility) return;
-    if (isAttack && attackerCharaId !== "") {
-      fetchAttackTargets(villageId, Number(attackerCharaId))
-        .then((response) => setTargets(response.targets ?? []))
-        .catch(() => {});
-    }
-    if ((isAttack || ability.isTargetingAndFootstep) && targetCharaId !== "") {
-      fetchAbilityFootsteps(
-        villageId,
-        isAttack && attackerCharaId !== "" ? Number(attackerCharaId) : null,
-        Number(targetCharaId),
-      )
-        .then((response) => {
-          const opts = response.footsteps ?? [];
-          setFootstepOptions(opts);
-          if (!footstep && opts.length > 0) setFootstep(opts[0]);
-        })
-        .catch(() => {});
-    }
-    // 初期表示のみ。以降の変更は onAttackerChange / onTargetChange が取得する
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // 襲撃者を選ぶと対象候補が変わり、対象を選ぶと足音候補が変わる
-  const onAttackerChange = async (value: string) => {
-    setAttackerCharaId(value);
-    setTargetCharaId("");
-    setFootstep("");
-    setFootstepOptions([]);
-    if (value === "") return;
-    try {
-      const response = await fetchAttackTargets(villageId, Number(value));
-      const newTargets = response.targets ?? [];
-      setTargets(newTargets);
-      if (newTargets.length > 0) {
-        const firstTargetId = newTargets[0].charaId;
-        setTargetCharaId(String(firstTargetId));
-        const fsResponse = await fetchAbilityFootsteps(villageId, Number(value), firstTargetId);
-        const opts = fsResponse.footsteps ?? [];
-        setFootstepOptions(opts);
-        setFootstep(opts.length > 0 ? opts[0] : "");
-      }
-    } catch {
-      setTargets([]);
-    }
-  };
-
-  const onTargetChange = async (value: string) => {
-    setTargetCharaId(value);
-    setFootstep("");
-    if (!(isAttack || ability.isTargetingAndFootstep) || value === "") return;
-    try {
-      const response = await fetchAbilityFootsteps(
-        villageId,
-        isAttack && attackerCharaId !== "" ? Number(attackerCharaId) : null,
-        Number(value),
-      );
-      const opts = response.footsteps ?? [];
-      setFootstepOptions(opts);
-      setFootstep(opts.length > 0 ? opts[0] : "");
-    } catch {
-      setFootstepOptions([]);
-    }
-  };
 
   const submit = () =>
     execute(async () => {

--- a/frontend/app/features/village/components/action/SayPanel.tsx
+++ b/frontend/app/features/village/components/action/SayPanel.tsx
@@ -42,19 +42,6 @@ const TYPE_TO_STYLE_KEY: Record<string, string> = {
   [MessageType.SPECTATE_SAY]: "message-spectate",
 };
 
-/** 発言種別 → 既定の表情種別コード。 */
-const TYPE_TO_FACE: Record<string, string> = {
-  [MessageType.NORMAL_SAY]: "NORMAL",
-  [MessageType.WEREWOLF_SAY]: "WEREWOLF",
-  [MessageType.MASON_SAY]: "MASON",
-  [MessageType.LOVERS_SAY]: "LOVER",
-  [MessageType.TELEPATHY]: "SECRET",
-  [MessageType.MONOLOGUE_SAY]: "MONOLOGUE",
-  [MessageType.SECRET_SAY]: "SECRET",
-  [MessageType.GRAVE_SAY]: "GRAVE",
-  [MessageType.SPECTATE_SAY]: "NORMAL",
-};
-
 /** 装飾タグ (選択範囲を囲む)。 */
 const DECORATION_TAGS: { name: string; label: string; color?: string }[] = [
   { name: "b", label: "B" },
@@ -87,6 +74,7 @@ export function SayPanel({
   onClearReply,
   onConfirm,
   registerOnDone,
+  sayState,
 }: {
   village: VillageDetailView;
   mySituation: ParticipantSituationView;
@@ -97,6 +85,18 @@ export function SayPanel({
   onConfirm: (request: VillageSayRequest) => void;
   /** 発言完了時のクリア関数を登録する */
   registerOnDone: (kind: "say" | "action" | "creatorSay", fn: () => void) => void;
+  sayState: {
+    messageType: string;
+    message: string;
+    setMessage: (value: string | ((prev: string) => string)) => void;
+    faceType: string;
+    setFaceType: (value: string) => void;
+    convertDisable: boolean;
+    setConvertDisable: (value: boolean) => void;
+    secretTargetCharaId: string;
+    setSecretTargetCharaId: (value: string) => void;
+    changeType: (type: string) => void;
+  };
 }) {
   const say = mySituation.say;
   const myself = mySituation.myself;
@@ -105,22 +105,19 @@ export function SayPanel({
   const images = say.selectableCharaImageList ?? [];
 
   const displayImages = images.filter((i) => i.isDisplay);
-  const defaultType =
-    say.defaultMessageType?.code ?? selectable[0]?.messageType.code ?? MessageType.NORMAL_SAY;
-  const [messageType, setMessageType] = useState(defaultType);
-  const [message, setMessage] = useState("");
+  const {
+    messageType,
+    message,
+    setMessage,
+    faceType,
+    setFaceType,
+    convertDisable,
+    setConvertDisable,
+    secretTargetCharaId,
+    setSecretTargetCharaId,
+    changeType,
+  } = sayState;
   registerOnDone("say", () => setMessage(""));
-  const [faceType, setFaceType] = useState<string>(
-    () =>
-      faceTypeFor(
-        defaultType,
-        displayImages.map((i) => i.faceType.code),
-      ) ??
-      displayImages[0]?.faceType.code ??
-      "NORMAL",
-  );
-  const [convertDisable, setConvertDisable] = useState(false);
-  const [secretTargetCharaId, setSecretTargetCharaId] = useState<string>("");
   const [faceModalOpen, setFaceModalOpen] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -154,20 +151,6 @@ export function SayPanel({
     overLimit ||
     message.trim().length === 0 ||
     (messageType === MessageType.SECRET_SAY && secretTargetCharaId === "");
-
-  function faceTypeFor(type: string, codes: string[]): string | null {
-    const candidate = TYPE_TO_FACE[type];
-    return candidate != null && codes.includes(candidate) ? candidate : null;
-  }
-
-  const changeType = (type: string) => {
-    setMessageType(type);
-    const face = faceTypeFor(
-      type,
-      displayImages.map((i) => i.faceType.code),
-    );
-    if (face != null) setFaceType(face);
-  };
 
   const insertAtCursor = (text: string, wrap?: { close: string }) => {
     const textarea = textareaRef.current;

--- a/frontend/app/features/village/components/action/SayPanel.tsx
+++ b/frontend/app/features/village/components/action/SayPanel.tsx
@@ -15,6 +15,7 @@ import { resolveParticipantName } from "~/features/village/participants";
 import { useDisplaySettings } from "~/features/village/displaySettings";
 import { MessageType } from "~/features/village/components/message/messageType";
 import { MessageCard, type ReplyDraft } from "../message/MessageCard";
+import { useSayState } from "./useSayState";
 export type { ReplyDraft };
 
 /** 発言種別ラジオの表示順とラベル (フォーム上の並び)。 */
@@ -74,7 +75,6 @@ export function SayPanel({
   onClearReply,
   onConfirm,
   registerOnDone,
-  sayState,
 }: {
   village: VillageDetailView;
   mySituation: ParticipantSituationView;
@@ -85,18 +85,6 @@ export function SayPanel({
   onConfirm: (request: VillageSayRequest) => void;
   /** 発言完了時のクリア関数を登録する */
   registerOnDone: (kind: "say" | "action" | "creatorSay", fn: () => void) => void;
-  sayState: {
-    messageType: string;
-    message: string;
-    setMessage: (value: string | ((prev: string) => string)) => void;
-    faceType: string;
-    setFaceType: (value: string) => void;
-    convertDisable: boolean;
-    setConvertDisable: (value: boolean) => void;
-    secretTargetCharaId: string;
-    setSecretTargetCharaId: (value: string) => void;
-    changeType: (type: string) => void;
-  };
 }) {
   const say = mySituation.say;
   const myself = mySituation.myself;
@@ -116,7 +104,7 @@ export function SayPanel({
     secretTargetCharaId,
     setSecretTargetCharaId,
     changeType,
-  } = sayState;
+  } = useSayState(say);
   registerOnDone("say", () => setMessage(""));
   const [faceModalOpen, setFaceModalOpen] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);

--- a/frontend/app/features/village/components/action/VotePanel.tsx
+++ b/frontend/app/features/village/components/action/VotePanel.tsx
@@ -1,5 +1,3 @@
-import { useState } from "react";
-
 import { ErrorMessage } from "~/components/ui/Alert";
 import { Button } from "~/components/ui/Button";
 import { selectClass } from "~/components/ui/Input";
@@ -18,17 +16,18 @@ export function VotePanel({
   villageId,
   village,
   mySituation,
+  targetCharaId,
+  setTargetCharaId,
   onDone,
 }: {
   villageId: number;
   village: VillageDetailView;
   mySituation: ParticipantSituationView;
+  targetCharaId: string;
+  setTargetCharaId: (value: string) => void;
   onDone: () => Promise<unknown>;
 }) {
   const vote = mySituation.vote;
-  const [targetCharaId, setTargetCharaId] = useState<string>(
-    vote.targetCharaId != null ? String(vote.targetCharaId) : "",
-  );
   const showToast = useToast((s) => s.show);
   const { error, submitting, execute } = useAsyncAction();
 

--- a/frontend/app/features/village/components/action/VotePanel.tsx
+++ b/frontend/app/features/village/components/action/VotePanel.tsx
@@ -10,24 +10,22 @@ import {
 } from "~/features/village/api";
 import { resolveParticipantName } from "~/features/village/participants";
 import { useAsyncAction } from "~/lib/useAsyncAction";
+import { useVoteState } from "./useVoteState";
 
 /** 処刑対象への投票。未セットのまま日付が更新されると突然死するため警告を出す。 */
 export function VotePanel({
   villageId,
   village,
   mySituation,
-  targetCharaId,
-  setTargetCharaId,
   onDone,
 }: {
   villageId: number;
   village: VillageDetailView;
   mySituation: ParticipantSituationView;
-  targetCharaId: string;
-  setTargetCharaId: (value: string) => void;
   onDone: () => Promise<unknown>;
 }) {
   const vote = mySituation.vote;
+  const { targetCharaId, setTargetCharaId } = useVoteState(vote);
   const showToast = useToast((s) => s.show);
   const { error, submitting, execute } = useAsyncAction();
 

--- a/frontend/app/features/village/components/action/useAbilityState.ts
+++ b/frontend/app/features/village/components/action/useAbilityState.ts
@@ -1,0 +1,173 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  fetchAbilityFootsteps,
+  fetchAttackTargets,
+  type ParticipantSituationView,
+  type VillageDetailView,
+} from "~/features/village/api";
+import { resolveParticipantName } from "~/features/village/participants";
+
+type Ability = ParticipantSituationView["ability"];
+type Skill = NonNullable<ParticipantSituationView["myself"]>["skill"];
+
+const NO_FOOTSTEP = "なし";
+
+export function useAbilityState(
+  villageId: number,
+  village: VillageDetailView,
+  ability: Ability | undefined,
+  skill: Skill | undefined | null,
+) {
+  const isAttack = (ability?.attackerCharaIds.length ?? 0) > 0;
+  const isInvestigate = skill?.hasInvestigateAbility ?? false;
+  const isDisturb =
+    (skill?.hasDisturbAbility ?? false) && (ability?.targetCharaIds.length ?? 0) === 0;
+
+  const [attackerCharaId, setAttackerCharaId] = useState<string>(
+    ability?.attackerCharaId != null ? String(ability.attackerCharaId) : "",
+  );
+  const [targetCharaId, setTargetCharaId] = useState<string>(
+    ability?.targetCharaId != null ? String(ability.targetCharaId) : "",
+  );
+  const [footstep, setFootstep] = useState<string>(
+    ability?.targetFootstep ?? ability?.footstep ?? ability?.targetFootstepList?.[0] ?? "",
+  );
+  const [disturbRooms, setDisturbRooms] = useState<string[]>(() => {
+    const current = ability?.footstep;
+    return current == null || current === NO_FOOTSTEP ? [] : current.split(",");
+  });
+  const [targets, setTargets] = useState<{ charaId: number; name: string }[]>(
+    (ability?.targetCharaIds ?? []).map((id) => ({
+      charaId: id,
+      name: resolveParticipantName(village, id),
+    })),
+  );
+  const [footstepOptions, setFootstepOptions] = useState<string[]>(
+    ability?.targetFootstepList ?? [],
+  );
+
+  const dataRef = useRef({ villageId, village, ability, skill });
+  dataRef.current = { villageId, village, ability, skill };
+
+  useEffect(() => {
+    if (ability == null || !ability.canUseAbility) return;
+    if (isAttack && attackerCharaId !== "") {
+      fetchAttackTargets(villageId, Number(attackerCharaId))
+        .then((response) => setTargets(response.targets ?? []))
+        .catch(() => {});
+    }
+    if ((isAttack || ability.isTargetingAndFootstep) && targetCharaId !== "") {
+      fetchAbilityFootsteps(
+        villageId,
+        isAttack && attackerCharaId !== "" ? Number(attackerCharaId) : null,
+        Number(targetCharaId),
+      )
+        .then((response) => {
+          const opts = response.footsteps ?? [];
+          setFootstepOptions(opts);
+          if (!footstep && opts.length > 0) setFootstep(opts[0]);
+        })
+        .catch(() => {});
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const initialize = useCallback(() => {
+    const { villageId: vid, village: v, ability: a, skill: s } = dataRef.current;
+    if (a == null) return;
+
+    const atkId = a.attackerCharaId != null ? String(a.attackerCharaId) : "";
+    const tgtId = a.targetCharaId != null ? String(a.targetCharaId) : "";
+    setAttackerCharaId(atkId);
+    setTargetCharaId(tgtId);
+    setFootstep(a.targetFootstep ?? a.footstep ?? a.targetFootstepList?.[0] ?? "");
+    const current = a.footstep;
+    setDisturbRooms(current == null || current === NO_FOOTSTEP ? [] : current.split(","));
+    setTargets(
+      a.targetCharaIds.map((id) => ({
+        charaId: id,
+        name: resolveParticipantName(v, id),
+      })),
+    );
+    setFootstepOptions(a.targetFootstepList ?? []);
+
+    if (!a.canUseAbility) return;
+
+    const isAtk = a.attackerCharaIds.length > 0;
+    const isDisturb2 = (s?.hasDisturbAbility ?? false) && a.targetCharaIds.length === 0;
+    if (isAtk && atkId !== "") {
+      fetchAttackTargets(vid, Number(atkId))
+        .then((response) => setTargets(response.targets ?? []))
+        .catch(() => {});
+    }
+    if ((isAtk || a.isTargetingAndFootstep) && tgtId !== "") {
+      fetchAbilityFootsteps(vid, isAtk && atkId !== "" ? Number(atkId) : null, Number(tgtId))
+        .then((response) => {
+          const opts = response.footsteps ?? [];
+          setFootstepOptions(opts);
+          if (opts.length > 0 && !a.targetFootstep && !a.footstep) setFootstep(opts[0]);
+        })
+        .catch(() => {});
+    }
+    void isDisturb2;
+  }, []);
+
+  const onAttackerChange = async (value: string) => {
+    setAttackerCharaId(value);
+    setTargetCharaId("");
+    setFootstep("");
+    setFootstepOptions([]);
+    if (value === "") return;
+    try {
+      const response = await fetchAttackTargets(villageId, Number(value));
+      const newTargets = response.targets ?? [];
+      setTargets(newTargets);
+      if (newTargets.length > 0) {
+        const firstTargetId = newTargets[0].charaId;
+        setTargetCharaId(String(firstTargetId));
+        const fsResponse = await fetchAbilityFootsteps(villageId, Number(value), firstTargetId);
+        const opts = fsResponse.footsteps ?? [];
+        setFootstepOptions(opts);
+        setFootstep(opts.length > 0 ? opts[0] : "");
+      }
+    } catch {
+      setTargets([]);
+    }
+  };
+
+  const onTargetChange = async (value: string) => {
+    setTargetCharaId(value);
+    setFootstep("");
+    if (!(isAttack || (ability?.isTargetingAndFootstep ?? false)) || value === "") return;
+    try {
+      const response = await fetchAbilityFootsteps(
+        villageId,
+        isAttack && attackerCharaId !== "" ? Number(attackerCharaId) : null,
+        Number(value),
+      );
+      const opts = response.footsteps ?? [];
+      setFootstepOptions(opts);
+      setFootstep(opts.length > 0 ? opts[0] : "");
+    } catch {
+      setFootstepOptions([]);
+    }
+  };
+
+  return {
+    isAttack,
+    isInvestigate,
+    isDisturb,
+    attackerCharaId,
+    targetCharaId,
+    footstep,
+    setFootstep,
+    disturbRooms,
+    setDisturbRooms,
+    targets,
+    footstepOptions,
+    onAttackerChange,
+    onTargetChange,
+    initialize,
+  };
+}

--- a/frontend/app/features/village/components/action/useAbilityState.ts
+++ b/frontend/app/features/village/components/action/useAbilityState.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { useRegisterRefresh } from "~/features/village/useRefresh";
 import {
   fetchAbilityFootsteps,
   fetchAttackTargets,
@@ -74,7 +75,7 @@ export function useAbilityState(
   }, []);
 
   const initialize = useCallback(() => {
-    const { villageId: vid, village: v, ability: a, skill: s } = dataRef.current;
+    const { villageId: vid, village: v, ability: a } = dataRef.current;
     if (a == null) return;
 
     const atkId = a.attackerCharaId != null ? String(a.attackerCharaId) : "";
@@ -95,7 +96,6 @@ export function useAbilityState(
     if (!a.canUseAbility) return;
 
     const isAtk = a.attackerCharaIds.length > 0;
-    const isDisturb2 = (s?.hasDisturbAbility ?? false) && a.targetCharaIds.length === 0;
     if (isAtk && atkId !== "") {
       fetchAttackTargets(vid, Number(atkId))
         .then((response) => setTargets(response.targets ?? []))
@@ -110,8 +110,9 @@ export function useAbilityState(
         })
         .catch(() => {});
     }
-    void isDisturb2;
   }, []);
+
+  useRegisterRefresh(initialize);
 
   const onAttackerChange = async (value: string) => {
     setAttackerCharaId(value);
@@ -168,6 +169,5 @@ export function useAbilityState(
     footstepOptions,
     onAttackerChange,
     onTargetChange,
-    initialize,
   };
 }

--- a/frontend/app/features/village/components/action/useSayState.ts
+++ b/frontend/app/features/village/components/action/useSayState.ts
@@ -2,6 +2,7 @@ import { useCallback, useRef, useState } from "react";
 
 import type { ParticipantSituationView } from "~/features/village/api";
 import { MessageType } from "~/features/village/components/message/messageType";
+import { useRegisterRefresh } from "~/features/village/useRefresh";
 
 type Say = ParticipantSituationView["say"];
 
@@ -55,6 +56,8 @@ export function useSayState(say: Say | undefined) {
     setSecretTargetCharaId("");
   }, []);
 
+  useRegisterRefresh(initialize);
+
   const changeType = useCallback(
     (type: string) => {
       setMessageType(type);
@@ -80,6 +83,5 @@ export function useSayState(say: Say | undefined) {
     secretTargetCharaId,
     setSecretTargetCharaId,
     changeType,
-    initialize,
   };
 }

--- a/frontend/app/features/village/components/action/useSayState.ts
+++ b/frontend/app/features/village/components/action/useSayState.ts
@@ -1,0 +1,85 @@
+import { useCallback, useRef, useState } from "react";
+
+import type { ParticipantSituationView } from "~/features/village/api";
+import { MessageType } from "~/features/village/components/message/messageType";
+
+type Say = ParticipantSituationView["say"];
+
+const TYPE_TO_FACE: Record<string, string> = {
+  [MessageType.NORMAL_SAY]: "NORMAL",
+  [MessageType.WEREWOLF_SAY]: "WEREWOLF",
+  [MessageType.MASON_SAY]: "MASON",
+  [MessageType.LOVERS_SAY]: "LOVER",
+  [MessageType.TELEPATHY]: "SECRET",
+  [MessageType.MONOLOGUE_SAY]: "MONOLOGUE",
+  [MessageType.SECRET_SAY]: "SECRET",
+  [MessageType.GRAVE_SAY]: "GRAVE",
+  [MessageType.SPECTATE_SAY]: "NORMAL",
+};
+
+function faceTypeFor(type: string, codes: string[]): string | null {
+  const candidate = TYPE_TO_FACE[type];
+  return candidate != null && codes.includes(candidate) ? candidate : null;
+}
+
+function defaultFaceType(say: Say, type: string): string {
+  const images = say.selectableCharaImageList ?? [];
+  const displayCodes = images.filter((i) => i.isDisplay).map((i) => i.faceType.code);
+  return faceTypeFor(type, displayCodes) ?? displayCodes[0] ?? "NORMAL";
+}
+
+export function useSayState(say: Say | undefined) {
+  const selectable = say?.selectableMessageTypeList ?? [];
+  const defaultType =
+    say?.defaultMessageType?.code ?? selectable[0]?.messageType.code ?? MessageType.NORMAL_SAY;
+
+  const [messageType, setMessageType] = useState(defaultType);
+  const [message, setMessage] = useState("");
+  const [faceType, setFaceType] = useState<string>(() =>
+    say != null ? defaultFaceType(say, defaultType) : "NORMAL",
+  );
+  const [convertDisable, setConvertDisable] = useState(false);
+  const [secretTargetCharaId, setSecretTargetCharaId] = useState<string>("");
+
+  const dataRef = useRef(say);
+  dataRef.current = say;
+
+  const initialize = useCallback(() => {
+    const s = dataRef.current;
+    if (s == null) return;
+    const sel = s.selectableMessageTypeList ?? [];
+    const dt = s.defaultMessageType?.code ?? sel[0]?.messageType.code ?? MessageType.NORMAL_SAY;
+    setMessageType(dt);
+    setFaceType(defaultFaceType(s, dt));
+    setConvertDisable(false);
+    setSecretTargetCharaId("");
+  }, []);
+
+  const changeType = useCallback(
+    (type: string) => {
+      setMessageType(type);
+      if (say == null) return;
+      const candidate = TYPE_TO_FACE[type];
+      const images = say.selectableCharaImageList ?? [];
+      const displayCodes = images.filter((i) => i.isDisplay).map((i) => i.faceType.code);
+      if (candidate != null && displayCodes.includes(candidate)) {
+        setFaceType(candidate);
+      }
+    },
+    [say],
+  );
+
+  return {
+    messageType,
+    message,
+    setMessage,
+    faceType,
+    setFaceType,
+    convertDisable,
+    setConvertDisable,
+    secretTargetCharaId,
+    setSecretTargetCharaId,
+    changeType,
+    initialize,
+  };
+}

--- a/frontend/app/features/village/components/action/useVoteState.ts
+++ b/frontend/app/features/village/components/action/useVoteState.ts
@@ -1,12 +1,13 @@
 import { useCallback, useRef, useState } from "react";
 
 import type { ParticipantSituationView } from "~/features/village/api";
+import { useRegisterRefresh } from "~/features/village/useRefresh";
 
 type Vote = ParticipantSituationView["vote"];
 
-export function useVoteState(vote: Vote | undefined) {
+export function useVoteState(vote: Vote) {
   const [targetCharaId, setTargetCharaId] = useState<string>(
-    vote?.targetCharaId != null ? String(vote.targetCharaId) : "",
+    vote.targetCharaId != null ? String(vote.targetCharaId) : "",
   );
 
   const dataRef = useRef(vote);
@@ -14,8 +15,10 @@ export function useVoteState(vote: Vote | undefined) {
 
   const initialize = useCallback(() => {
     const v = dataRef.current;
-    setTargetCharaId(v?.targetCharaId != null ? String(v.targetCharaId) : "");
+    setTargetCharaId(v.targetCharaId != null ? String(v.targetCharaId) : "");
   }, []);
 
-  return { targetCharaId, setTargetCharaId, initialize };
+  useRegisterRefresh(initialize);
+
+  return { targetCharaId, setTargetCharaId };
 }

--- a/frontend/app/features/village/components/action/useVoteState.ts
+++ b/frontend/app/features/village/components/action/useVoteState.ts
@@ -1,0 +1,21 @@
+import { useCallback, useRef, useState } from "react";
+
+import type { ParticipantSituationView } from "~/features/village/api";
+
+type Vote = ParticipantSituationView["vote"];
+
+export function useVoteState(vote: Vote | undefined) {
+  const [targetCharaId, setTargetCharaId] = useState<string>(
+    vote?.targetCharaId != null ? String(vote.targetCharaId) : "",
+  );
+
+  const dataRef = useRef(vote);
+  dataRef.current = vote;
+
+  const initialize = useCallback(() => {
+    const v = dataRef.current;
+    setTargetCharaId(v?.targetCharaId != null ? String(v.targetCharaId) : "");
+  }, []);
+
+  return { targetCharaId, setTargetCharaId, initialize };
+}

--- a/frontend/app/features/village/useRefresh.ts
+++ b/frontend/app/features/village/useRefresh.ts
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useRef } from "react";
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
 
 import { useInvalidateVillage } from "~/features/village/useVillage";
 
@@ -10,6 +10,7 @@ export const RefreshContext = createContext<RegisterFn | null>(null);
 export function useRefresh(villageId: number) {
   const invalidate = useInvalidateVillage(villageId);
   const initializersRef = useRef<Array<() => void>>([]);
+  const [initSignal, setInitSignal] = useState(0);
 
   const register = useCallback<RegisterFn>((fn) => {
     initializersRef.current = [...initializersRef.current, fn];
@@ -18,11 +19,14 @@ export function useRefresh(villageId: number) {
     };
   }, []);
 
+  useEffect(() => {
+    if (initSignal === 0) return;
+    for (const init of initializersRef.current) init();
+  }, [initSignal]);
+
   const refresh = useCallback(async () => {
     await invalidate();
-    requestAnimationFrame(() => {
-      for (const init of initializersRef.current) init();
-    });
+    setInitSignal((n) => n + 1);
   }, [invalidate]);
 
   return { refresh, invalidate, register };

--- a/frontend/app/features/village/useRefresh.ts
+++ b/frontend/app/features/village/useRefresh.ts
@@ -1,0 +1,18 @@
+import { useCallback, useRef } from "react";
+
+import { useInvalidateVillage } from "~/features/village/useVillage";
+
+export function useRefresh(villageId: number, initializers: Array<() => void>) {
+  const invalidate = useInvalidateVillage(villageId);
+  const initRef = useRef(initializers);
+  initRef.current = initializers;
+
+  const refresh = useCallback(async () => {
+    await invalidate();
+    requestAnimationFrame(() => {
+      for (const init of initRef.current) init();
+    });
+  }, [invalidate]);
+
+  return { refresh, invalidate };
+}

--- a/frontend/app/features/village/useRefresh.ts
+++ b/frontend/app/features/village/useRefresh.ts
@@ -1,18 +1,40 @@
-import { useCallback, useRef } from "react";
+import { createContext, useCallback, useContext, useEffect, useRef } from "react";
 
 import { useInvalidateVillage } from "~/features/village/useVillage";
 
-export function useRefresh(villageId: number, initializers: Array<() => void>) {
+type UnregisterFn = () => void;
+type RegisterFn = (initializer: () => void) => UnregisterFn;
+
+export const RefreshContext = createContext<RegisterFn | null>(null);
+
+export function useRefresh(villageId: number) {
   const invalidate = useInvalidateVillage(villageId);
-  const initRef = useRef(initializers);
-  initRef.current = initializers;
+  const initializersRef = useRef<Array<() => void>>([]);
+
+  const register = useCallback<RegisterFn>((fn) => {
+    initializersRef.current = [...initializersRef.current, fn];
+    return () => {
+      initializersRef.current = initializersRef.current.filter((f) => f !== fn);
+    };
+  }, []);
 
   const refresh = useCallback(async () => {
     await invalidate();
     requestAnimationFrame(() => {
-      for (const init of initRef.current) init();
+      for (const init of initializersRef.current) init();
     });
   }, [invalidate]);
 
-  return { refresh, invalidate };
+  return { refresh, invalidate, register };
+}
+
+export function useRegisterRefresh(initializer: () => void) {
+  const register = useContext(RefreshContext);
+  const ref = useRef(initializer);
+  ref.current = initializer;
+
+  useEffect(() => {
+    if (register == null) return;
+    return register(() => ref.current());
+  }, [register]);
 }

--- a/frontend/app/features/village/useVillage.ts
+++ b/frontend/app/features/village/useVillage.ts
@@ -73,7 +73,7 @@ export function useVillageDebugInfo(id: number) {
   });
 }
 
-/** 村系クエリをまとめて無効化する (日付更新・手動更新時)。発言一覧も含む。 */
+/** 村系クエリをまとめて無効化する (日付更新・手動更新時)。発言一覧・デバッグ情報も含む。 */
 export function useInvalidateVillage(id: number) {
   const queryClient = useQueryClient();
   return useCallback(
@@ -83,6 +83,7 @@ export function useInvalidateVillage(id: number) {
         queryClient.invalidateQueries({ queryKey: [VILLAGE_SITUATION_QUERY_KEY, id] }),
         queryClient.invalidateQueries({ queryKey: [MY_VILLAGE_SITUATION_QUERY_KEY, id] }),
         queryClient.invalidateQueries({ queryKey: [VILLAGE_MESSAGES_QUERY_KEY, id] }),
+        queryClient.invalidateQueries({ queryKey: ["village-debug", id] }),
       ]),
     [queryClient, id],
   );

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -21,7 +21,7 @@ import {
 } from "~/features/village/filter";
 import { useMessagePaging } from "~/features/village/useMessagePaging";
 import { useMessageSync } from "~/features/village/useMessageSync";
-import { useRefresh } from "~/features/village/useRefresh";
+import { RefreshContext, useRefresh } from "~/features/village/useRefresh";
 import { useSayFlow } from "~/features/village/useSayFlow";
 import {
   useMyVillageSituation,
@@ -39,9 +39,6 @@ import { CommitPanel } from "~/features/village/components/action/CommitPanel";
 import { FaceTypePanel } from "~/features/village/components/action/FaceTypePanel";
 import { RpPanel } from "~/features/village/components/action/RpPanel";
 import { SayPanel } from "~/features/village/components/action/SayPanel";
-import { useAbilityState } from "~/features/village/components/action/useAbilityState";
-import { useSayState } from "~/features/village/components/action/useSayState";
-import { useVoteState } from "~/features/village/components/action/useVoteState";
 import { VotePanel } from "~/features/village/components/action/VotePanel";
 import { AdminPanel } from "~/features/village/components/admin/AdminPanel";
 import { CreatorPanel } from "~/features/village/components/admin/CreatorPanel";
@@ -148,19 +145,7 @@ export default function Village({ params }: Route.ComponentProps) {
   const { data: mySituation, error: mySituationError } = useMyVillageSituation(villageId, dayParam);
   const { data: debugInfo } = useVillageDebugInfo(villageId);
   const { data: randomKeywords } = useRandomKeywords();
-  const voteState = useVoteState(mySituation?.vote);
-  const abilityState = useAbilityState(
-    villageId,
-    village!,
-    mySituation?.ability,
-    mySituation?.myself?.skill,
-  );
-  const sayState = useSayState(mySituation?.say);
-  const { refresh, invalidate } = useRefresh(villageId, [
-    voteState.initialize,
-    abilityState.initialize,
-    sayState.initialize,
-  ]);
+  const { refresh, invalidate, register } = useRefresh(villageId);
   const keywordList = (randomKeywords ?? []).map((k) => k.keyword ?? "").filter(Boolean);
   const canAction =
     mySituation?.say.selectableMessageTypeList?.some(
@@ -301,287 +286,289 @@ export default function Village({ params }: Route.ComponentProps) {
 
   return (
     <PageLayout noAd={noAd} footerPaddingBottom={50}>
-      <div className={`px-[15px] ${largeText ? "text-[150%]" : ""}`}>
-        {/* 村タイトル */}
-        <div className="flex">
-          <h1 className="my-[10.5px] flex-1 text-[1.125em]">
-            {villageNumber(village.id)}. {village.name}
-          </h1>
-          <div className="my-[10.5px]">
-            <XPostButton village={village} />
+      <RefreshContext.Provider value={register}>
+        <div className={`px-[15px] ${largeText ? "text-[150%]" : ""}`}>
+          {/* 村タイトル */}
+          <div className="flex">
+            <h1 className="my-[10.5px] flex-1 text-[1.125em]">
+              {villageNumber(village.id)}. {village.name}
+            </h1>
+            <div className="my-[10.5px]">
+              <XPostButton village={village} />
+            </div>
           </div>
-        </div>
-        <hr className="mt-[5px] mb-[10px] border-[#464545]" />
+          <hr className="mt-[5px] mb-[10px] border-[#464545]" />
 
-        <DayList
-          villageId={villageId}
-          dayList={(village.days.list ?? []).map((d) => d.day)}
-          currentDay={currentDay}
-          epilogueDay={village.epilogueDay}
-          onInfo={() => setInfoOpen(true)}
-        />
+          <DayList
+            villageId={villageId}
+            dayList={(village.days.list ?? []).map((d) => d.day)}
+            currentDay={currentDay}
+            epilogueDay={village.epilogueDay}
+            onInfo={() => setInfoOpen(true)}
+          />
 
-        <MessageArea
-          villageId={villageId}
-          day={dayParam}
-          randomKeywords={keywordList}
-          filter={filter}
-          allParticipants={[
-            ...(village.participants.list ?? []),
-            ...(village.spectators.list ?? []),
-          ]}
-          page={page}
-          setPage={setPage}
-          isPaging={isPaging}
-          pageSize={pageSize}
-          onHashtagClick={onHashtagClick}
-          onReply={mySituation?.say.isAvailableSay ? onReply : undefined}
-          onSecret={canSecretReply ? onReply : undefined}
-          onLoaded={onMessagesLoaded}
-          confirmArea={
-            sayPreview != null ? (
-              <div
-                id="message-confirm-area"
-                className="mb-[20px] rounded border border-[#ffff00] bg-[#303030] p-[10px]"
-              >
-                <p className="mb-[10px]">
-                  以下の内容で発言してよろしいですか？（まだ発言されていません）
-                </p>
-                <MessageCard
-                  villageId={villageId}
-                  message={sayPreview.message}
-                  randomKeywords={keywordList}
-                />
-                <div className="flex justify-end gap-[10px]">
-                  <Button variant="default" onClick={onSayCancel}>
-                    キャンセル
-                  </Button>
-                  <Button onClick={onSayDetermine} disabled={saySubmitting}>
-                    {sayPreview.kind === "action"
-                      ? "アクション"
-                      : sayPreview.kind === "creatorSay"
-                        ? "発言する（村建て）"
-                        : sayLabel(sayPreview.request.messageType)}
-                  </Button>
+          <MessageArea
+            villageId={villageId}
+            day={dayParam}
+            randomKeywords={keywordList}
+            filter={filter}
+            allParticipants={[
+              ...(village.participants.list ?? []),
+              ...(village.spectators.list ?? []),
+            ]}
+            page={page}
+            setPage={setPage}
+            isPaging={isPaging}
+            pageSize={pageSize}
+            onHashtagClick={onHashtagClick}
+            onReply={mySituation?.say.isAvailableSay ? onReply : undefined}
+            onSecret={canSecretReply ? onReply : undefined}
+            onLoaded={onMessagesLoaded}
+            confirmArea={
+              sayPreview != null ? (
+                <div
+                  id="message-confirm-area"
+                  className="mb-[20px] rounded border border-[#ffff00] bg-[#303030] p-[10px]"
+                >
+                  <p className="mb-[10px]">
+                    以下の内容で発言してよろしいですか？（まだ発言されていません）
+                  </p>
+                  <MessageCard
+                    villageId={villageId}
+                    message={sayPreview.message}
+                    randomKeywords={keywordList}
+                  />
+                  <div className="flex justify-end gap-[10px]">
+                    <Button variant="default" onClick={onSayCancel}>
+                      キャンセル
+                    </Button>
+                    <Button onClick={onSayDetermine} disabled={saySubmitting}>
+                      {sayPreview.kind === "action"
+                        ? "アクション"
+                        : sayPreview.kind === "creatorSay"
+                          ? "発言する（村建て）"
+                          : sayLabel(sayPreview.request.messageType)}
+                    </Button>
+                  </div>
                 </div>
-              </div>
-            ) : null
-          }
-        />
-        <DayList
-          villageId={villageId}
-          dayList={(village.days.list ?? []).map((d) => d.day)}
-          currentDay={currentDay}
-          epilogueDay={village.epilogueDay}
-          onInfo={() => setInfoOpen(true)}
-        />
-        {!noAd && <AdSense slot="2768254717" className="mt-[15px]" />}
-        <div id="bottom" />
-        <hr className="mt-[5px] mb-[10px] border-[#464545]" />
-
-        {situation != null && (
-          <SituationPanel situation={situation} day={currentDay} spoiled={filter.spoiled} />
-        )}
-
-        {mySituation?.say.isAvailableSay && (
-          <div id="say-panel">
-            {sayError != null && <p className="mb-[5px] text-[#e74c3c]">{sayError}</p>}
-            <SayPanel
-              village={village}
-              mySituation={mySituation}
-              randomKeywords={keywordList}
-              reply={reply}
-              onClearReply={clearReply}
-              onConfirm={onSayConfirm}
-              registerOnDone={registerSayDone}
-              sayState={sayState}
-            />
-          </div>
-        )}
-
-        {mySituation != null && canAction && (
-          <ActionPanel
-            mySituation={mySituation}
-            participants={situation?.participantList ?? []}
-            onConfirm={onActionConfirm}
-            registerOnDone={registerSayDone}
+              ) : null
+            }
           />
-        )}
-
-        {isLatestDay && mySituation != null && mySituation.vote.canVote && (
-          <VotePanel
+          <DayList
             villageId={villageId}
-            village={village}
-            mySituation={mySituation}
-            targetCharaId={voteState.targetCharaId}
-            setTargetCharaId={voteState.setTargetCharaId}
-            onDone={invalidate}
+            dayList={(village.days.list ?? []).map((d) => d.day)}
+            currentDay={currentDay}
+            epilogueDay={village.epilogueDay}
+            onInfo={() => setInfoOpen(true)}
           />
-        )}
+          {!noAd && <AdSense slot="2768254717" className="mt-[15px]" />}
+          <div id="bottom" />
+          <hr className="mt-[5px] mb-[10px] border-[#464545]" />
 
-        {isLatestDay && mySituation != null && mySituation.myself?.skill != null && (
-          <AbilityPanel
-            villageId={villageId}
-            village={village}
-            mySituation={mySituation}
-            roomAssignedRows={situation?.roomAssignedRowList}
-            abilityState={abilityState}
-            onDone={invalidate}
-          />
-        )}
+          {situation != null && (
+            <SituationPanel situation={situation} day={currentDay} spoiled={filter.spoiled} />
+          )}
 
-        {mySituation != null &&
-          !mySituation.participate.isParticipating &&
-          (mySituation.participate.isAvailableParticipate ||
-            mySituation.participate.isAvailableSpectate) && (
-            <div>
-              {participateError != null && (
-                <p className="mb-[5px] text-[#e74c3c]">{participateError}</p>
-              )}
-              <ParticipatePanel
+          {mySituation?.say.isAvailableSay && (
+            <div id="say-panel">
+              {sayError != null && <p className="mb-[5px] text-[#e74c3c]">{sayError}</p>}
+              <SayPanel
                 village={village}
                 mySituation={mySituation}
-                onParticipated={onParticipated}
-                onError={setParticipateError}
+                randomKeywords={keywordList}
+                reply={reply}
+                onClearReply={clearReply}
+                onConfirm={onSayConfirm}
+                registerOnDone={registerSayDone}
               />
             </div>
           )}
 
-        {mySituation != null &&
-          mySituation.participate.isParticipating &&
-          mySituation.skillRequest.isAvailableSkillRequest && (
-            <ChangeSkillPanel villageId={villageId} mySituation={mySituation} onDone={invalidate} />
-          )}
-        {mySituation?.participate.isAvailableSwitchParticipate && (
-          <SwitchParticipatePanel villageId={villageId} onDone={invalidate} />
-        )}
-        {mySituation?.participate.isAvailableLeave && (
-          <LeavePanel villageId={villageId} onDone={invalidate} />
-        )}
-
-        {isLatestDay && mySituation != null && mySituation.commit.isAvailableCommit && (
-          <CommitPanel villageId={villageId} mySituation={mySituation} onDone={invalidate} />
-        )}
-
-        {mySituation != null &&
-          (mySituation.rp.isAvailableChangeName || mySituation.rp.isAvailableMemo) && (
-            <RpPanel villageId={villageId} mySituation={mySituation} onDone={invalidate} />
+          {mySituation != null && canAction && (
+            <ActionPanel
+              mySituation={mySituation}
+              participants={situation?.participantList ?? []}
+              onConfirm={onActionConfirm}
+              registerOnDone={registerSayDone}
+            />
           )}
 
-        {mySituation != null && mySituation.rp.canAddImage && (
-          <FaceTypePanel villageId={villageId} mySituation={mySituation} onDone={invalidate} />
-        )}
+          {isLatestDay && mySituation != null && mySituation.vote.canVote && (
+            <VotePanel
+              villageId={villageId}
+              village={village}
+              mySituation={mySituation}
+              onDone={invalidate}
+            />
+          )}
 
-        {mySituation != null && mySituation.creator.isCreator && (
-          <CreatorPanel
-            villageId={villageId}
-            mySituation={mySituation}
-            participants={(situation?.participantList ?? []).map((p) => ({
-              charaId: p.charaId,
-              name: p.name,
-            }))}
-            members={(situation?.memberList ?? []).flatMap((m) => m.statusMemberList)}
-            onConfirm={onCreatorSayConfirm}
-            onDone={invalidate}
-            registerOnDone={registerSayDone}
-          />
-        )}
+          {isLatestDay && mySituation != null && mySituation.myself?.skill != null && (
+            <AbilityPanel
+              villageId={villageId}
+              village={village}
+              mySituation={mySituation}
+              roomAssignedRows={situation?.roomAssignedRowList}
+              onDone={invalidate}
+            />
+          )}
 
-        {mySituation != null && mySituation.admin.isAdmin && (
-          <AdminPanel villageId={villageId} onDone={invalidate} />
-        )}
+          {mySituation != null &&
+            !mySituation.participate.isParticipating &&
+            (mySituation.participate.isAvailableParticipate ||
+              mySituation.participate.isAvailableSpectate) && (
+              <div>
+                {participateError != null && (
+                  <p className="mb-[5px] text-[#e74c3c]">{participateError}</p>
+                )}
+                <ParticipatePanel
+                  village={village}
+                  mySituation={mySituation}
+                  onParticipated={onParticipated}
+                  onError={setParticipateError}
+                />
+              </div>
+            )}
 
-        {debugInfo?.isDebugMode && (
-          <DebugPanel
-            villageId={villageId}
-            currentDay={currentDay}
-            debugInfo={debugInfo}
-            onDone={refresh}
-          />
-        )}
+          {mySituation != null &&
+            mySituation.participate.isParticipating &&
+            mySituation.skillRequest.isAvailableSkillRequest && (
+              <ChangeSkillPanel
+                villageId={villageId}
+                mySituation={mySituation}
+                onDone={invalidate}
+              />
+            )}
+          {mySituation?.participate.isAvailableSwitchParticipate && (
+            <SwitchParticipatePanel villageId={villageId} onDone={invalidate} />
+          )}
+          {mySituation?.participate.isAvailableLeave && (
+            <LeavePanel villageId={villageId} onDone={invalidate} />
+          )}
 
-        <div className="mb-[10px]">
-          <LinkButton to="/" variant="default">
-            サイトトップへ
-          </LinkButton>
-          <LinkButton
-            to={`/village/${villageId}/scrap`}
-            target="_blank"
-            variant="success"
-            className="ml-[10px]"
-          >
-            切り抜き画面へ
-          </LinkButton>
-        </div>
-      </div>
+          {isLatestDay && mySituation != null && mySituation.commit.isAvailableCommit && (
+            <CommitPanel villageId={villageId} mySituation={mySituation} onDone={invalidate} />
+          )}
 
-      <FooterMenu
-        onRefresh={() => {
-          resetToLatest();
-          pendingScroll.current = true;
-          if (dayParam != null) {
-            navigate(`/village/${villageId}`);
-          } else {
-            void refresh();
-          }
-        }}
-        hasNewMessage={hasNewMessage}
-        onFilter={() => setFilterOpen(true)}
-        filtering={isFiltering(filter)}
-        onSettings={() => setSettingsOpen(true)}
-        onInfo={() => setInfoOpen(true)}
-      />
-      <SettingsModal
-        open={settingsOpen}
-        onClose={() => setSettingsOpen(false)}
-        villageId={villageId}
-        mySituation={mySituation}
-      />
-      <VillageInfoModal
-        open={infoOpen}
-        onClose={() => setInfoOpen(false)}
-        villageId={villageId}
-        canModifySetting={mySituation?.creator.isAvailableModifySetting ?? false}
-      />
-      <InitialSkillModal
-        villageId={villageId}
-        mySituation={mySituation}
-        suppressed={ageLimit != null && !ageLimitResolved}
-      />
-      <FilterModal
-        open={filterOpen}
-        onClose={() => setFilterOpen(false)}
-        filter={filter}
-        participants={situation?.participantList ?? []}
-        myselfId={mySituation?.myself?.id ?? null}
-        notificationKeyword={
-          mySituation?.myself?.notification?.message?.keywords?.join("\n") ?? null
-        }
-        onApply={applyFilter}
-        onApplyNewTab={applyFilterNewTab}
-      />
-      {ageLimit != null && (
-        <AgeLimitModal
-          villageId={villageId}
-          ageLimit={ageLimit}
-          onResolved={() => setAgeLimitResolved(true)}
-        />
-      )}
+          {mySituation != null &&
+            (mySituation.rp.isAvailableChangeName || mySituation.rp.isAvailableMemo) && (
+              <RpPanel villageId={villageId} mySituation={mySituation} onDone={invalidate} />
+            )}
 
-      {/* ステータス表示 */}
-      {leftTime != null && (
-        <div className="fixed top-[5px] right-[5px] z-[100] rounded bg-[#3498db] p-[5px] text-white">
-          更新まで <span>{leftTime}</span>
-        </div>
-      )}
-      {me != null && !sessionExpired && (
-        <Link to={`/user/${me.name}`} target="_blank">
-          <div className="fixed top-[5px] left-[5px] z-[100] rounded bg-[#3498db] p-[5px] text-white">
-            ユーザID: {me.name}
+          {mySituation != null && mySituation.rp.canAddImage && (
+            <FaceTypePanel villageId={villageId} mySituation={mySituation} onDone={invalidate} />
+          )}
+
+          {mySituation != null && mySituation.creator.isCreator && (
+            <CreatorPanel
+              villageId={villageId}
+              mySituation={mySituation}
+              participants={(situation?.participantList ?? []).map((p) => ({
+                charaId: p.charaId,
+                name: p.name,
+              }))}
+              members={(situation?.memberList ?? []).flatMap((m) => m.statusMemberList)}
+              onConfirm={onCreatorSayConfirm}
+              onDone={invalidate}
+              registerOnDone={registerSayDone}
+            />
+          )}
+
+          {mySituation != null && mySituation.admin.isAdmin && (
+            <AdminPanel villageId={villageId} onDone={invalidate} />
+          )}
+
+          {debugInfo?.isDebugMode && (
+            <DebugPanel
+              villageId={villageId}
+              currentDay={currentDay}
+              debugInfo={debugInfo}
+              onDone={refresh}
+            />
+          )}
+
+          <div className="mb-[10px]">
+            <LinkButton to="/" variant="default">
+              サイトトップへ
+            </LinkButton>
+            <LinkButton
+              to={`/village/${villageId}/scrap`}
+              target="_blank"
+              variant="success"
+              className="ml-[10px]"
+            >
+              切り抜き画面へ
+            </LinkButton>
           </div>
-        </Link>
-      )}
-      <Toast />
+        </div>
+
+        <FooterMenu
+          onRefresh={() => {
+            resetToLatest();
+            pendingScroll.current = true;
+            if (dayParam != null) {
+              navigate(`/village/${villageId}`);
+            } else {
+              void refresh();
+            }
+          }}
+          hasNewMessage={hasNewMessage}
+          onFilter={() => setFilterOpen(true)}
+          filtering={isFiltering(filter)}
+          onSettings={() => setSettingsOpen(true)}
+          onInfo={() => setInfoOpen(true)}
+        />
+        <SettingsModal
+          open={settingsOpen}
+          onClose={() => setSettingsOpen(false)}
+          villageId={villageId}
+          mySituation={mySituation}
+        />
+        <VillageInfoModal
+          open={infoOpen}
+          onClose={() => setInfoOpen(false)}
+          villageId={villageId}
+          canModifySetting={mySituation?.creator.isAvailableModifySetting ?? false}
+        />
+        <InitialSkillModal
+          villageId={villageId}
+          mySituation={mySituation}
+          suppressed={ageLimit != null && !ageLimitResolved}
+        />
+        <FilterModal
+          open={filterOpen}
+          onClose={() => setFilterOpen(false)}
+          filter={filter}
+          participants={situation?.participantList ?? []}
+          myselfId={mySituation?.myself?.id ?? null}
+          notificationKeyword={
+            mySituation?.myself?.notification?.message?.keywords?.join("\n") ?? null
+          }
+          onApply={applyFilter}
+          onApplyNewTab={applyFilterNewTab}
+        />
+        {ageLimit != null && (
+          <AgeLimitModal
+            villageId={villageId}
+            ageLimit={ageLimit}
+            onResolved={() => setAgeLimitResolved(true)}
+          />
+        )}
+
+        {/* ステータス表示 */}
+        {leftTime != null && (
+          <div className="fixed top-[5px] right-[5px] z-[100] rounded bg-[#3498db] p-[5px] text-white">
+            更新まで <span>{leftTime}</span>
+          </div>
+        )}
+        {me != null && !sessionExpired && (
+          <Link to={`/user/${me.name}`} target="_blank">
+            <div className="fixed top-[5px] left-[5px] z-[100] rounded bg-[#3498db] p-[5px] text-white">
+              ユーザID: {me.name}
+            </div>
+          </Link>
+        )}
+        <Toast />
+      </RefreshContext.Provider>
     </PageLayout>
   );
 }

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -21,9 +21,9 @@ import {
 } from "~/features/village/filter";
 import { useMessagePaging } from "~/features/village/useMessagePaging";
 import { useMessageSync } from "~/features/village/useMessageSync";
+import { useRefresh } from "~/features/village/useRefresh";
 import { useSayFlow } from "~/features/village/useSayFlow";
 import {
-  useInvalidateVillage,
   useMyVillageSituation,
   useVillage,
   useVillageDebugInfo,
@@ -39,6 +39,9 @@ import { CommitPanel } from "~/features/village/components/action/CommitPanel";
 import { FaceTypePanel } from "~/features/village/components/action/FaceTypePanel";
 import { RpPanel } from "~/features/village/components/action/RpPanel";
 import { SayPanel } from "~/features/village/components/action/SayPanel";
+import { useAbilityState } from "~/features/village/components/action/useAbilityState";
+import { useSayState } from "~/features/village/components/action/useSayState";
+import { useVoteState } from "~/features/village/components/action/useVoteState";
 import { VotePanel } from "~/features/village/components/action/VotePanel";
 import { AdminPanel } from "~/features/village/components/admin/AdminPanel";
 import { CreatorPanel } from "~/features/village/components/admin/CreatorPanel";
@@ -145,7 +148,19 @@ export default function Village({ params }: Route.ComponentProps) {
   const { data: mySituation, error: mySituationError } = useMyVillageSituation(villageId, dayParam);
   const { data: debugInfo } = useVillageDebugInfo(villageId);
   const { data: randomKeywords } = useRandomKeywords();
-  const invalidate = useInvalidateVillage(villageId);
+  const voteState = useVoteState(mySituation?.vote);
+  const abilityState = useAbilityState(
+    villageId,
+    village!,
+    mySituation?.ability,
+    mySituation?.myself?.skill,
+  );
+  const sayState = useSayState(mySituation?.say);
+  const { refresh, invalidate } = useRefresh(villageId, [
+    voteState.initialize,
+    abilityState.initialize,
+    sayState.initialize,
+  ]);
   const keywordList = (randomKeywords ?? []).map((k) => k.keyword ?? "").filter(Boolean);
   const canAction =
     mySituation?.say.selectableMessageTypeList?.some(
@@ -208,6 +223,7 @@ export default function Village({ params }: Route.ComponentProps) {
 
   const latestDay = village != null ? latestDayOf(village) : undefined;
   const currentDay = dayParam ?? latestDay ?? 0;
+  const isLatestDay = latestDay != null && currentDay === latestDay;
 
   const daychangeDetected = useVillagePolling(villageId, latestDay);
   const showToast = useToast((s) => s.show);
@@ -378,6 +394,7 @@ export default function Village({ params }: Route.ComponentProps) {
               onClearReply={clearReply}
               onConfirm={onSayConfirm}
               registerOnDone={registerSayDone}
+              sayState={sayState}
             />
           </div>
         )}
@@ -391,21 +408,24 @@ export default function Village({ params }: Route.ComponentProps) {
           />
         )}
 
-        {mySituation != null && mySituation.vote.canVote && (
+        {isLatestDay && mySituation != null && mySituation.vote.canVote && (
           <VotePanel
             villageId={villageId}
             village={village}
             mySituation={mySituation}
+            targetCharaId={voteState.targetCharaId}
+            setTargetCharaId={voteState.setTargetCharaId}
             onDone={invalidate}
           />
         )}
 
-        {mySituation != null && mySituation.myself?.skill != null && (
+        {isLatestDay && mySituation != null && mySituation.myself?.skill != null && (
           <AbilityPanel
             villageId={villageId}
             village={village}
             mySituation={mySituation}
             roomAssignedRows={situation?.roomAssignedRowList}
+            abilityState={abilityState}
             onDone={invalidate}
           />
         )}
@@ -439,7 +459,7 @@ export default function Village({ params }: Route.ComponentProps) {
           <LeavePanel villageId={villageId} onDone={invalidate} />
         )}
 
-        {mySituation != null && mySituation.commit.isAvailableCommit && (
+        {isLatestDay && mySituation != null && mySituation.commit.isAvailableCommit && (
           <CommitPanel villageId={villageId} mySituation={mySituation} onDone={invalidate} />
         )}
 
@@ -476,7 +496,7 @@ export default function Village({ params }: Route.ComponentProps) {
             villageId={villageId}
             currentDay={currentDay}
             debugInfo={debugInfo}
-            onDone={invalidate}
+            onDone={refresh}
           />
         )}
 
@@ -502,7 +522,7 @@ export default function Village({ params }: Route.ComponentProps) {
           if (dayParam != null) {
             navigate(`/village/${villageId}`);
           } else {
-            void invalidate();
+            void refresh();
           }
         }}
         hasNewMessage={hasNewMessage}


### PR DESCRIPTION
closes .issues/fix-daychange-situation-refresh.md

## Summary

- 投票/役職/コミットパネルを最新日のみ表示するよう制御（`isLatestDay`）
- VotePanel / AbilityPanel / SayPanel の内部状態を hook に切り出し（`useVoteState` / `useAbilityState` / `useSayState`）、明示的な `initialize()` 関数を提供
- `useRefresh` hook を新規作成。`invalidate()` 後に `requestAnimationFrame` で全パネルの `initialize()` を呼び、状態をリセット
- `useInvalidateVillage` に debug info の再取得を追加
- DebugPanel の `onDone` を `refresh` に変更し、日付進行時にパネルが正しく更新される
- SayPanel の `message`（入力中テキスト）はリセットしない

## Test plan

- [ ] 特定日のページ（例: `/village/5/day/1`）で投票/役職/コミットパネルが非表示
- [ ] 最新日で更新ボタン押下後、投票先・役職能力の選択が最新データでリセットされる
- [ ] DebugPanel で日付を進めた後、パネルが正しく更新される
- [ ] 発言パネルのメッセージ入力中に更新しても入力内容が消えない
- [ ] debug info がフッター更新ボタンで再取得される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sk7uQeAKGhvKJTzq9G6s4u