### PR TITLE
fix: アンカー発言のネスト展開を兄弟要素としてフラット表示する

### DIFF
--- a/frontend/app/features/village/components/message/MessageCard.tsx
+++ b/frontend/app/features/village/components/message/MessageCard.tsx
@@ -26,6 +26,7 @@ export function MessageCard({
   onHashtagClick,
   onReply,
   onSecret,
+  onAnchorExpand,
 }: {
   villageId: number;
   message: VillageMessageContent;
@@ -35,6 +36,7 @@ export function MessageCard({
   onHashtagClick?: (tag: string) => void;
   onReply?: (reply: ReplyDraft) => void;
   onSecret?: (reply: ReplyDraft) => void;
+  onAnchorExpand?: (type: string, number: number) => void;
 }) {
   const [expandedAnchors, setExpandedAnchors] = useState<ExpandedAnchor[]>([]);
   const largeImage = useDisplaySettings((s) => s.largeImage);
@@ -50,6 +52,10 @@ export function MessageCard({
   }, [message, randomKeywords]);
 
   const toggleAnchor = async (type: string, number: number) => {
+    if (onAnchorExpand) {
+      onAnchorExpand(type, number);
+      return;
+    }
     const key = `${type}_${number}`;
     const existing = expandedAnchors.find((a) => a.key === key);
     if (existing) {
@@ -149,6 +155,7 @@ export function MessageCard({
                 villageId={villageId}
                 message={a.message}
                 randomKeywords={randomKeywords}
+                onAnchorExpand={(type, number) => toggleAnchor(type, number)}
               />
             </div>
           </div>


### PR DESCRIPTION
closes .issues/fix-anchor-nested-display.md

## Summary

- アンカー発言内のアンカーをクリックした際、入れ子（子要素）ではなく同じ階層（兄弟要素）として縦に並べて展開されるように修正
- `MessageCard` に `onAnchorExpand` コールバックを追加し、ネストされた `MessageCard` のアンカークリックを親に委譲することでフラット表示を実現

## Test plan

- [ ] `pnpm dev` + backend 起動で進行中の村を表示
- [ ] アンカー付き発言（`>>#N`）をクリックして展開
- [ ] 展開された発言内のアンカーをさらにクリック → 入れ子ではなく縦に並んで表示されることを確認
- [ ] 3段以上のネストでも表示領域が狭まらないことを確認
- [ ] 各展開ブロックの × ボタンで個別に閉じられることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sk7uQeAKGhvKJTzq9G6s4u