### PR TITLE
fix: e2eテストの既存失敗を修正

### DIFF
--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -39,19 +39,19 @@ test("signup → me 表示 → logout → login の自己完結フロー", async
   await page.getByRole("button", { name: "作成" }).click();
 
   // 成功でトップへ。トップ画像のユーザID 表示にログイン名 (= userId) が出る。
-  await expect(page).toHaveURL(/\/wolf-mansion$/);
+  await expect(page).toHaveURL(/\/wolf-mansion\/?$/);
   await expect(page.getByText(`ユーザID: ${userId}`)).toBeVisible();
 
-  // --- マイページで me 情報を確認 ---
+  // --- マイページ (ユーザプロフィール) で me 情報を確認 ---
   await page.getByRole("link", { name: "マイページ" }).click();
-  await expect(page).toHaveURL(/\/mypage$/);
-  // 共通ヘッダーがマイページにも「ユーザID: <id>」を出す。情報欄の <dd> も userId 単体を含むため、
-  // ヘッダー側の一意な文言で確認する。
-  await expect(page.getByText(`ユーザID: ${userId}`)).toBeVisible();
+  await expect(page).toHaveURL(new RegExp(`/user/${userId}\\/?$`));
+  await expect(page.getByText("総合戦績")).toBeVisible({ timeout: 15000 });
 
-  // --- logout ---
+  // --- logout (ホームに戻ってからログアウト) ---
+  await page.goto("");
+  await expect(page.getByRole("button", { name: /ログアウト/ })).toBeVisible({ timeout: 15000 });
   await page.getByRole("button", { name: /ログアウト/ }).click();
-  await expect(page).toHaveURL(/\/wolf-mansion$/);
+  await expect(page).toHaveURL(/\/wolf-mansion\/?$/);
   await expect(page.getByRole("link", { name: "ログイン" })).toBeVisible();
 
   // --- 同じ ID で login ---
@@ -61,13 +61,13 @@ test("signup → me 表示 → logout → login の自己完結フロー", async
   await page.fill("#password", PASSWORD);
   await page.getByRole("button", { name: "ログイン" }).click();
 
-  await expect(page).toHaveURL(/\/wolf-mansion$/);
+  await expect(page).toHaveURL(/\/wolf-mansion\/?$/);
   await expect(page.getByText(`ユーザID: ${userId}`)).toBeVisible();
 });
 
 test("未ログインで保護ルートに来ると /login にリダイレクトされる", async ({ page }) => {
-  // 新規コンテキスト (Cookie なし) で保護ルートへ直接アクセス。
-  await page.goto("mypage");
+  // 新規コンテキスト (Cookie なし) で RequireAuth 付きルートへ直接アクセス。
+  await page.goto("change-password");
 
   // RequireAuth が returnTo 付きで /login へ飛ばす。
   await expect(page).toHaveURL(/\/login\?returnTo=/);

--- a/e2e/tests/chara-group.spec.ts
+++ b/e2e/tests/chara-group.spec.ts
@@ -23,7 +23,7 @@ test("一覧から詳細画面へ遷移できる", async ({ page }) => {
   const chipName = await firstLink.textContent();
   await firstLink.click();
 
-  await expect(page).toHaveURL(/\/chara-group\/\d+$/);
+  await expect(page).toHaveURL(/\/chara-group\/\d+\/?$/);
   await expect(page.getByRole("heading", { name: `キャラチップ: ${chipName}` })).toBeVisible();
 });
 
@@ -45,6 +45,6 @@ test("ホームからキャラチップ一覧へ SPA 遷移できる", async ({ 
   await page.goto("");
 
   await page.getByRole("link", { name: "Character list" }).click();
-  await expect(page).toHaveURL(/\/chara-group$/);
+  await expect(page).toHaveURL(/\/chara-group\/?$/);
   await expect(page.getByRole("heading", { name: "キャラチップ一覧" })).toBeVisible();
 });

--- a/e2e/tests/home.spec.ts
+++ b/e2e/tests/home.spec.ts
@@ -55,7 +55,7 @@ test("ログイン後: マイページ/ログアウトタイルに切り替わ�
   // signup ボタンは `:8091` の new-player.html に合わせ「作成」。
   await page.getByRole("button", { name: "作成" }).click();
 
-  await expect(page).toHaveURL(/\/wolf-mansion$/);
+  await expect(page).toHaveURL(/\/wolf-mansion\/?$/);
   // トップ画像にユーザID、ログイン専用タイル
   await expect(page.getByText(`ユーザID: ${userId}`)).toBeVisible();
   await expect(page.getByRole("link", { name: "マイページ" })).toBeVisible();

--- a/e2e/tests/info-pages.spec.ts
+++ b/e2e/tests/info-pages.spec.ts
@@ -65,6 +65,6 @@ test("ホームから about へ SPA 遷移できる", async ({ page }) => {
   await page.goto("");
 
   await page.getByRole("link", { name: "About" }).click();
-  await expect(page).toHaveURL(/\/about$/);
+  await expect(page).toHaveURL(/\/about\/?$/);
   await expect(page.getByRole("heading", { name: "本サイトは" })).toBeVisible();
 });

--- a/e2e/tests/intro.spec.ts
+++ b/e2e/tests/intro.spec.ts
@@ -27,6 +27,6 @@ test("ホームから intro へ SPA 遷移できる", async ({ page }) => {
   await page.goto("");
 
   await page.getByRole("link", { name: "Introduction" }).click();
-  await expect(page).toHaveURL(/\/intro$/);
+  await expect(page).toHaveURL(/\/intro\/?$/);
   await expect(page.getByRole("heading", { name: "このページは" })).toBeVisible();
 });

--- a/e2e/tests/random-keyword.spec.ts
+++ b/e2e/tests/random-keyword.spec.ts
@@ -67,7 +67,7 @@ test("作成 → 一覧反映 → 検索 → 編集 → 削除 の CRUD フロ�
   await page.getByRole("button", { name: "登録" }).click();
 
   // 一覧に反映。6 行目は折りたたまれ「全て表示」で展開される
-  await expect(page).toHaveURL(/\/random-message$/);
+  await expect(page).toHaveURL(/\/random-message\/?$/);
   const row = page.getByRole("row", { name: new RegExp(keyword) });
   await expect(row.getByText(`[[${keyword}]]`)).toBeVisible();
   await expect(row.getByText("へ")).toBeHidden();
@@ -84,7 +84,7 @@ test("作成 → 一覧反映 → 検索 → 編集 → 削除 の CRUD フロ�
   await expect(page.getByRole("heading", { name: "ランダムメッセージ編集" })).toBeVisible();
   await page.fill("#message", "甲\n乙\n丙");
   await page.getByRole("button", { name: "登録" }).click();
-  await expect(page).toHaveURL(/\/random-message$/);
+  await expect(page).toHaveURL(/\/random-message\/?$/);
   await expect(page.getByText("甲")).toBeVisible();
 
   // --- 削除 (確認ダイアログ) → 一覧から消える ---
@@ -94,6 +94,6 @@ test("作成 → 一覧反映 → 検索 → 編集 → 削除 の CRUD フロ�
     .click();
   page.once("dialog", (dialog) => dialog.accept());
   await page.getByRole("button", { name: "削除" }).click();
-  await expect(page).toHaveURL(/\/random-message$/);
+  await expect(page).toHaveURL(/\/random-message\/?$/);
   await expect(page.getByText(`[[${keyword}]]`)).toBeHidden();
 });

--- a/e2e/tests/rule.spec.ts
+++ b/e2e/tests/rule.spec.ts
@@ -36,6 +36,6 @@ test("ホームからルールへ SPA 遷移できる", async ({ page }) => {
   await page.goto("");
 
   await page.getByRole("link", { name: "ルール Rule" }).click();
-  await expect(page).toHaveURL(/\/rule$/);
+  await expect(page).toHaveURL(/\/rule\/?$/);
   await expect(page.getByRole("heading", { name: "ルール", exact: true })).toBeVisible();
 });

--- a/e2e/tests/skill.spec.ts
+++ b/e2e/tests/skill.spec.ts
@@ -39,6 +39,6 @@ test("ホームから役職一覧へ SPA 遷移できる", async ({ page }) => {
   await page.goto("");
 
   await page.getByRole("link", { name: "Skill" }).click();
-  await expect(page).toHaveURL(/\/skill$/);
+  await expect(page).toHaveURL(/\/skill\/?$/);
   await expect(page.getByRole("heading", { name: "役職一覧" })).toBeVisible();
 });

--- a/e2e/tests/village-list.spec.ts
+++ b/e2e/tests/village-list.spec.ts
@@ -61,6 +61,6 @@ test("ホーム: 村一覧タイルから村一覧画面へ遷移する", async 
 
   await page.getByRole("link", { name: "Village list" }).click();
 
-  await expect(page).toHaveURL(/\/wolf-mansion\/village-list$/);
+  await expect(page).toHaveURL(/\/wolf-mansion\/village-list\/?$/);
   await expect(page.getByRole("heading", { name: "村一覧" })).toBeVisible();
 });

--- a/e2e/tests/village-participate.spec.ts
+++ b/e2e/tests/village-participate.spec.ts
@@ -34,7 +34,7 @@ test("入村: キャラ選択 → 確認画面 (同意チェックで活性化) 
   await page.fill("#userId", uniqueUserId());
   await page.fill("#password", "test1234!");
   await page.getByRole("button", { name: "作成" }).click();
-  await expect(page).toHaveURL(/\/wolf-mansion$/);
+  await expect(page).toHaveURL(/\/wolf-mansion\/?$/);
 
   await page.goto(`village/${village.id}`);
   await expect(page.getByText("入村", { exact: true })).toBeVisible({ timeout: 15000 });
@@ -69,7 +69,7 @@ test("入村 → 役職希望変更 → 退村の自己完結フロー", async (
   await page.fill("#userId", uniqueUserId());
   await page.fill("#password", "test1234!");
   await page.getByRole("button", { name: "作成" }).click();
-  await expect(page).toHaveURL(/\/wolf-mansion$/);
+  await expect(page).toHaveURL(/\/wolf-mansion\/?$/);
 
   await page.goto(`village/${village.id}`);
   await expect(page.getByText("入村", { exact: true })).toBeVisible({ timeout: 15000 });

--- a/e2e/tests/village-say.spec.ts
+++ b/e2e/tests/village-say.spec.ts
@@ -21,7 +21,7 @@ async function loginAsMaster(page: Page) {
   await page.fill("#userId", "master");
   await page.fill("#password", "testuser");
   await page.getByRole("button", { name: "ログイン" }).click();
-  await expect(page).toHaveURL(/\/wolf-mansion$/);
+  await expect(page).toHaveURL(/\/wolf-mansion\/?$/);
 }
 /** 初回役職確認モーダルが被っていたら閉じる。 */
 async function dismissInitialSkillModal(page: Page) {

--- a/e2e/tests/village-settings-update.spec.ts
+++ b/e2e/tests/village-settings-update.spec.ts
@@ -55,7 +55,7 @@ test("村設定変更: 村名を変更して保存し、元に戻す", async ({ 
   await page.getByRole("button", { name: "変更する" }).click();
 
   // 保存後は村画面へ戻り、村名が反映されている
-  await expect(page).toHaveURL(new RegExp(`/village/${village.id}$`), { timeout: 15000 });
+  await expect(page).toHaveURL(new RegExp(`/village/${village.id}\\/?$`), { timeout: 15000 });
   await expect(page.getByRole("heading", { name: new RegExp(newName) })).toBeVisible({
     timeout: 15000,
   });
@@ -65,7 +65,7 @@ test("村設定変更: 村名を変更して保存し、元に戻す", async ({ 
   await expect(page.getByLabel("村名")).toHaveValue(newName, { timeout: 15000 });
   await page.getByLabel("村名").fill(village.name);
   await page.getByRole("button", { name: "変更する" }).click();
-  await expect(page).toHaveURL(new RegExp(`/village/${village.id}$`), { timeout: 15000 });
+  await expect(page).toHaveURL(new RegExp(`/village/${village.id}\\/?$`), { timeout: 15000 });
   await expect(page.getByRole("heading", { name: new RegExp(village.name) })).toBeVisible({
     timeout: 15000,
   });

--- a/e2e/tests/village-settings.spec.ts
+++ b/e2e/tests/village-settings.spec.ts
@@ -79,15 +79,16 @@ test("設定モーダルで表示設定を変更でき、ブラウザに保存�
 
   // ページサイズ変更が保存される
   await dialog.getByLabel("ページあたりの表示発言数").selectOption("10");
-  const stored = await page.evaluate(() =>
-    localStorage.getItem("wolf-mansion-display-settings"),
+  await page.waitForFunction(
+    () => localStorage.getItem("wolf-mansion-display-settings")?.includes('"pageSize":10'),
   );
-  expect(stored).toContain('"pageSize":10');
 
   // リセットでデフォルト (50) に戻る
+  page.on("dialog", (d) => d.accept());
   await dialog.getByRole("button", { name: "リセット" }).click();
-  const reset = await page.evaluate(() => localStorage.getItem("wolf-mansion-display-settings"));
-  expect(reset).toContain('"pageSize":50');
+  await page.waitForFunction(
+    () => localStorage.getItem("wolf-mansion-display-settings")?.includes('"pageSize":50'),
+  );
 
   // 未ログイン or 未参加では Discord 通知設定が出ない (このテストは未ログイン)
   await expect(dialog.getByText("Discord通知設定")).toHaveCount(0);

--- a/e2e/tests/village-vote.spec.ts
+++ b/e2e/tests/village-vote.spec.ts
@@ -11,12 +11,22 @@ type SimpleVillage = { id: number; name: string };
 
 type VoteView = {
   canVote: boolean;
-  targetList: { charaId: number; name: string }[];
+  targetCharaIds: number[];
   targetCharaId: number | null;
-  targetName: string | null;
 };
 
-type Candidate = { villageId: number; userId: string; vote: VoteView };
+type Participant = { chara: { id: number }; name: string };
+type VillageDetail = {
+  participants: { list: Participant[] };
+  spectators: { list: Participant[] };
+};
+
+type Candidate = {
+  villageId: number;
+  userId: string;
+  vote: VoteView;
+  village: VillageDetail;
+};
 
 const CANDIDATE_USERS = Array.from(
   { length: 16 },
@@ -45,6 +55,16 @@ async function dismissInitialSkillModal(page: Page) {
   }
 }
 
+function resolveCharaName(village: VillageDetail, charaId: number): string {
+  const all = [...(village.participants.list ?? []), ...(village.spectators.list ?? [])];
+  return all.find((p) => p.chara.id === charaId)?.name ?? `(${charaId})`;
+}
+
+async function fetchVillage(page: Page, villageId: number): Promise<VillageDetail> {
+  const res = await page.request.get(`/wolf-mansion-api/api/v1/villages/${villageId}`);
+  expect(res.ok()).toBeTruthy();
+  return (await res.json()) as VillageDetail;
+}
 
 async function findVoteCandidate(
   page: Page,
@@ -54,14 +74,15 @@ async function findVoteCandidate(
   if (villages.length === 0) return null;
   for (const userId of CANDIDATE_USERS) {
     if (!(await login(page, userId))) continue;
-    for (const village of villages) {
+    for (const v of villages) {
       const res = await page.request.get(
-        `/wolf-mansion-api/api/v1/villages/${village.id}/situation/me`,
+        `/wolf-mansion-api/api/v1/villages/${v.id}/situation/me`,
       );
       if (!res.ok()) continue;
       const body = (await res.json()) as { vote: VoteView };
       if (body.vote.canVote && filter(body.vote)) {
-        return { villageId: village.id, userId, vote: body.vote };
+        const village = await fetchVillage(page, v.id);
+        return { villageId: v.id, userId, vote: body.vote, village };
       }
     }
   }
@@ -73,44 +94,48 @@ test("投票可能な参加者に投票パネルが表示される", async ({ pa
   test.skip(candidate == null, "投票できる参加者が見つからない DB のためスキップ");
   if (candidate == null) return;
 
+  const targetName =
+    candidate.vote.targetCharaId != null
+      ? resolveCharaName(candidate.village, candidate.vote.targetCharaId)
+      : null;
+
   await page.goto(`village/${candidate.villageId}`);
   await expect(page.getByRole("button", { name: "投票セット" })).toBeVisible({ timeout: 15000 });
   await dismissInitialSkillModal(page);
-  await expect(
-    page.getByText(`現在の投票先: ${candidate.vote.targetName ?? "なし"}`),
-  ).toBeVisible();
-  // 未セットの場合は突然死の警告が出る
+  await expect(page.getByText(`現在の投票先: ${targetName ?? "なし"}`)).toBeVisible();
   if (candidate.vote.targetCharaId == null) {
     await expect(page.getByText("(未セットのままだと突然死します)")).toBeVisible();
   }
 });
 
 test("投票先を変更してセットできる (元に戻して共有 DB の状態を変えない)", async ({ page }) => {
-  // 復元のためセット済みかつ候補 2 名以上の参加者に限定する
   const candidate = await findVoteCandidate(
     page,
-    (vote) => vote.targetCharaId != null && vote.targetList.length >= 2,
+    (vote) => vote.targetCharaId != null && vote.targetCharaIds.length >= 2,
   );
   test.skip(candidate == null, "投票セット済みの参加者が見つからない DB のためスキップ");
   if (candidate == null) return;
 
   const original = candidate.vote.targetCharaId;
-  const another = candidate.vote.targetList.find((t) => t.charaId !== original);
-  expect(another).toBeTruthy();
-  if (another == null) return;
+  const anotherCharaId = candidate.vote.targetCharaIds.find((id) => id !== original);
+  expect(anotherCharaId).toBeTruthy();
+  if (anotherCharaId == null) return;
+
+  const anotherName = resolveCharaName(candidate.village, anotherCharaId);
+  const originalName = resolveCharaName(candidate.village, original!);
 
   await page.goto(`village/${candidate.villageId}`);
   await expect(page.getByRole("button", { name: "投票セット" })).toBeVisible({ timeout: 15000 });
   await dismissInitialSkillModal(page);
 
-  await page.getByLabel("投票先").selectOption(String(another.charaId));
+  await page.getByLabel("投票先").selectOption(String(anotherCharaId));
   await page.getByRole("button", { name: "投票セット" }).click();
-  await expect(page.getByText(`現在の投票先: ${another.name}`)).toBeVisible({ timeout: 15000 });
+  await expect(page.getByText(`現在の投票先: ${anotherName}`)).toBeVisible({ timeout: 15000 });
 
   // 元の投票先に戻す
   await page.getByLabel("投票先").selectOption(String(original));
   await page.getByRole("button", { name: "投票セット" }).click();
-  await expect(page.getByText(`現在の投票先: ${candidate.vote.targetName}`)).toBeVisible({
+  await expect(page.getByText(`現在の投票先: ${originalName}`)).toBeVisible({
     timeout: 15000,
   });
 });

--- a/e2e/tests/village.spec.ts
+++ b/e2e/tests/village.spec.ts
@@ -62,7 +62,7 @@ test("進行中以降の村で日付ナビ遷移と状況タブが動く", async
 
   // 日付ナビでプロローグへ遷移できる
   await page.getByRole("link", { name: "プロローグ" }).first().click();
-  await expect(page).toHaveURL(new RegExp(`/village/${village.id}/day/0$`));
+  await expect(page).toHaveURL(new RegExp(`/village/${village.id}/day/0\\/?$`));
   // プロローグ表示では部屋割りタブが無く参加者タブが初期表示
   await expect(page.getByRole("button", { name: "部屋割り当て" })).toHaveCount(0);
   await expect(page.getByText("生存 (", { exact: false }).first()).toBeVisible();


### PR DESCRIPTION
closes .issues/fix-e2e-existing-failures.md

## Summary
- URL 末尾スラッシュの不一致: 全 spec の `toHaveURL` 正規表現を `\/?$` に統一
- auth テスト: マイページ URL を `/user/<id>` に修正、ログアウトをホームから実行、保護ルートテストを `/change-password` に変更
- settings テスト: リセット時の `window.confirm` ダイアログを accept するよう追加
- vote テスト: `VoteView` 型を API レスポンス (`targetCharaIds`) に合わせ、名前解決を village API から行うよう修正

## Test plan
- [x] `pnpm test tests/auth.spec.ts` — 2 passed
- [x] `pnpm test tests/village-settings.spec.ts` — passed
- [x] `pnpm test tests/village-vote.spec.ts` — passed
- [x] `pnpm test` (全体) — 70 passed, 0 failed (残りは DB 状態依存の skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)