### PR TITLE
enhance: MessageArea下部の広告を画面サイズに応じて出し分け

### DIFF
--- a/frontend/app/components/ui/AdSense.tsx
+++ b/frontend/app/components/ui/AdSense.tsx
@@ -1,8 +1,18 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 const AD_CLIENT = "ca-pub-0917187897820609";
 
-export function AdSense({ slot, className }: { slot: string; className?: string }) {
+export function AdSense({
+  slot,
+  className,
+  width,
+  height,
+}: {
+  slot: string;
+  className?: string;
+  width?: number;
+  height?: number;
+}) {
   const ref = useRef<HTMLDivElement>(null);
   const pushed = useRef(false);
 
@@ -22,16 +32,47 @@ export function AdSense({ slot, className }: { slot: string; className?: string 
     };
   }, []);
 
+  const isFixed = width != null && height != null;
+
   return (
     <div ref={ref} className={className}>
       <ins
         className="adsbygoogle"
-        style={{ display: "block" }}
+        style={
+          isFixed
+            ? { display: "inline-block", width: `${width}px`, height: `${height}px` }
+            : { display: "block" }
+        }
         data-ad-client={AD_CLIENT}
         data-ad-slot={slot}
-        data-ad-format="auto"
-        data-full-width-responsive="true"
+        {...(!isFixed && {
+          "data-ad-format": "auto",
+          "data-full-width-responsive": "true",
+        })}
       />
     </div>
+  );
+}
+
+export function ResponsiveAdSense({
+  sm,
+  lg,
+  className,
+}: {
+  sm: { slot: string; width: number; height: number };
+  lg: { slot: string; width: number; height: number };
+  className?: string;
+}) {
+  const [isSmall, setIsSmall] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    setIsSmall(window.matchMedia("(max-width: 639px)").matches);
+  }, []);
+
+  if (isSmall === null) return null;
+
+  const config = isSmall ? sm : lg;
+  return (
+    <AdSense slot={config.slot} width={config.width} height={config.height} className={className} />
   );
 }

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router";
 
 import { PageLayout } from "~/components/layout/PageLayout";
-import { AdSense } from "~/components/ui/AdSense";
+import { ResponsiveAdSense } from "~/components/ui/AdSense";
 import { LinkButton } from "~/components/ui/Button";
 import { useMe } from "~/features/auth/useMe";
 import type { VillageDetailView } from "~/features/village/api";
@@ -232,7 +232,13 @@ export default function Village({ params }: Route.ComponentProps) {
               }
             />
             <DayList currentDay={currentDay} onInfo={() => setInfoOpen(true)} />
-            {!noAd && <AdSense slot="2768254717" className="mt-[15px]" />}
+            {!noAd && (
+              <ResponsiveAdSense
+                sm={{ slot: "2553009704", width: 300, height: 90 }}
+                lg={{ slot: "2768254717", width: 728, height: 90 }}
+                className="mt-[15px]"
+              />
+            )}
             <div id="bottom" />
             <hr className="mt-[5px] mb-[10px] border-[#464545]" />
 


### PR DESCRIPTION
closes .issues/enhance-village-message-area-bottom-ad.md

## Summary
- `AdSense` コンポーネントに `width`/`height` プロップを追加し、固定サイズ広告に対応
- `ResponsiveAdSense` コンポーネントを新設。`window.matchMedia` で sm breakpoint (640px) を判定し、1つの広告のみレンダリング
- village route の MessageArea 下部広告を `ResponsiveAdSense` に差し替え
  - sm より大きい場合: slot `2768254717`、728x90px
  - sm 以下: slot `2553009704`、300x90px

## Test plan
- [ ] PC幅で村ページを開き、MessageArea 下部に 728x90 の広告枠が表示されること
- [ ] DevTools で 375px 程度にリサイズし、300x90 の広告枠に切り替わること
- [ ] Footer の広告（auto format）が従来通り動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)