### PR TITLE
fix: 役職詳細モーダルを進行中の村でのみ表示する

### DIFF
--- a/frontend/app/features/village/components/participate/InitialSkillModal.tsx
+++ b/frontend/app/features/village/components/participate/InitialSkillModal.tsx
@@ -36,12 +36,12 @@ export function InitialSkillModal({
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
-    if (skill == null || suppressed) {
+    if (skill == null || suppressed || !village.status.isProgress) {
       setOpen(false);
       return;
     }
     setOpen(!confirmedVillages().includes(String(villageId)));
-  }, [villageId, skill, suppressed]);
+  }, [villageId, skill, suppressed, village.status.isProgress]);
 
   if (!open || skill == null) return null;
 


### PR DESCRIPTION
closes .issues/fix-skill-modal-shown-in-finished-village.md

## Summary
- `InitialSkillModal` の `useEffect` に `village.status.isProgress` チェックを追加
- 進行中（Progress）以外の村（エピローグ・終了・廃村）ではモーダルが表示されなくなる

## Test plan
- [ ] 進行中の村を開き、役職詳細モーダルが表示されること（未確認の場合）
- [ ] 終了済みの村を開き、役職詳細モーダルが表示されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)