### PR TITLE
fix: 日付更新通知が消えない問題を修正し自動更新設定に応じた挙動に変更 (step-14)

### DIFF
--- a/frontend/app/components/ui/Toast.tsx
+++ b/frontend/app/components/ui/Toast.tsx
@@ -6,12 +6,16 @@ type ToastItem = {
   message: string;
   variant: "success" | "info" | "error";
   persistent: boolean;
+  duration?: number;
 };
 
 type ToastState = {
   items: ToastItem[];
   nextId: number;
-  show: (message: string, opts?: { variant?: ToastItem["variant"]; persistent?: boolean }) => void;
+  show: (
+    message: string,
+    opts?: { variant?: ToastItem["variant"]; persistent?: boolean; duration?: number },
+  ) => void;
   dismiss: (id: number) => void;
 };
 
@@ -27,6 +31,7 @@ export const useToast = create<ToastState>((set) => ({
           message,
           variant: opts?.variant ?? "success",
           persistent: opts?.persistent ?? false,
+          duration: opts?.duration,
         },
       ],
       nextId: s.nextId + 1,
@@ -44,10 +49,10 @@ function ToastEntry({ item }: { item: ToastItem }) {
   const dismiss = useToast((s) => s.dismiss);
 
   useEffect(() => {
-    if (item.persistent) return;
-    const timer = setTimeout(() => dismiss(item.id), 3000);
+    if (item.persistent && item.duration == null) return;
+    const timer = setTimeout(() => dismiss(item.id), item.duration ?? 3000);
     return () => clearTimeout(timer);
-  }, [item.id, item.persistent, dismiss]);
+  }, [item.id, item.persistent, item.duration, dismiss]);
 
   return (
     <div

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -129,14 +129,16 @@ export default function Village({ params }: Route.ComponentProps) {
 
   const daychangeDetected = useVillagePolling(villageId, latestDay);
   const showToast = useToast((s) => s.show);
+  const autoReload = useDisplaySettings((s) => s.autoReload);
   useEffect(() => {
     if (daychangeDetected) {
-      showToast("日付が更新されました。ページを再読み込みしてください。", {
+      showToast("日付が更新されました。", {
         variant: "info",
-        persistent: true,
+        persistent: !autoReload,
+        duration: autoReload ? 10_000 : undefined,
       });
     }
-  }, [daychangeDetected, showToast]);
+  }, [daychangeDetected, showToast, autoReload]);
 
   const { onMessagesLoaded: onMessagesLoadedBase, hasNewMessage } = useMessageSync(
     villageId,


### PR DESCRIPTION
closes .issues/fix-daychange-notification-not-dismissed.md

## Summary

- 日付更新通知のテキストを「日付が更新されました。」に簡略化（リロード促進メッセージを削除）
- 自動更新ON時: 通知が10秒後に自動消去されるように変更
- 自動更新OFF時: 通知は永続表示のまま（クリックで消去可能）
- Toast コンポーネントに `duration` オプションを追加し、カスタム自動消去時間をサポート

## Changes

- `frontend/app/components/ui/Toast.tsx`: `duration` オプション追加。`persistent: true` でも `duration` 指定があれば自動消去
- `frontend/app/routes/village/route.tsx`: `autoReload` 設定に応じて通知挙動を分岐

## Test plan

- [ ] 自動更新ONの状態で村の日付更新が発生した際、通知が約10秒後に自動消去されること
- [ ] 自動更新OFFの状態で村の日付更新が発生した際、通知が永続表示されクリックで消去できること
- [ ] 通知テキストが「日付が更新されました。」のみであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)