### PR TITLE
fix: [[tp]]/[[netabare]]内のネスト装飾クリックで内容が見られない問題を修正

### DIFF
--- a/frontend/app/features/village/components/message/MessageCard.tsx
+++ b/frontend/app/features/village/components/message/MessageCard.tsx
@@ -86,12 +86,14 @@ export function MessageCard({
       if (tag !== "" && onHashtagClick != null) onHashtagClick(tag);
       return;
     }
-    if (target.classList.contains("netabare")) {
-      target.classList.remove("netabare");
+    const netabare = target.closest(".netabare") as HTMLElement | null;
+    if (netabare != null) {
+      netabare.classList.remove("netabare");
       return;
     }
-    if (target.classList.contains("transparency")) {
-      target.classList.remove("transparency");
+    const transparency = target.closest(".transparency") as HTMLElement | null;
+    if (transparency != null) {
+      transparency.classList.remove("transparency");
     }
   };
 


### PR DESCRIPTION
## Summary

- `[[tp]]` や `[[netabare]]` の中に `[[#ffffff]]` 等の色装飾がネストされている場合、クリックしても透明/ネタバレ解除が発動しないバグを修正
- `target.classList.contains()` → `target.closest()` に変更し、子要素クリック時も親の装飾クラスを正しく除去

## Root Cause

`onContentClick` ハンドラが `event.target.classList.contains("transparency")` で判定していたため、`[[tp]][[#ffffff]]text[[/#]][[/tp]]` のように内側に別の装飾 span がある場合、クリック対象が内側の `<span style="color: ...">` になり、外側の `.transparency` クラス除去が発動しなかった。

## Test plan

- [ ] `[[tp]][[#ffffff]]テスト[[/#]][[/tp]]` を含む発言を表示し、クリックで透明が解除されることを確認
- [ ] `[[netabare]][[#ff0000]]テスト[[/#]][[/netabare]]` を含む発言を表示し、クリックでネタバレが解除されることを確認
- [ ] 装飾なしの `[[tp]]テスト[[/tp]]` が従来通りクリックで解除されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)