### PR TITLE
fix: access token失効後の更新で1回だけ未認証状態でメッセージが取得される問題を修正

### DIFF
--- a/frontend/app/features/auth/useMe.ts
+++ b/frontend/app/features/auth/useMe.ts
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { ApiError } from "~/lib/api";
 import { fetchMe, type MeResponse } from "./api";
@@ -60,4 +60,19 @@ export function useSetMe(): (me: MeResponse | null) => void {
 export function useInvalidateMe(): () => Promise<void> {
   const queryClient = useQueryClient();
   return () => queryClient.invalidateQueries({ queryKey: ME_QUERY_KEY });
+}
+
+/**
+ * ログイン中 (me キャッシュあり) なら me を取り直し、失効した access token を立て直す。
+ * 公開 GET は access token が失効していても 401 にならず匿名視点の 200 を返すため、
+ * 可視範囲がログイン状態に依存するクエリを再取得する前に await で呼ぶ。
+ * me は認証必須のため、失効していれば apiFetch の refresh → リトライで token が更新される。
+ * refresh も失効していた場合は me が null になり、呼び出し側は匿名視点として扱える。
+ */
+export function useEnsureFreshAuth(): () => Promise<void> {
+  const queryClient = useQueryClient();
+  return useCallback(async () => {
+    if (queryClient.getQueryData(ME_QUERY_KEY) == null) return;
+    await queryClient.refetchQueries({ queryKey: ME_QUERY_KEY });
+  }, [queryClient]);
 }

--- a/frontend/app/features/village/useVillage.ts
+++ b/frontend/app/features/village/useVillage.ts
@@ -1,7 +1,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { useMe } from "~/features/auth/useMe";
+import { useEnsureFreshAuth, useMe } from "~/features/auth/useMe";
 import {
   fetchMyVillageSituation,
   fetchVillage,
@@ -64,20 +64,24 @@ export function useVillageDebugInfo(id: number) {
   });
 }
 
-/** 村系クエリをまとめて無効化する (日付更新・手動更新時)。発言一覧・デバッグ情報も含む。 */
+/**
+ * 村系クエリをまとめて無効化する (日付更新・手動更新時)。発言一覧・デバッグ情報も含む。
+ * 発言一覧などの公開 GET は access token が失効していても匿名視点の 200 を返してしまうため、
+ * 再取得の前に me を取り直して認証状態を立て直してから無効化する。
+ */
 export function useInvalidateVillage(id: number) {
   const queryClient = useQueryClient();
-  return useCallback(
-    () =>
-      Promise.all([
-        queryClient.invalidateQueries({ queryKey: [VILLAGE_QUERY_KEY, id] }),
-        queryClient.invalidateQueries({ queryKey: [VILLAGE_SITUATION_QUERY_KEY, id] }),
-        queryClient.invalidateQueries({ queryKey: [MY_VILLAGE_SITUATION_QUERY_KEY, id] }),
-        queryClient.invalidateQueries({ queryKey: [VILLAGE_MESSAGES_QUERY_KEY, id] }),
-        queryClient.invalidateQueries({ queryKey: ["village-debug", id] }),
-      ]),
-    [queryClient, id],
-  );
+  const ensureFreshAuth = useEnsureFreshAuth();
+  return useCallback(async () => {
+    await ensureFreshAuth();
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: [VILLAGE_QUERY_KEY, id] }),
+      queryClient.invalidateQueries({ queryKey: [VILLAGE_SITUATION_QUERY_KEY, id] }),
+      queryClient.invalidateQueries({ queryKey: [MY_VILLAGE_SITUATION_QUERY_KEY, id] }),
+      queryClient.invalidateQueries({ queryKey: [VILLAGE_MESSAGES_QUERY_KEY, id] }),
+      queryClient.invalidateQueries({ queryKey: ["village-debug", id] }),
+    ]);
+  }, [queryClient, id, ensureFreshAuth]);
 }
 
 export function useVillageInvalidate() {


### PR DESCRIPTION
closes .issues/fix-stale-auth-message-fetch.md

## 根本原因

- 発言一覧などの公開 GET (`/api/v1/villages/{id}/messages` 等) は permitAll で、`JwtAuthenticationFilter` は失効した access token を「匿名」として素通しする。そのため **access token が失効していても 401 にならず匿名視点の 200 が返り**、`apiFetch` の「401 → refresh → リトライ」が発動しない
- 村ポーリングの `/villages/{id}/update` も permitAll のため、村画面を開き続けていても token 失効を回復する機会がない（`refetchOnWindowFocus: false` のためタブ復帰時も me 再検証なし）
- 更新ボタンの `invalidateQueries` で、メッセージは失効 token のまま匿名視点で取得され参加者限定発言が消える。同時に走る `useMyVillageSituation`（認証必須）が 401 → refresh で token を立て直すため、2回目以降は正常 =「1回だけ」発生

## 修正内容

- `useEnsureFreshAuth` を追加: ログイン中キャッシュがあるとき me を取り直す。me は認証必須のため、失効時は apiFetch の refresh → リトライで access token が更新される
- `useInvalidateVillage` の先頭で `ensureFreshAuth()` を await し、認証状態を立て直してから村系クエリ（メッセージ含む）を無効化・再取得する。更新ボタン・日付更新検知の両経路をカバー

## 動作確認

- ローカルで backend/frontend を起動し、進行中の村に testuser01 でログイン → 独り言を投稿 → access_token Cookie を削除（失効の再現）→ 更新ボタン押下
- リクエスト順序を確認: `GET /auth/me` **401** → `POST /auth/refresh` 200 → `GET /auth/me` 200 → その後に `GET /villages/1/messages` 等が認証済みで 200。独り言は表示されたまま消えないことを確認
- frontend lint / format / build: pass
- e2e: 修正前後で結果差分なし（`village-settings-update` の 1 件のみ失敗するが、base でも同様に失敗する DB 状態起因の pre-existing）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAzWW9S6uojU7btEcXckeR