### PR TITLE
enhance: 発言抽出の参加者一覧を部屋番号順に並べる

### DIFF
--- a/frontend/app/features/village/components/modal/FilterModal.tsx
+++ b/frontend/app/features/village/components/modal/FilterModal.tsx
@@ -7,7 +7,7 @@ import { Modal } from "~/components/ui/Modal";
 import { TextButton } from "~/components/ui/TextButton";
 import type { VillageParticipantView } from "~/features/village/api";
 import { useVillageContext } from "~/features/village/VillageContext";
-import { allParticipants } from "~/features/village/participants";
+import { allParticipants, sortByRoomNumber } from "~/features/village/participants";
 import { useMyVillageSituation } from "~/features/village/useVillage";
 import { EMPTY_FILTER, FILTER_TYPES, type MessageFilter } from "~/features/village/filter";
 import { MessageType } from "~/features/village/components/message/messageType";
@@ -164,7 +164,8 @@ export function FilterModal({
 }) {
   const village = useVillageContext();
   const { data: mySituation } = useMyVillageSituation(village.id, dayParam);
-  const participants = allParticipants(village).map(toFilterParticipant);
+  // 部屋割りのある村では部屋番号と一覧の並びを一致させて対象を探しやすくする (表示専用のソート)
+  const participants = sortByRoomNumber(allParticipants(village)).map(toFilterParticipant);
   const myselfId = mySituation?.myself?.id ?? null;
   const notificationKeyword =
     mySituation?.myself?.notification?.message?.keywords?.join("\n") ?? null;

--- a/frontend/app/features/village/participants.ts
+++ b/frontend/app/features/village/participants.ts
@@ -8,3 +8,14 @@ export function resolveParticipantName(village: VillageDetailView, charaId: numb
 export function allParticipants(village: VillageDetailView): VillageParticipantView[] {
   return [...(village.participants.list ?? []), ...(village.spectators.list ?? [])];
 }
+
+/**
+ * 部屋番号昇順に並べ替えた新しい配列を返す。
+ * 部屋を持たない参加者 (部屋割り前・部屋なし村・見学者) は元の順のまま末尾に置く。
+ */
+export function sortByRoomNumber(participants: VillageParticipantView[]): VillageParticipantView[] {
+  return [...participants].sort(
+    (a, b) =>
+      (a.room?.number ?? Number.MAX_SAFE_INTEGER) - (b.room?.number ?? Number.MAX_SAFE_INTEGER),
+  );
+}


### PR DESCRIPTION
closes .issues/enhance-filter-participants-room-order.md

## 変更内容

- 発言抽出モーダル（`FilterModal`）の「発言者」「宛先」チェックリストを部屋番号昇順で表示する
- `features/village/participants.ts` に表示用ソート `sortByRoomNumber` を追加。部屋を持たない参加者（部屋割り前・部屋なし村・見学者）は元の順のまま末尾に置く（stable sort）
- ソートは表示専用で、`MessageFilter` に保存する ID の扱い（空 = 全選択の変換）は変えていない

## 動作確認

- ローカルで backend/frontend を起動し、部屋割りあり進行中村（部屋番号が入村順にバラバラ: 5,3,2,8,7,6,11,10）で抽出モーダルを開き、発言者・宛先とも部屋番号昇順（02→03→05→06→07→08→10→11）で表示されることを確認
- 発言者を 1 人チェック → 抽出で従来どおり `?fpid=<参加者ID>` が適用され絞り込みが動作することを確認（ID の扱いは不変）
- 部屋割りのない募集中村でも表示が崩れないことを確認
- frontend lint / format: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAzWW9S6uojU7btEcXckeR