### PR TITLE
enhance: 発言確認・確定時のスクロールをメッセージ末尾基準にする

### DIFF
--- a/frontend/app/features/village/components/message/MessageArea.tsx
+++ b/frontend/app/features/village/components/message/MessageArea.tsx
@@ -107,6 +107,8 @@ export function MessageArea({
         />
       ))}
       {confirmArea}
+      {/* 発言確認・確定時のスクロール下端。メッセージエリア外の要素 (DayList・広告) を画面に入れない */}
+      <div id="message-bottom" />
       {data.suddenlyDeathMessage != null && <Announce text={data.suddenlyDeathMessage} />}
       {data.villageStatusMessage != null && <Announce text={data.villageStatusMessage} />}
       {data.commitStatusMessage != null && <Announce text={data.commitStatusMessage} />}

--- a/frontend/app/features/village/useSayFlow.ts
+++ b/frontend/app/features/village/useSayFlow.ts
@@ -39,8 +39,8 @@ export function useSayFlow(villageId: number, invalidate: () => Promise<unknown>
   type SayKind = "say" | "action" | "creatorSay";
   const onSayDoneCallbacks = useRef<Map<SayKind, () => void>>(new Map());
 
-  // state 更新直後はプレビューが DOM に反映される前でスクロール位置の計算がずれるため、
-  // 反映後の effect からスクロールする
+  // ハンドラ内で state 更新直後にスクロールするとプレビューの DOM 反映前で位置計算がずれる。
+  // 反映後に走る effect から、レイアウト確定を待って次フレームでスクロールする
   useEffect(() => {
     if (sayPreview == null) return;
     requestAnimationFrame(() => scrollToMessageBottom());

--- a/frontend/app/features/village/useSayFlow.ts
+++ b/frontend/app/features/village/useSayFlow.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
   actionVillage,
@@ -13,6 +13,7 @@ import {
 } from "~/features/village/api";
 import type { ReplyDraft } from "~/features/village/components/message/MessageCard";
 import type { SayPreview } from "~/features/village/components/action/SayPreviewArea";
+import { useVillageScroll } from "~/features/village/useVillageScroll";
 import { ApiError } from "~/lib/api";
 
 function isSayPanelFixed(): boolean {
@@ -29,17 +30,21 @@ function scrollToSayPanel() {
   }
 }
 
-export function useSayFlow(
-  villageId: number,
-  invalidate: () => Promise<unknown>,
-  scrollToBottom: () => void,
-) {
+export function useSayFlow(villageId: number, invalidate: () => Promise<unknown>) {
+  const { scrollToMessageBottom } = useVillageScroll();
   const [reply, setReply] = useState<ReplyDraft | null>(null);
   const [sayPreview, setSayPreview] = useState<SayPreview | null>(null);
   const [sayError, setSayError] = useState<string | null>(null);
   const [saySubmitting, setSaySubmitting] = useState(false);
   type SayKind = "say" | "action" | "creatorSay";
   const onSayDoneCallbacks = useRef<Map<SayKind, () => void>>(new Map());
+
+  // state 更新直後はプレビューが DOM に反映される前でスクロール位置の計算がずれるため、
+  // 反映後の effect からスクロールする
+  useEffect(() => {
+    if (sayPreview == null) return;
+    requestAnimationFrame(() => scrollToMessageBottom());
+  }, [sayPreview, scrollToMessageBottom]);
 
   const onReply = useCallback((draft: ReplyDraft) => {
     setReply(draft);
@@ -61,7 +66,6 @@ export function useSayFlow(
         return;
       }
       setSayPreview({ kind: "say", message: response.message, request });
-      requestAnimationFrame(() => scrollToBottom());
     } catch (e) {
       setSayError(e instanceof ApiError ? e.detail : "発言の確認に失敗しました");
     }
@@ -76,7 +80,6 @@ export function useSayFlow(
         return;
       }
       setSayPreview({ kind: "action", message: response.message, request });
-      requestAnimationFrame(() => scrollToBottom());
     } catch (e) {
       setSayError(e instanceof ApiError ? e.detail : "アクションの確認に失敗しました");
     }
@@ -91,7 +94,6 @@ export function useSayFlow(
         return;
       }
       setSayPreview({ kind: "creatorSay", message: response.message, request });
-      requestAnimationFrame(() => scrollToBottom());
     } catch (e) {
       setSayError(e instanceof ApiError ? e.detail : "村建て発言の確認に失敗しました");
     }
@@ -114,7 +116,7 @@ export function useSayFlow(
       setReply(null);
       onSayDoneCallbacks.current.get(kind)?.();
       await invalidate();
-      requestAnimationFrame(() => scrollToBottom());
+      requestAnimationFrame(() => scrollToMessageBottom());
     } catch (e) {
       setSayError(e instanceof ApiError ? e.detail : "発言に失敗しました");
     } finally {

--- a/frontend/app/features/village/useVillageScroll.ts
+++ b/frontend/app/features/village/useVillageScroll.ts
@@ -2,17 +2,34 @@ import { useCallback } from "react";
 
 const FOOTER_HEIGHT = 45;
 
+/**
+ * 指定 ID の要素が画面下端 (固定フッターの上) に来る位置までスクロールする。
+ * 要素が positioned ancestor 内にあっても正しく計算できるよう viewport 座標基準で求める。
+ */
+function scrollToElementBottom(id: string, smooth: boolean) {
+  const el = document.getElementById(id);
+  if (el == null) return;
+  const top = el.getBoundingClientRect().top + window.scrollY - window.innerHeight + FOOTER_HEIGHT;
+  window.scrollTo({ top: Math.max(0, top), behavior: smooth ? "smooth" : "instant" });
+}
+
 export function useVillageScroll() {
   const scrollToTop = useCallback(() => {
     window.scrollTo({ top: 0, behavior: "smooth" });
   }, []);
 
+  /** ページ末尾 (`#bottom` = DayList・広告の下) を下端に合わせる。フッターの▼ボタン用。 */
   const scrollToBottom = useCallback((smooth = true) => {
-    const el = document.getElementById("bottom");
-    if (el == null) return;
-    const top = el.offsetTop - window.innerHeight + FOOTER_HEIGHT;
-    window.scrollTo({ top: Math.max(0, top), behavior: smooth ? "smooth" : "instant" });
+    scrollToElementBottom("bottom", smooth);
   }, []);
 
-  return { scrollToTop, scrollToBottom };
+  /**
+   * メッセージ末尾 (`#message-bottom` = 発言プレビューの直下) を下端に合わせる。
+   * 発言確認・確定時に確認したいメッセージが見やすい位置で止まるようにする。
+   */
+  const scrollToMessageBottom = useCallback((smooth = true) => {
+    scrollToElementBottom("message-bottom", smooth);
+  }, []);
+
+  return { scrollToTop, scrollToBottom, scrollToMessageBottom };
 }

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -106,7 +106,7 @@ export default function Village({ params }: Route.ComponentProps) {
     onCreatorSayConfirm,
     onSayDetermine,
     onSayCancel,
-  } = useSayFlow(villageId, invalidate, scrollToBottom);
+  } = useSayFlow(villageId, invalidate);
 
   // 発言抽出。URL searchParams が正本 (共有 URL で再現できる)
   const [searchParams, setSearchParams] = useSearchParams();


### PR DESCRIPTION
closes .issues/enhance-say-confirm-scroll-to-message-bottom.md

## 変更内容

- `MessageArea` の `{confirmArea}` 直後（突然死アナウンスの前）に `#message-bottom` アンカーを追加
- `useVillageScroll` に `scrollToMessageBottom` を追加。スクロール位置の計算を `offsetTop` から viewport 座標基準（`getBoundingClientRect().top + scrollY`）に変更し、positioned ancestor（`MessageArea` の `relative`）内の要素でも正しく下端合わせできるようにした
- `useSayFlow`: 発言 / アクション / 村建て発言の確認時・発言確定時のスクロールを `#message-bottom` 基準に変更
  - プレビューの DOM 反映**前**に `requestAnimationFrame` でスクロール位置を計算していたため位置がずれる問題があり、`sayPreview` 反映後の `useEffect` からスクロールする方式に変更
  - `useSayFlow` はスクロール関数を内部で取得する形にし、route からの受け渡しを廃止
- フッターの▼ボタン・`#bottom` は従来どおり

## 動作確認

ローカルで backend/frontend を起動し、進行中の村に参加者でログインして確認:

- 発言確認: プレビュー表示後、`#message-bottom` が画面下端（固定フッター上端）ちょうどで停止（実測 823px = viewport 868 − footer 45）
- 発言確定: 投稿後も新着メッセージ直下の `#message-bottom` が下端ちょうどで停止、発言はログに反映
- フッター▼ボタン: 従来どおり `#bottom`（DayList・広告の下）が下端に来る位置まで到達
- frontend lint / format / build: pass
- e2e（village-say / village-rp / village-creator / village）: 13 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAzWW9S6uojU7btEcXckeR