### PR TITLE
refactor: 参加者の部屋番号順ソートを共通化しセマンティクスを統一

### DIFF
--- a/frontend/app/features/village/components/info/MemberListTab.tsx
+++ b/frontend/app/features/village/components/info/MemberListTab.tsx
@@ -1,6 +1,6 @@
 import type { VillageParticipantView } from "~/features/village/api";
 import { useVillageContext } from "~/features/village/VillageContext";
-import { allParticipants } from "~/features/village/participants";
+import { allParticipants, compareByRoomNumber } from "~/features/village/participants";
 
 const cellBorderClass = "border border-[#464545]";
 
@@ -8,9 +8,6 @@ type MemberGroup = {
   status: string;
   members: { name: string; deadDay: string | null; memo: string | null }[];
 };
-
-const sortByRoom = (a: VillageParticipantView, b: VillageParticipantView) =>
-  (a.room?.number ?? 0) - (b.room?.number ?? 0) || a.chara.id - b.chara.id;
 
 function groupParticipants(participants: VillageParticipantView[]): MemberGroup[] {
   const alive: VillageParticipantView[] = [];
@@ -38,16 +35,16 @@ function groupParticipants(participants: VillageParticipantView[]): MemberGroup[
     }));
 
   const groups: MemberGroup[] = [
-    { status: "生存", members: toMembers([...alive].sort(sortByRoom)) },
+    { status: "生存", members: toMembers([...alive].sort(compareByRoomNumber)) },
   ];
   for (const [reason, list] of deadByReason) {
     const sorted = [...list].sort(
-      (a, b) => (a.dead.deadDay ?? 0) - (b.dead.deadDay ?? 0) || sortByRoom(a, b),
+      (a, b) => (a.dead.deadDay ?? 0) - (b.dead.deadDay ?? 0) || compareByRoomNumber(a, b),
     );
     groups.push({ status: reason, members: toMembers(sorted) });
   }
   if (spectators.length > 0) {
-    groups.push({ status: "見学", members: toMembers([...spectators].sort(sortByRoom)) });
+    groups.push({ status: "見学", members: toMembers([...spectators].sort(compareByRoomNumber)) });
   }
   return groups;
 }

--- a/frontend/app/features/village/components/message/SystemMessage.tsx
+++ b/frontend/app/features/village/components/message/SystemMessage.tsx
@@ -2,6 +2,7 @@ import { type MouseEvent, useMemo } from "react";
 
 import type { VillageMessageContent } from "~/features/village/api";
 import { useVillageContext } from "~/features/village/VillageContext";
+import { allParticipants, sortByRoomNumber } from "~/features/village/participants";
 import { ParticipantsTable } from "../info/ParticipantsTable";
 import { MessageType } from "./messageType";
 import { SYSTEM_VARIANTS, bubbleClass } from "./message";
@@ -17,14 +18,7 @@ export function SystemMessage({
   onContentClick: (e: MouseEvent<HTMLDivElement>) => void;
 }) {
   const village = useVillageContext();
-  const sortedParticipants = useMemo(() => {
-    return [...(village.participants.list ?? []), ...(village.spectators.list ?? [])].sort(
-      (a, b) =>
-        Number(a.isSpectator) - Number(b.isSpectator) ||
-        (a.room?.number ?? 0) - (b.room?.number ?? 0) ||
-        a.chara.id - b.chara.id,
-    );
-  }, [village.participants.list, village.spectators.list]);
+  const sortedParticipants = useMemo(() => sortByRoomNumber(allParticipants(village)), [village]);
 
   if (message.messageType === MessageType.PARTICIPANTS && sortedParticipants.length > 0) {
     return (

--- a/frontend/app/features/village/participants.ts
+++ b/frontend/app/features/village/participants.ts
@@ -10,12 +10,18 @@ export function allParticipants(village: VillageDetailView): VillageParticipantV
 }
 
 /**
- * 部屋番号昇順に並べ替えた新しい配列を返す。
- * 部屋を持たない参加者 (部屋割り前・部屋なし村・見学者) は元の順のまま末尾に置く。
+ * 部屋番号順の比較関数。backend の VillageParticipants.sortedByRoomNumber と同じセマンティクス:
+ * 見学者を末尾に置き、部屋番号昇順 (部屋を持たない参加者は先頭)、同順位は chara.id 昇順。
  */
-export function sortByRoomNumber(participants: VillageParticipantView[]): VillageParticipantView[] {
-  return [...participants].sort(
-    (a, b) =>
-      (a.room?.number ?? Number.MAX_SAFE_INTEGER) - (b.room?.number ?? Number.MAX_SAFE_INTEGER),
+export function compareByRoomNumber(a: VillageParticipantView, b: VillageParticipantView): number {
+  return (
+    Number(a.isSpectator) - Number(b.isSpectator) ||
+    (a.room?.number ?? 0) - (b.room?.number ?? 0) ||
+    a.chara.id - b.chara.id
   );
+}
+
+/** 部屋番号順 (compareByRoomNumber) に並べ替えた新しい配列を返す。 */
+export function sortByRoomNumber(participants: VillageParticipantView[]): VillageParticipantView[] {
+  return [...participants].sort(compareByRoomNumber);
 }


### PR DESCRIPTION
closes .issues/refactor-unify-room-order-sort.md

## 概要

部屋番号順のソートロジックが frontend の 3 箇所（`participants.ts` / `MemberListTab.tsx` / `SystemMessage.tsx`）に重複し、部屋なし参加者の扱いとタイブレークが三者三様になっていたため、`participants.ts` に一本化した。

## 統一セマンティクス

backend のドメイン実装 `VillageParticipants.sortedByRoomNumber()` を正とする:

1. 見学者を末尾
2. 部屋番号昇順（部屋を持たない参加者は 0 扱いで先頭）
3. 同順位は chara.id 昇順

## 変更内容

- `participants.ts`: 上記セマンティクスの `compareByRoomNumber` を追加し、`sortByRoomNumber` をこれに基づく実装へ変更
- `MemberListTab.tsx`: 独自 `sortByRoom` を削除し `compareByRoomNumber` を利用
- `SystemMessage.tsx`: インラインのソートを削除し `sortByRoomNumber(allParticipants(village))` を利用

## 表示への影響

- メンバー一覧タブ・システムメッセージ（参加者一覧）: 変更なし（従来と同じ並び）
- 発言抽出モーダル: 部屋なし参加者が末尾→先頭、タイブレークが入村順→chara.id 順に変わり、メンバー一覧タブと同じ並びになる（プロローグ村で表示順が変わる）

## 動作確認

- `pnpm lint` / `pnpm format:check` / `pnpm build` 成功
- e2e: 変更あり/なしで結果が同一であることを確認（失敗 1 件は e2e 共有村のデータ状態起因で本変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAzWW9S6uojU7btEcXckeR