### PR TITLE
enhance: 推理補助の足音表示で欠けた部屋の経路を推定補完する

### DIFF
--- a/frontend/app/features/village/analyzer/footstepGaps.ts
+++ b/frontend/app/features/village/analyzer/footstepGaps.ts
@@ -1,0 +1,118 @@
+// 足音の鳴った部屋の集合から、鳴らなかった部屋（空き部屋・死亡者・防音者など）で
+// 途切れた経路区間を推定する。
+//
+// 徘徊・襲撃の経路は縦横移動のみで曲がりは最大1回（直線または L字）。
+// 足音は経路の内部の部屋（始点・終点を除く）でのみ鳴り、部屋番号昇順で記録される
+// ため経路順は失われている。ここでは「すべての鳴った部屋が乗る直線または L字」を
+// 幾何的に復元し、鳴った部屋同士の間で欠けているセル列を gap 区間として返す。
+// L字の角が複数通りあり得る場合（対角2部屋など）は、あり得る候補すべてを返す。
+
+export interface GridCell {
+  x: number;
+  y: number;
+}
+
+export function parseFootstepRoomNumbers(footstep: string): number[] {
+  return footstep
+    .split(",")
+    .map((s) => Number.parseInt(s.trim(), 10))
+    .filter((n) => !Number.isNaN(n));
+}
+
+function cellKey(cell: GridCell): string {
+  return `${cell.x},${cell.y}`;
+}
+
+// 一直線上に並んだ鳴った部屋の間の gap 区間を返す
+function straightGapSegments(cells: GridCell[], axis: "x" | "y"): GridCell[][] {
+  const sorted = [...cells].sort((a, b) => a[axis] - b[axis]);
+  const segments: GridCell[][] = [];
+  for (let i = 0; i < sorted.length - 1; i++) {
+    const from = sorted[i];
+    const to = sorted[i + 1];
+    if (to[axis] - from[axis] <= 1) continue;
+    const segment = [from];
+    for (let v = from[axis] + 1; v < to[axis]; v++) {
+      segment.push(axis === "x" ? { x: v, y: from.y } : { x: from.x, y: v });
+    }
+    segment.push(to);
+    segments.push(segment);
+  }
+  return segments;
+}
+
+// 角 (cx, cy) の L字経路としてすべての鳴った部屋を説明できる場合、
+// 経路順に並べたセル列（両端は鳴った部屋）を返す。できなければ null
+function orderedLPathCells(cells: GridCell[], cx: number, cy: number): GridCell[] | null {
+  if (!cells.every((c) => c.x === cx || c.y === cy)) return null;
+
+  const verticalYs = cells.filter((c) => c.x === cx).map((c) => c.y);
+  const horizontalXs = cells.filter((c) => c.y === cy).map((c) => c.x);
+  // 角は各辺の端点なので、辺上の部屋が角を跨いで両側にある並び（T字・十字）は L字ではない
+  if (Math.min(...verticalYs) < cy && Math.max(...verticalYs) > cy) return null;
+  if (Math.min(...horizontalXs) < cx && Math.max(...horizontalXs) > cx) return null;
+
+  const farY = verticalYs.reduce((far, y) => (Math.abs(y - cy) > Math.abs(far - cy) ? y : far), cy);
+  const farX = horizontalXs.reduce(
+    (far, x) => (Math.abs(x - cx) > Math.abs(far - cx) ? x : far),
+    cx,
+  );
+  // どちらかの辺に鳴った部屋がなければ L字ではなく直線として扱われるべき並び
+  if (farY === cy || farX === cx) return null;
+
+  const path: GridCell[] = [];
+  const yStep = farY < cy ? 1 : -1;
+  for (let y = farY; y !== cy; y += yStep) path.push({ x: cx, y });
+  path.push({ x: cx, y: cy });
+  const xStep = farX < cx ? -1 : 1;
+  for (let x = cx + xStep; x !== farX + xStep; x += xStep) path.push({ x, y: cy });
+  return path;
+}
+
+// 経路順セル列を歩き、鳴った部屋の間に鳴らなかったセルが挟まる区間を切り出す
+function gapSegmentsAlongPath(path: GridCell[], audibleKeys: Set<string>): GridCell[][] {
+  const segments: GridCell[][] = [];
+  let current: GridCell[] | null = null;
+  for (const cell of path) {
+    if (audibleKeys.has(cellKey(cell))) {
+      if (current && current.length > 1) {
+        current.push(cell);
+        segments.push(current);
+      }
+      current = [cell];
+    } else if (current) {
+      current.push(cell);
+    }
+  }
+  return segments;
+}
+
+// 鳴った部屋のセル集合から補完すべき gap 区間を求める。
+// 各区間は「鳴った部屋 → 鳴らなかったセル列 → 鳴った部屋」の経路順セル列
+export function interpolateFootstepGapSegments(audibleCells: GridCell[]): GridCell[][] {
+  if (audibleCells.length < 2) return [];
+
+  const xs = [...new Set(audibleCells.map((c) => c.x))];
+  const ys = [...new Set(audibleCells.map((c) => c.y))];
+  if (ys.length === 1) return straightGapSegments(audibleCells, "x");
+  if (xs.length === 1) return straightGapSegments(audibleCells, "y");
+
+  const audibleKeys = new Set(audibleCells.map(cellKey));
+  const segments: GridCell[][] = [];
+  const seenSegmentKeys = new Set<string>();
+  for (const cx of xs) {
+    for (const cy of ys) {
+      const path = orderedLPathCells(audibleCells, cx, cy);
+      if (!path) continue;
+      for (const segment of gapSegmentsAlongPath(path, audibleKeys)) {
+        const keys = segment.map(cellKey);
+        const segmentKey = keys.join(">");
+        if (seenSegmentKeys.has(segmentKey)) continue;
+        seenSegmentKeys.add(segmentKey);
+        seenSegmentKeys.add(keys.reverse().join(">"));
+        segments.push(segment);
+      }
+    }
+  }
+  return segments;
+}

--- a/frontend/app/features/village/components/analyzer/AnalyzerRoomGrid.tsx
+++ b/frontend/app/features/village/components/analyzer/AnalyzerRoomGrid.tsx
@@ -4,6 +4,7 @@ import type { AnalyzerDayRoom, AnalyzerVillageData } from "~/features/village/an
 import type { DayFootstep, ParticipantMemo } from "~/features/village/analyzer/types";
 import { TextButton } from "~/components/ui/TextButton";
 import { deadColor, deadMark } from "~/features/village/components/info/dead";
+import { FootstepGapLines } from "./FootstepGapLines";
 import { FootstepLines } from "./FootstepLines";
 
 // 簡易部屋割テキスト。空室は「＿」、メモなしは「□」、メモありはメモの1文字目で表す
@@ -106,97 +107,106 @@ export function AnalyzerRoomGrid({
   return (
     <div>
       <div className="overflow-x-auto">
-        <table className="border-collapse">
-          <tbody>
-            {rows.map((row, y) => (
-              <tr key={y}>
-                {row.map((room) => {
-                  const pMemo = getMemo(room.participantId);
-                  const memoText = pMemo?.memo ?? "";
-                  const memoColor = pMemo?.color ?? "ffffff";
-                  const displayMemo =
-                    memoText.length > 24 ? `${memoText.slice(0, 23)}...` : memoText;
-                  const img = room.participantId
-                    ? charaImageUrl(room.participantId, participantIdToChara)
-                    : null;
-                  const isDummy =
-                    room.participantId != null &&
-                    participantIdToChara[String(room.participantId)]?.id === dummyCharaId;
+        <div className="relative inline-block">
+          <table className="border-collapse">
+            <tbody>
+              {rows.map((row, y) => (
+                <tr key={y}>
+                  {row.map((room) => {
+                    const pMemo = getMemo(room.participantId);
+                    const memoText = pMemo?.memo ?? "";
+                    const memoColor = pMemo?.color ?? "ffffff";
+                    const displayMemo =
+                      memoText.length > 24 ? `${memoText.slice(0, 23)}...` : memoText;
+                    const img = room.participantId
+                      ? charaImageUrl(room.participantId, participantIdToChara)
+                      : null;
+                    const isDummy =
+                      room.participantId != null &&
+                      participantIdToChara[String(room.participantId)]?.id === dummyCharaId;
 
-                  return (
-                    <td
-                      key={room.roomNumber}
-                      className={`relative border border-[#464545] p-0 text-center ${room.participantId != null ? "cursor-pointer" : ""}`}
-                      style={{ width: cellW, minWidth: cellW, height: cellH }}
-                      onClick={() =>
-                        room.participantId != null && onParticipantClick(room.participantId)
-                      }
-                    >
-                      {footsteps.map((fs, idx) => (
-                        <FootstepLines
-                          key={`${room.roomNumber}-fs-${idx}`}
-                          footstep={fs.footstep}
-                          color={fs.color}
-                          show={fs.show}
-                          room={room}
-                          allRooms={rooms}
-                          index={idx}
-                        />
-                      ))}
-                      {displayMemo && (
-                        <div className="absolute top-0 left-0 right-0 z-[3] px-[2px]">
-                          <p
-                            className="my-0 whitespace-normal text-[0.75rem] leading-tight"
-                            style={{ color: `#${memoColor}` }}
-                          >
-                            {displayMemo}
-                          </p>
-                        </div>
-                      )}
-                      {img && (
-                        <div
-                          className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
-                          style={{
-                            width: img.width,
-                            height: img.height,
-                            backgroundImage: `url(${img.url})`,
-                            backgroundRepeat: "no-repeat",
-                            backgroundSize: "contain",
-                            opacity: room.isDead == null || room.isDead ? 0.2 : 0.7,
-                          }}
-                        />
-                      )}
-                      <div className="absolute bottom-0 left-1/2 -translate-x-1/2 whitespace-nowrap opacity-80">
-                        <span className="bg-wm-base text-[11px]">
-                          {String(room.roomNumber).padStart(2, "0")}{" "}
-                          {room.participantId != null
-                            ? (participants.find((p) => p.id === room.participantId)?.charaName
-                                .shortName ?? "")
-                            : ""}
-                        </span>
-                        {room.isDead && (
-                          <span
-                            className="bg-wm-base text-[11px]"
-                            style={{ color: deadColor(room.deadReason?.code) ?? undefined }}
-                          >
-                            <br />
-                            {room.deadDay}d {deadMark(room.deadReason?.code)}
-                          </span>
+                    return (
+                      <td
+                        key={room.roomNumber}
+                        className={`relative border border-[#464545] p-0 text-center ${room.participantId != null ? "cursor-pointer" : ""}`}
+                        style={{ width: cellW, minWidth: cellW, height: cellH }}
+                        onClick={() =>
+                          room.participantId != null && onParticipantClick(room.participantId)
+                        }
+                      >
+                        {footsteps.map((fs, idx) => (
+                          <FootstepLines
+                            key={`${room.roomNumber}-fs-${idx}`}
+                            footstep={fs.footstep}
+                            color={fs.color}
+                            show={fs.show}
+                            room={room}
+                            allRooms={rooms}
+                            index={idx}
+                          />
+                        ))}
+                        {displayMemo && (
+                          <div className="absolute top-0 left-0 right-0 z-[3] px-[2px]">
+                            <p
+                              className="my-0 whitespace-normal text-[0.75rem] leading-tight"
+                              style={{ color: `#${memoColor}` }}
+                            >
+                              {displayMemo}
+                            </p>
+                          </div>
                         )}
-                        {isDummy && (
+                        {img && (
+                          <div
+                            className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
+                            style={{
+                              width: img.width,
+                              height: img.height,
+                              backgroundImage: `url(${img.url})`,
+                              backgroundRepeat: "no-repeat",
+                              backgroundSize: "contain",
+                              opacity: room.isDead == null || room.isDead ? 0.2 : 0.7,
+                            }}
+                          />
+                        )}
+                        <div className="absolute bottom-0 left-1/2 -translate-x-1/2 whitespace-nowrap opacity-80">
                           <span className="bg-wm-base text-[11px]">
-                            <br />
-                            ダミー
+                            {String(room.roomNumber).padStart(2, "0")}{" "}
+                            {room.participantId != null
+                              ? (participants.find((p) => p.id === room.participantId)?.charaName
+                                  .shortName ?? "")
+                              : ""}
                           </span>
-                        )}
-                      </div>
-                    </td>
-                  );
-                })}
-              </tr>
-            ))}
-          </tbody>
-        </table>
+                          {room.isDead && (
+                            <span
+                              className="bg-wm-base text-[11px]"
+                              style={{ color: deadColor(room.deadReason?.code) ?? undefined }}
+                            >
+                              <br />
+                              {room.deadDay}d {deadMark(room.deadReason?.code)}
+                            </span>
+                          )}
+                          {isDummy && (
+                            <span className="bg-wm-base text-[11px]">
+                              <br />
+                              ダミー
+                            </span>
+                          )}
+                        </div>
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <FootstepGapLines
+            footsteps={footsteps}
+            rooms={rooms}
+            roomSize={roomSize}
+            cellW={cellW}
+            cellH={cellH}
+          />
+        </div>
       </div>
       <div className="mt-[4px]">
         <SimpleRoomMapCopyButton rows={rows} getMemo={getMemo} />

--- a/frontend/app/features/village/components/analyzer/FootstepGapLines.tsx
+++ b/frontend/app/features/village/components/analyzer/FootstepGapLines.tsx
@@ -7,10 +7,12 @@ import {
   parseFootstepRoomNumbers,
 } from "~/features/village/analyzer/footstepGaps";
 
-// FootstepLines の実線・破線と同じ index ごとのずらし量に合わせる
-function overlayOffset(index: number): number {
+// FootstepLines の実線・破線・ドットと同じ index ごとのずらし量に合わせる。
+// FootstepLines は縦線を x 方向、横線を y 方向に逆符号でずらすため、y は x の逆符号
+function overlayOffset(index: number): { x: number; y: number } {
   const half = Math.floor(index / 2);
-  return index % 2 === 0 ? 4 * half : -(4 * half + 4);
+  const x = index % 2 === 0 ? 4 * half : -(4 * half + 4);
+  return { x, y: -x };
 }
 
 // 鳴らなかった部屋（空き部屋・死亡者・防音者など）で途切れた足音経路の推定区間を、
@@ -48,7 +50,8 @@ export function FootstepGapLines({
       color,
       points: segment
         .map(
-          (cell) => `${cell.x * cellW + cellW / 2 + offset},${cell.y * cellH + cellH / 2 + offset}`,
+          (cell) =>
+            `${cell.x * cellW + cellW / 2 + offset.x},${cell.y * cellH + cellH / 2 + offset.y}`,
         )
         .join(" "),
     }));

--- a/frontend/app/features/village/components/analyzer/FootstepGapLines.tsx
+++ b/frontend/app/features/village/components/analyzer/FootstepGapLines.tsx
@@ -1,0 +1,78 @@
+import { useMemo } from "react";
+
+import type { AnalyzerDayRoom } from "~/features/village/analyzer/analyzerApi";
+import type { DayFootstep } from "~/features/village/analyzer/types";
+import {
+  interpolateFootstepGapSegments,
+  parseFootstepRoomNumbers,
+} from "~/features/village/analyzer/footstepGaps";
+
+// FootstepLines の実線・破線と同じ index ごとのずらし量に合わせる
+function overlayOffset(index: number): number {
+  const half = Math.floor(index / 2);
+  return index % 2 === 0 ? 4 * half : -(4 * half + 4);
+}
+
+// 鳴らなかった部屋（空き部屋・死亡者・防音者など）で途切れた足音経路の推定区間を、
+// 部屋割テーブルに重ねて描く。防音者の可能性があり推測にすぎないため、
+// 鳴った部屋同士を繋ぐ実線・破線とは区別できる半透明の細かい点線にする
+export function FootstepGapLines({
+  footsteps,
+  rooms,
+  roomSize,
+  cellW,
+  cellH,
+}: {
+  footsteps: DayFootstep[];
+  rooms: AnalyzerDayRoom[];
+  roomSize: { width: number; height: number };
+  cellW: number;
+  cellH: number;
+}) {
+  const roomMap = useMemo(() => {
+    const map = new Map<number, AnalyzerDayRoom>();
+    for (const r of rooms) map.set(r.roomNumber, r);
+    return map;
+  }, [rooms]);
+
+  const polylines = footsteps.flatMap((fs, index) => {
+    if (!fs.show) return [];
+    const audibleCells = parseFootstepRoomNumbers(fs.footstep)
+      .map((rn) => roomMap.get(rn))
+      .filter((r) => r != null)
+      .map((r) => ({ x: r.x, y: r.y }));
+    const offset = overlayOffset(index);
+    const color = fs.color.startsWith("#") ? fs.color : `#${fs.color}`;
+    return interpolateFootstepGapSegments(audibleCells).map((segment, segmentIndex) => ({
+      key: `${index}-${segmentIndex}`,
+      color,
+      points: segment
+        .map(
+          (cell) => `${cell.x * cellW + cellW / 2 + offset},${cell.y * cellH + cellH / 2 + offset}`,
+        )
+        .join(" "),
+    }));
+  });
+
+  if (polylines.length === 0) return null;
+
+  return (
+    <svg
+      className="pointer-events-none absolute inset-0 z-[6]"
+      width={roomSize.width * cellW}
+      height={roomSize.height * cellH}
+    >
+      {polylines.map((p) => (
+        <polyline
+          key={p.key}
+          points={p.points}
+          fill="none"
+          stroke={p.color}
+          strokeWidth={1.5}
+          strokeDasharray="3 4"
+          opacity={0.6}
+        />
+      ))}
+    </svg>
+  );
+}

--- a/frontend/app/features/village/components/analyzer/FootstepLines.tsx
+++ b/frontend/app/features/village/components/analyzer/FootstepLines.tsx
@@ -1,13 +1,7 @@
 import { useMemo } from "react";
 
 import type { AnalyzerDayRoom } from "~/features/village/analyzer/analyzerApi";
-
-function parseRoomNumbers(footstep: string): number[] {
-  return footstep
-    .split(",")
-    .map((s) => Number.parseInt(s.trim(), 10))
-    .filter((n) => !Number.isNaN(n));
-}
+import { parseFootstepRoomNumbers } from "~/features/village/analyzer/footstepGaps";
 
 function lineStyle(
   direction: "up" | "right" | "down" | "left" | "dot",
@@ -107,7 +101,7 @@ export function FootstepLines({
 
   if (!show) return null;
 
-  const roomNumbers = parseRoomNumbers(footstep);
+  const roomNumbers = parseFootstepRoomNumbers(footstep);
   if (!roomNumbers.includes(room.roomNumber)) return null;
 
   const pathRooms = roomNumbers.map((rn) => roomMap.get(rn)).filter(Boolean) as AnalyzerDayRoom[];


### PR DESCRIPTION
closes .issues/enhance-analyzer-footstep-gap-interpolation.md

## 概要

推理補助の部屋割グリッドの足音表示で、空き部屋・死亡者・防音者などで足音が鳴らず経路が途切れて見える問題を、推定経路の補完表示で解消する。

## 実装

- `footstepGaps.ts`: 鳴った部屋の集合（部屋番号昇順で経路順は失われている）から、backend の経路仕様（縦横移動のみ・曲がり最大1回の直線/L字）に基づいて経路を幾何的に復元し、鳴った部屋同士の間で欠けているセル列（gap 区間）を求める純関数
  - L字の角が複数通りあり得る場合（対角2部屋など）は候補をすべて返す
  - 直線/L字で説明できない並び（T字等、実データでは発生しない）は補完しない
- `FootstepGapLines.tsx`: gap 区間をテーブルに重ねた SVG ポリライン（同色・透過60%・1.5px・細点線）で描画。既存の実線（2px）・破線と一目で区別でき、推測であることが分かる表現（ユーザー合意済み）
- 既存のセル内描画（実線・破線・単一ドット）は不変更。複数足音は既存と同じ index ごとのオフセットでずらして重なりを回避

## 動作確認

- ロジック単体: 直線 gap / L字 leg 内 gap / 角欠け / 対角（両候補）/ 隣接・単一（補完なし）/ T字（補完なし）の12ケースを Node で確認
- 実画面: 村3に検証用足音を投入し、5日目の推理補助タブで以下を確認（検証データは削除済み）
  - 直線 gap（02,04 → 03 を点線補完）
  - 対角の両候補表示（02,08 → 07 経由・03 経由の2本）
  - L字の曲がりを含む gap（04,09,14,17 → 14→19→18→17 を補完）
  - 途切れのない足音・単一ドットの見た目が不変であること
  - 複数足音同時表示でオフセットにより破綻しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAzWW9S6uojU7btEcXckeR