### PR TITLE
chore: e2e の実行時間短縮とフレーキー解消

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/request/VillageSettingForm.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/request/VillageSettingForm.kt
@@ -188,8 +188,9 @@ data class VillageSettingForm(
                 CDef.Camp.恋人陣営,
                 CDef.Camp.愉快犯陣営,
             ).mapNotNull { cdefCamp ->
-                // 通常編成の村は陣営配分を持たないことがある。無い陣営は返さず、
-                // frontend 側のデフォルト値補完に任せる
+                // 陣営配分は通常編成でも保存される前提だが、REST 作成経路の初期化漏れ
+                // (form.initialize() 未呼び出し) の期間に配分なしで作られた村が存在する。
+                // 無い陣営は返さず、frontend 側のデフォルト値補完に任せる
                 val campAllocation =
                     village.setting.organize.randomOrganization.campAllocation
                         .firstOrNull { it.camp.code == cdefCamp.code() }

--- a/backend/src/main/kotlin/com/ort/app/api/request/VillageSettingForm.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/request/VillageSettingForm.kt
@@ -187,10 +187,13 @@ data class VillageSettingForm(
                 CDef.Camp.狐陣営,
                 CDef.Camp.恋人陣営,
                 CDef.Camp.愉快犯陣営,
-            ).map { cdefCamp ->
+            ).mapNotNull { cdefCamp ->
+                // 通常編成の村は陣営配分を持たないことがある。無い陣営は返さず、
+                // frontend 側のデフォルト値補完に任せる
                 val campAllocation =
                     village.setting.organize.randomOrganization.campAllocation
-                        .first { it.camp.code == cdefCamp.code() }
+                        .firstOrNull { it.camp.code == cdefCamp.code() }
+                        ?: return@mapNotNull null
                 RandomOrganizationCampForm(
                     campCode = campAllocation.camp.code,
                     campName = campAllocation.camp.name,

--- a/backend/src/main/kotlin/com/ort/app/api/village/VillageRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/VillageRestController.kt
@@ -227,6 +227,9 @@ class VillageRestController(
         if (codeErrors.isNotEmpty()) throw WolfMansionValidationException(codeErrors)
 
         val form = request.toForm(dummyCharaImage)
+        // 未指定項目に SSR と同じデフォルトを補完する。特に陣営・役職配分は
+        // 通常編成でも保存される前提のデータなので、初期化しないと設定変更画面が壊れる
+        form.initialize()
         val errors = BeanPropertyBindingResult(form, "villageForm")
         newVillageFormValidator.validate(form, errors)
         if (errors.hasErrors()) {

--- a/backend/src/main/kotlin/com/ort/app/application/service/DebugVillageService.kt
+++ b/backend/src/main/kotlin/com/ort/app/application/service/DebugVillageService.kt
@@ -4,8 +4,11 @@ import com.ort.app.application.coordinator.DaychangeCoordinator
 import com.ort.app.application.coordinator.VillageCoordinator
 import com.ort.app.domain.model.skill.Skills
 import com.ort.app.fw.exception.WolfMansionBusinessException
+import com.ort.dbflute.cbean.PlayerCB
 import com.ort.dbflute.cbean.VillageDayCB
+import com.ort.dbflute.exbhv.PlayerBhv
 import com.ort.dbflute.exbhv.VillageDayBhv
+import com.ort.dbflute.exentity.Player
 import com.ort.dbflute.exentity.VillageDay
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
@@ -17,12 +20,18 @@ import java.time.LocalDateTime
 @Service
 class DebugVillageService(
     private val villageDayBhv: VillageDayBhv,
+    private val playerBhv: PlayerBhv,
     private val villageService: VillageService,
     private val playerService: PlayerService,
     private val charaService: CharaService,
     private val daychangeCoordinator: DaychangeCoordinator,
     private val villageCoordinator: VillageCoordinator,
 ) {
+    companion object {
+        // ローカル開発 DB のテストアカウント (testuser01〜16)
+        private val TEST_PLAYER_IDS = (2..17).toList()
+    }
+
     fun allParticipate(
         villageId: Int,
         personNumber: Int,
@@ -38,8 +47,18 @@ class DebugVillageService(
             charas.list
                 .filterNot { c -> village.participants.list.any { it.charaId == c.id } }
                 .take(personNumber)
-        for (i in charaList.indices) {
-            val playerId = i + 2
+        // 放置村の突然死ペナルティで参加制限が付いたテストアカウントがいると
+        // 村を用意できなくなるため、デバッグ用途では制限を解除してから参加させる
+        unrestrictTestPlayers()
+        val players =
+            TEST_PLAYER_IDS
+                .map { playerService.findPlayer(it) }
+                .filter { it.isAvailableParticipateVillage(village.id) }
+                .take(charaList.size)
+        if (players.size < charaList.size) {
+            throw WolfMansionBusinessException("参加可能なテストアカウントが不足しています")
+        }
+        players.forEachIndexed { i, player ->
             val randomSkill =
                 Skills
                     .all()
@@ -52,7 +71,6 @@ class DebugVillageService(
                     .list
                     .shuffled()
                     .first()
-            val player = playerService.findPlayer(playerId)
             villageCoordinator.participate(
                 village = village,
                 player = player,
@@ -67,6 +85,15 @@ class DebugVillageService(
                 isSpectator = false,
                 ipAddress = "test account $i",
             )
+        }
+    }
+
+    private fun unrestrictTestPlayers() {
+        val entity = Player()
+        entity.setIsRestrictedParticipation(false)
+        playerBhv.queryUpdate(entity) { cb: PlayerCB ->
+            cb.query().setPlayerId_InScope(TEST_PLAYER_IDS)
+            cb.query().setIsRestrictedParticipation_Equal(true)
         }
     }
 

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -12,5 +12,6 @@
 # ローカル実行ログ (動作確認用、git 管理外)
 /.logs/
 
-# globalSetup で生成する村プロビジョニングキャッシュ
+# globalSetup で生成する村プロビジョニングキャッシュ / 作成村の記録
 /tests/.provision-cache.json
+/tests/.provision-created.ndjson

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -24,9 +24,15 @@ export default defineConfig({
   testDir: "./tests",
   // テストは独立データ前提なので並列で良い (05-e2e.md)
   fullyParallel: true,
+  // デフォルト (コア数の半分) だと 2 コア環境で 1 worker = 直列になる。
+  // e2e は大半が HTTP 待ちなので、コア数が少なくても 2 worker で有意に短縮できる
+  workers: 2,
   forbidOnly: isCI,
   retries: 1,
   reporter: "html",
+  // 共有 2 コアに backend/frontend/MySQL/ブラウザが同居するため、負荷スパイク時の
+  // 描画遅延をフレーク扱いしないよう expect のデフォルト (5s) を延ばす
+  expect: { timeout: 10_000 },
   use: {
     baseURL: BASE_URL,
     // 失敗時のみ artifacts を残す (05-e2e.md)。video は取らない。
@@ -38,6 +44,11 @@ export default defineConfig({
     {
       name: "setup",
       testMatch: /global\.setup\.ts/,
+      teardown: "cleanup",
+    },
+    {
+      name: "cleanup",
+      testMatch: /global\.teardown\.ts/,
     },
     {
       name: "chromium",

--- a/e2e/tests/global.setup.ts
+++ b/e2e/tests/global.setup.ts
@@ -3,11 +3,10 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
-  findVillages,
   provisionInProgressVillage,
   provisionRecruitingVillage,
+  provisionVotingVillage,
   type ProvisionCache,
-  type SimpleVillage,
 } from "./helpers/provision";
 
 const CACHE_PATH = path.join(
@@ -15,25 +14,18 @@ const CACHE_PATH = path.join(
   ".provision-cache.json",
 );
 
+// 共有村はこの実行専用に必ず新規作成する。DB にたまたまある村を拾うと、
+// 開始時刻超過・日数進行・master 不参加など前提の崩れた村に当たってフレークする
 setup("provision shared villages", async ({ page }) => {
   setup.setTimeout(180000);
 
-  let inProgress: SimpleVillage;
-  const existing = await findVillages(page, ["IN_PROGRESS"]);
-  if (existing.length > 0) {
-    inProgress = existing[0];
-  } else {
-    inProgress = await provisionInProgressVillage(page);
-  }
+  // 過去の実行の古いキャッシュを specs に読ませないよう、provision 前に消しておく
+  fs.rmSync(CACHE_PATH, { force: true });
 
-  let recruiting: SimpleVillage;
-  const existingPrep = await findVillages(page, ["IN_PREPARATION"]);
-  if (existingPrep.length > 0) {
-    recruiting = existingPrep[0];
-  } else {
-    recruiting = await provisionRecruitingVillage(page);
-  }
+  const inProgress = await provisionInProgressVillage(page);
+  const voting = await provisionVotingVillage(page);
+  const recruiting = await provisionRecruitingVillage(page);
 
-  const cache: ProvisionCache = { inProgress, recruiting };
+  const cache: ProvisionCache = { inProgress, recruiting, voting };
   fs.writeFileSync(CACHE_PATH, JSON.stringify(cache));
 });

--- a/e2e/tests/global.teardown.ts
+++ b/e2e/tests/global.teardown.ts
@@ -5,7 +5,8 @@ import { clearCreatedVillages, readCreatedVillages, settleVillage } from "./help
 // 日付更新スケジューラに日送りされてテストアカウントが突然死ペナルティを受けたり、
 // 村一覧を汚したりするため
 teardown("settle provisioned villages", async ({ page }) => {
-  teardown.setTimeout(180000);
+  // 全村を直列に settle するため、村数が多い実行 (前回残骸の回収時など) に備えて長めにとる
+  teardown.setTimeout(300000);
 
   for (const village of readCreatedVillages()) {
     try {

--- a/e2e/tests/global.teardown.ts
+++ b/e2e/tests/global.teardown.ts
@@ -1,0 +1,18 @@
+import { test as teardown } from "@playwright/test";
+import { clearCreatedVillages, readCreatedVillages, settleVillage } from "./helpers/provision";
+
+// この実行で作成した村を終了状態に片付ける。進行中の村を残すと、開発サーバー側の
+// 日付更新スケジューラに日送りされてテストアカウントが突然死ペナルティを受けたり、
+// 村一覧を汚したりするため
+teardown("settle provisioned villages", async ({ page }) => {
+  teardown.setTimeout(180000);
+
+  for (const village of readCreatedVillages()) {
+    try {
+      await settleVillage(page, village.id);
+    } catch {
+      // 片付けは best effort でよい。失敗しても次回実行は新しい村を作るため影響しない
+    }
+  }
+  clearCreatedVillages();
+});

--- a/e2e/tests/helpers/provision.ts
+++ b/e2e/tests/helpers/provision.ts
@@ -94,8 +94,10 @@ const DEFAULT_ORGANIZATION = [
   "村狼狼狼狼魔狐賢導狩霊霊霊霊霊霊霊霊共共",
 ].join("\n");
 
-// このプロセスが作成した村の記録 (global.teardown が廃村して後片付けする)。
-// 並列 worker からの追記が混ざっても壊れないよう 1 行 1 村の NDJSON で追記する
+// 作成した村の記録 (global.teardown が決着させて後片付けする)。
+// 並列 worker からの追記が混ざっても壊れないよう 1 行 1 村の NDJSON で追記する。
+// 意図的に実行を跨いで残す: 前回の teardown が中断などで走らなかった場合、
+// 次回の teardown が残骸の村も片付ける (決着済みの村の settle は即 return の no-op)
 const CREATED_PATH = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
   "../.provision-created.ndjson",

--- a/e2e/tests/helpers/provision.ts
+++ b/e2e/tests/helpers/provision.ts
@@ -94,6 +94,54 @@ const DEFAULT_ORGANIZATION = [
   "村狼狼狼狼魔狐賢導狩霊霊霊霊霊霊霊霊共共",
 ].join("\n");
 
+// このプロセスが作成した村の記録 (global.teardown が廃村して後片付けする)。
+// 並列 worker からの追記が混ざっても壊れないよう 1 行 1 村の NDJSON で追記する
+const CREATED_PATH = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../.provision-created.ndjson",
+);
+
+function recordCreatedVillage(village: SimpleVillage): void {
+  fs.appendFileSync(CREATED_PATH, `${JSON.stringify(village)}\n`);
+}
+
+export function readCreatedVillages(): SimpleVillage[] {
+  try {
+    return fs
+      .readFileSync(CREATED_PATH, "utf-8")
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+  } catch {
+    return [];
+  }
+}
+
+export function clearCreatedVillages(): void {
+  fs.rmSync(CREATED_PATH, { force: true });
+}
+
+/**
+ * 村を終了状態に片付ける。廃村はプロローグ中しかできないため、
+ * 進行中・エピローグの村は debug の日送りで決着させる。
+ */
+export async function settleVillage(page: Page, villageId: number): Promise<void> {
+  await loginApi(page, "master");
+  for (let i = 0; i < 10; i++) {
+    const village = await fetchVillage(page, villageId);
+    const code: string = village.status?.code ?? "";
+    if (code === "IN_PREPARATION" || code === "WAITING") {
+      await page.request.post(`${API}/villages/${villageId}/creator/cancel`);
+      return;
+    }
+    if (code === "IN_PROGRESS" || code === "EPILOGUE") {
+      await page.request.post(`${API}/villages/${villageId}/debug/day-change`);
+      continue;
+    }
+    return;
+  }
+}
+
 async function createVillageApi(page: Page): Promise<SimpleVillage> {
   await loginApi(page, "master");
 
@@ -123,7 +171,11 @@ async function createVillageApi(page: Page): Promise<SimpleVillage> {
     availableSameWolfAttack: false,
     availableGuardSameTarget: false,
     reincarnationSkillAll: false,
-    availableSuddonlyDeath: true,
+    // 突然死ありにすると、片付け損ねた村の日送りでテストユーザーが突然死して
+    // 参加制限ペナルティを受け、以降の村プロビジョニングを壊す。
+    // 突然死なしの村は日付更新時に全生存者へ自投票が自動セットされるため、
+    // 投票系スペックの前提 (投票済み参加者の存在) はむしろ決定的になる
+    availableSuddonlyDeath: false,
     availableCommit: true,
     availableSpectate: true,
     creatorIsProducer: false,
@@ -152,7 +204,9 @@ async function createVillageApi(page: Page): Promise<SimpleVillage> {
     throw new Error(`Village creation failed: ${res.status()} ${body}`);
   }
   const id = ((await res.json()) as { id: number }).id;
-  return { id, name: villageName };
+  const village = { id, name: villageName };
+  recordCreatedVillage(village);
+  return village;
 }
 
 async function debugFillParticipants(
@@ -187,11 +241,27 @@ export async function provisionRecruitingVillage(
   return createVillageApi(page);
 }
 
+/**
+ * 進行中の村 (1日目) を作る。ダミーキャラは master (player_id=1) 名義で参加する
+ * 仕様のため、作成した村では master が最初からダミーとして参加者になっており、
+ * 村建て発言・独り言・村管理などの master 前提スペックがそのまま動く。
+ */
 export async function provisionInProgressVillage(
   page: Page,
 ): Promise<SimpleVillage> {
   const village = await createVillageApi(page);
   await debugFillParticipants(page, village.id, 7);
+  await debugForceDayChange(page, village.id);
+  return village;
+}
+
+/**
+ * 投票可能な村 (2日目) を作る。投票は2日目からのため、1日目の村では投票系の
+ * テストができない。突然死なし村は日付更新時に全生存者へ自投票が自動セット
+ * されるため、この村には「投票済みの参加者」が必ず存在する。
+ */
+export async function provisionVotingVillage(page: Page): Promise<SimpleVillage> {
+  const village = await provisionInProgressVillage(page);
   await debugForceDayChange(page, village.id);
   return village;
 }
@@ -219,6 +289,7 @@ export async function provisionCompletedVillage(
 export type ProvisionCache = {
   inProgress: SimpleVillage;
   recruiting: SimpleVillage;
+  voting: SimpleVillage;
 };
 
 const CACHE_PATH = path.join(
@@ -234,6 +305,11 @@ function readCache(): ProvisionCache | null {
   }
 }
 
+/**
+ * 状態に合う村を返す。募集中・進行中は「DB にたまたまある村」を拾わず、
+ * global.setup がこの実行用に作った村 (キャッシュ) を使う。
+ * 終了系 (EPILOGUE/COMPLETED/CANCEL) は状態が変わらないため既存村を再利用してよい。
+ */
 export async function ensureVillagesExist(
   page: Page,
   statuses: string[],
@@ -246,63 +322,42 @@ export async function ensureVillagesExist(
   if (statuses.includes("IN_PREPARATION") && cache?.recruiting) {
     return [cache.recruiting];
   }
-
-  const existing = await findVillages(page, statuses);
-  if (existing.length > 0) return existing;
-
   if (statuses.includes("IN_PREPARATION")) {
     return [await provisionRecruitingVillage(page)];
   }
   if (statuses.includes("IN_PROGRESS")) {
     return [await provisionInProgressVillage(page)];
   }
-  if (
-    statuses.some((s) => ["EPILOGUE", "COMPLETED", "CANCEL"].includes(s))
-  ) {
+  if (statuses.some((s) => ["EPILOGUE", "COMPLETED", "CANCEL"].includes(s))) {
+    const existing = await findVillages(page, statuses);
+    if (existing.length > 0) return existing;
     return [await provisionCompletedVillage(page)];
   }
 
   return [];
 }
 
-/** master が参加している IN_PROGRESS 村を返す。 */
+/** master が参加している IN_PROGRESS 村を返す (provision した村は master がダミーとして参加している)。 */
 export async function ensureMasterInProgressVillage(
   page: Page,
 ): Promise<SimpleVillage> {
   const cache = readCache();
   if (cache?.inProgress) return cache.inProgress;
-
-  const villages = await findVillages(page, ["IN_PROGRESS"]);
-  await loginApi(page, "master");
-  for (const v of villages) {
-    const res = await page.request.get(
-      `${API}/villages/${v.id}/situation/me`,
-    );
-    if (!res.ok()) continue;
-    const body = (await res.json()) as { myself: unknown };
-    if (body.myself != null) return v;
-  }
   return provisionInProgressVillage(page);
 }
 
-/** master が村建てした募集中の村を返す。 */
+/** master が村建てした募集中の村を返す (provision した村は master が村建てしている)。 */
 export async function ensureMasterRecruitingVillage(
   page: Page,
 ): Promise<SimpleVillage> {
   const cache = readCache();
   if (cache?.recruiting) return cache.recruiting;
-
-  const villages = await findVillages(page, ["IN_PREPARATION"]);
-  await loginApi(page, "master");
-  for (const v of villages) {
-    const res = await page.request.get(
-      `${API}/villages/${v.id}/situation/me`,
-    );
-    if (!res.ok()) continue;
-    const body = (await res.json()) as {
-      creator: { isAvailableModifySetting: boolean };
-    };
-    if (body.creator?.isAvailableModifySetting) return v;
-  }
   return provisionRecruitingVillage(page);
+}
+
+/** 投票可能な (2日目の) IN_PROGRESS 村を返す。 */
+export async function ensureVotingVillage(page: Page): Promise<SimpleVillage> {
+  const cache = readCache();
+  if (cache?.voting) return cache.voting;
+  return provisionVotingVillage(page);
 }

--- a/e2e/tests/village-ability.spec.ts
+++ b/e2e/tests/village-ability.spec.ts
@@ -1,18 +1,16 @@
 import { expect, test, type Page } from "@playwright/test";
 import {
-  findVillages,
+  ensureVillagesExist,
   loginApi,
   dismissInitialSkillModal,
-  provisionInProgressVillage,
   CANDIDATE_USERS,
   type SimpleVillage,
 } from "./helpers/provision";
 
 /**
- * 役職能力セットの e2e。能力を使える参加者が必要なため、進行中の村と
- * ローカル開発 DB のテストユーザー (testuser01〜16 / password=testuser) を
- * 走査して能力者を動的に探す。見つからなければ村を作成して再走査する。
- * セットは現在値の再セットに留め、共有 DB の進行状態を変えない。
+ * 役職能力セットの e2e。この実行用に provision された進行中の村を対象に、
+ * テストユーザー (testuser01〜16 / password=testuser) を走査して能力者を探す。
+ * セットは現在値の再セットに留め、村の進行状態を変えない。
  */
 
 type AbilityView = {
@@ -52,11 +50,8 @@ async function findAbilityCandidate(
   page: Page,
   filter: (ability: AbilityView) => boolean,
 ): Promise<Candidate | null> {
-  const existing = await findVillages(page, ["IN_PROGRESS"]);
-  const result = await scanAbilityCandidate(page, existing, filter);
-  if (result) return result;
-  const provisioned = await provisionInProgressVillage(page);
-  return scanAbilityCandidate(page, [provisioned], filter);
+  const villages = await ensureVillagesExist(page, ["IN_PROGRESS"]);
+  return scanAbilityCandidate(page, villages, filter);
 }
 
 test("能力者で村画面を開くと役職パネルが表示される", async ({ page }) => {

--- a/e2e/tests/village-commit.spec.ts
+++ b/e2e/tests/village-commit.spec.ts
@@ -1,17 +1,15 @@
 import { expect, test, type Page } from "@playwright/test";
 import {
-  findVillages,
+  ensureVillagesExist,
   loginApi,
-  provisionInProgressVillage,
   CANDIDATE_USERS,
   type SimpleVillage,
 } from "./helpers/provision";
 
 /**
- * コミットの e2e。コミット可の村の参加者が必要なため、進行中の村と
- * ローカル開発 DB のテストユーザー (testuser01〜16 / password=testuser) を
- * 走査して動的に探す。見つからなければ村を作成して再走査する。
- * ON → OFF と元に戻して終わるため共有 DB の進行状態を変えない
+ * コミットの e2e。この実行用に provision された進行中の村を対象に、
+ * テストユーザー (testuser01〜16 / password=testuser) を走査して
+ * コミット可能な参加者を探す。ON → OFF と元に戻して終わる
  * (未コミットの参加者を選ぶので、自分のコミットで全員コミットが成立して
  * 日付更新が走ることもない)。
  */
@@ -41,11 +39,8 @@ async function scanCommitCandidate(
 }
 
 async function findCommitCandidate(page: Page): Promise<Candidate | null> {
-  const existing = await findVillages(page, ["IN_PROGRESS"]);
-  const result = await scanCommitCandidate(page, existing);
-  if (result) return result;
-  const provisioned = await provisionInProgressVillage(page);
-  return scanCommitCandidate(page, [provisioned]);
+  const villages = await ensureVillagesExist(page, ["IN_PROGRESS"]);
+  return scanCommitCandidate(page, villages);
 }
 
 test("コミット可の村でコミット ON → OFF を切り替えられる", async ({ page }) => {

--- a/e2e/tests/village-participate.spec.ts
+++ b/e2e/tests/village-participate.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "@playwright/test";
-import { ensureVillagesExist, uniqueUserId } from "./helpers/provision";
+import {
+  ensureVillagesExist,
+  provisionRecruitingVillage,
+  uniqueUserId,
+} from "./helpers/provision";
 
 /**
  * 村画面の入村フォーム e2e。新規ユーザーで確認画面 (サーバ検証 204) まで進み、
@@ -43,8 +47,8 @@ test("入村: キャラ選択 → 確認画面 (同意チェックで活性化) 
 });
 
 test("入村 → 役職希望変更 → 退村の自己完結フロー", async ({ page }) => {
-  const villages = await ensureVillagesExist(page, ["IN_PREPARATION"]);
-  const village = villages[villages.length - 1];
+  // 入退村で参加者数を変えるため、共有村ではなくこのテスト専用の村を作る
+  const village = await provisionRecruitingVillage(page);
 
   await page.goto("signup");
   await page.waitForLoadState("networkidle");

--- a/e2e/tests/village-rp.spec.ts
+++ b/e2e/tests/village-rp.spec.ts
@@ -1,18 +1,16 @@
 import { expect, test, type Page } from "@playwright/test";
 import {
-  findVillages,
+  ensureVillagesExist,
   loginApi,
   dismissInitialSkillModal,
   dismissAgeLimitModal,
-  provisionInProgressVillage,
   CANDIDATE_USERS,
   type SimpleVillage,
 } from "./helpers/provision";
 
 /**
- * RP 支援 (名前変更・簡易メモ) の e2e。進行中の村の参加者を
- * ローカル開発 DB のテストユーザー (testuser01〜16 / password=testuser) から
- * 動的に探す。見つからなければ村を作成して再走査する。
+ * RP 支援 (名前変更・簡易メモ) の e2e。この実行用に provision された進行中の村を
+ * 対象に、テストユーザー (testuser01〜16 / password=testuser) から参加者を探す。
  * 変更後は元の値に戻して終わるため共有 DB の進行状態を変えない。
  */
 
@@ -58,11 +56,8 @@ async function findRpCandidate(
   page: Page,
   filter: (rpFlags: RpFlags, myself: Myself) => boolean,
 ): Promise<Candidate | null> {
-  const existing = await findVillages(page, ["IN_PROGRESS"]);
-  const result = await scanRpCandidate(page, existing, filter);
-  if (result) return result;
-  const provisioned = await provisionInProgressVillage(page);
-  return scanRpCandidate(page, [provisioned], filter);
+  const villages = await ensureVillagesExist(page, ["IN_PROGRESS"]);
+  return scanRpCandidate(page, villages, filter);
 }
 
 test("簡易メモを変更すると参加者一覧に表示される (元に戻す)", async ({ page }) => {

--- a/e2e/tests/village-settings-update.spec.ts
+++ b/e2e/tests/village-settings-update.spec.ts
@@ -1,33 +1,19 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import {
   ensureVillagesExist,
-  findVillages,
   loginApi,
-  type SimpleVillage,
+  provisionRecruitingVillage,
 } from "./helpers/provision";
 
 /**
  * 村設定変更 (`/village/{id}/settings`、村主のみ) の e2e。
- * master が村建てした募集中の村を動的に探し、村名を変更して保存 → 元に戻す。
+ * master 村建ての村を provision して使う (既存村頼みだと編集可能な村が無く落ち続ける)。
  */
 
-/** master が設定変更できる募集中の村を返す（creator/setting が正常に返る村を選ぶ）。 */
-async function findEditableVillage(page: Page): Promise<SimpleVillage | null> {
-  await loginApi(page, "master");
-  const villages = await findVillages(page, ["IN_PREPARATION"]);
-  for (const village of villages) {
-    const res = await page.request.get(
-      `/wolf-mansion-api/api/v1/villages/${village.id}/creator/setting`,
-    );
-    if (res.ok()) return village;
-  }
-  return null;
-}
-
 test("村設定変更: 村名を変更して保存し、元に戻す", async ({ page }) => {
-  const village = await findEditableVillage(page);
-  expect(village, "master が設定変更できる募集中の村が無い").not.toBeNull();
-  if (village == null) return;
+  // 村名を変更するため、共有村ではなくこのテスト専用の村を作る (master 村建て = 設定変更可)
+  const village = await provisionRecruitingVillage(page);
+  await loginApi(page, "master");
 
   await page.goto(`village/${village.id}/settings`);
   const nameInput = page.getByLabel("村名");

--- a/e2e/tests/village-vote.spec.ts
+++ b/e2e/tests/village-vote.spec.ts
@@ -1,19 +1,17 @@
 import { expect, test, type Page } from "@playwright/test";
 import {
-  findVillages,
+  ensureVotingVillage,
   loginApi,
   fetchVillage,
   dismissInitialSkillModal,
-  provisionInProgressVillage,
   CANDIDATE_USERS,
   type SimpleVillage,
 } from "./helpers/provision";
 
 /**
- * 投票セットの e2e。投票できる参加者が必要なため、進行中の村と
- * ローカル開発 DB のテストユーザー (testuser01〜16 / password=testuser) を
- * 走査して投票可能者を動的に探す。見つからなければ村を作成して再走査する。
- * 元の投票先に戻して終わるため共有 DB の進行状態を変えない。
+ * 投票セットの e2e。投票は2日目からのため、この実行用に provision された
+ * 投票可能な (2日目の) 村を対象に、テストユーザー (testuser01〜16 /
+ * password=testuser) を走査して投票可能者を探す。元の投票先に戻して終わる。
  */
 
 type VoteView = {
@@ -66,11 +64,8 @@ async function findVoteCandidate(
   page: Page,
   filter: (vote: VoteView) => boolean,
 ): Promise<Candidate | null> {
-  const existing = await findVillages(page, ["IN_PROGRESS"]);
-  const result = await scanVoteCandidate(page, existing, filter);
-  if (result) return result;
-  const provisioned = await provisionInProgressVillage(page);
-  return scanVoteCandidate(page, [provisioned], filter);
+  const village = await ensureVotingVillage(page);
+  return scanVoteCandidate(page, [village], filter);
 }
 
 /** 投票可能な参加者を探し、投票をセットして返す。 */
@@ -78,28 +73,27 @@ async function findVotedCandidate(page: Page): Promise<Candidate | null> {
   const simpleFilter = (vote: VoteView) =>
     vote.targetCharaId != null && vote.targetCharaIds.length >= 2;
 
-  const existing = await findVillages(page, ["IN_PROGRESS"]);
-  const result = await scanVoteCandidate(page, existing, simpleFilter);
+  const village = await ensureVotingVillage(page);
+  const result = await scanVoteCandidate(page, [village], simpleFilter);
   if (result) return result;
 
-  const provisioned = await provisionInProgressVillage(page);
-  // provisioned 村で投票可能な参加者を探し、API で投票をセットする
-  const unvoted = await scanVoteCandidate(page, [provisioned], (vote) =>
+  // まだ誰も投票していなければ、投票可能な参加者に API で投票をセットする
+  const unvoted = await scanVoteCandidate(page, [village], (vote) =>
     vote.canVote && vote.targetCharaIds.length >= 2,
   );
   if (!unvoted) return null;
 
   const targetCharaId = unvoted.vote.targetCharaIds[0];
-  const voteRes = await page.request.post(`${API}/villages/${provisioned.id}/vote`, {
+  const voteRes = await page.request.post(`${API}/villages/${unvoted.villageId}/vote`, {
     data: { targetCharaId },
   });
   if (!voteRes.ok()) return null;
 
-  const meRes = await page.request.get(`${API}/villages/${provisioned.id}/situation/me`);
+  const meRes = await page.request.get(`${API}/villages/${unvoted.villageId}/situation/me`);
   if (!meRes.ok()) return null;
   const updated = (await meRes.json()) as { vote: VoteView };
   return {
-    villageId: provisioned.id,
+    villageId: unvoted.villageId,
     userId: unvoted.userId,
     vote: updated.vote,
     village: unvoted.village,


### PR DESCRIPTION
closes .issues/chore-improve-e2e-speed-and-flakiness.md

## 問題

- フルスイート 85 件で 8〜9 分 + フレーク 4 件 (再実行で 3 件成功)
- `village-settings-update` が恒常的に失敗 (master が設定変更できる募集中の村が DB に無いと落ち続ける)
- 根本原因は **共有 DB の「たまたまある村」への依存**: 開始時刻超過・日数進行・master 不参加など前提の崩れた村を拾ってフレークしていた

## 対応

### 村の状態を偶然に任せず自分で作る

- `global.setup` は既存村を拾わず、実行ごとに専用の村を必ず provision する (進行中1日目 / 投票用2日目 / 募集中)。投票は2日目からのため投票用の村を分けた
- `global.teardown` (新設) で作成した村を決着状態に片付ける。廃村はプロローグ限定のため、進行中の村は debug の日送りで決着させる。作成村の記録は実行を跨いで残し、中断時の残骸も次回実行が回収する
- 村は**突然死なし**で建てる。放置村の日送りでテストユーザーが突然死ペナルティ (参加制限) を受け、以降の村プロビジョニングを壊すため。突然死なし村は日付更新時に全生存者へ自投票が自動セットされるため、投票系スペックの前提はむしろ決定的になる
- 破壊的なスペック (入退村・村設定変更) は共有村でなくテスト専用の村を作る
- vote/ability/commit/rp の候補走査も `findVillages` (DB 全体) でなく provision 済みの村に限定

### backend (debug 基盤と実バグの修正)

- **debug all-participate**: player_id 2〜8 固定だったのを、テストアカウント (2〜17) の参加制限をデバッグ用途として解除した上で参加可能なプレイヤーを動的に選ぶ方式に変更。実際にローカル DB で testuser01〜07 が参加制限状態になっており全滅していた
- **REST の村作成でデフォルト初期化が漏れていた実バグを修正**: レガシー SSR は `NewVillageForm.initialize()` で通常編成でも陣営・役職配分のデフォルトを保存していたが、REST 作成経路 (`VillageRestController.create`) では呼び出しが漏れており、配分なしの村が作られて村設定取得 API (`creator/setting`) が `.first{}` の NoSuchElementException で 500 になっていた
  - 根本修正: REST 作成経路に `form.initialize()` を追加 (camp_allocation 5行 + skill_allocation 123行が SSR と同様に保存されることを確認)
  - 互換: 初期化漏れ期間に作られた既存村のため、設定フォーム側は配分が無い陣営を返さない防御を追加 (frontend は欠けた陣営をデフォルト補完する実装のため表示は正常)

### 実行時間

- `workers: 2` を明示 (2コア環境では Playwright デフォルトが 1 worker = 直列だった)
- 負荷スパイク時の誤検知を防ぐため `expect.timeout` を 5s → 10s

## 動作確認

- フルスイート 86 件 (setup/cleanup 含む) を**4回連続で全パス** (フレーク 0、最終コードで1回 + 直前コードで3回)
- 実行時間: 6分40〜44秒で安定 (改善前: 7分55秒〜9分超 + フレーク切り分け再実行)
- `village-settings-update` 単独実行もパス (専用村を provision するため状態非依存)
- teardown 後の DB に実行残骸の進行中村が残らないことを確認
- REST 作成村に陣営・役職配分が保存され creator/setting が 200 を返すことを API + DB で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAzWW9S6uojU7btEcXckeR