### PR TITLE
enhance: 投票・役職の対象指定を部屋割から選択できるようにする

### DIFF
--- a/e2e/tests/village-ability.spec.ts
+++ b/e2e/tests/village-ability.spec.ts
@@ -88,7 +88,7 @@ test("人狼が現在の襲撃セットを再セットできる (共有 DB の�
   await expect(page.getByRole("button", { name: "能力セット" })).toBeVisible({ timeout: 15000 });
   await dismissInitialSkillModal(page);
 
-  const targetSelect = page.getByLabel("能力の対象");
+  const targetSelect = page.getByRole("combobox", { name: "能力の対象" });
   await expect(targetSelect).toHaveValue(String(candidate.ability.targetCharaId), {
     timeout: 15000,
   });

--- a/e2e/tests/village-vote.spec.ts
+++ b/e2e/tests/village-vote.spec.ts
@@ -20,7 +20,7 @@ type VoteView = {
   targetCharaId: number | null;
 };
 
-type Participant = { chara: { id: number }; name: string };
+type Participant = { id: number; chara: { id: number }; name: string };
 type VillageDetail = {
   participants: { list: Participant[] };
   spectators: { list: Participant[] };
@@ -138,13 +138,82 @@ test("投票先を変更してセットできる (元に戻して共有 DB の�
   await expect(page.getByRole("button", { name: "投票セット" })).toBeVisible({ timeout: 15000 });
   await dismissInitialSkillModal(page);
 
-  await page.getByLabel("投票先").selectOption(String(anotherCharaId));
+  await page.getByRole("combobox", { name: "投票先" }).selectOption(String(anotherCharaId));
   await page.getByRole("button", { name: "投票セット" }).click();
   await expect(page.getByText(`現在の投票先: ${anotherName}`)).toBeVisible({ timeout: 15000 });
 
-  await page.getByLabel("投票先").selectOption(String(original));
+  await page.getByRole("combobox", { name: "投票先" }).selectOption(String(original));
   await page.getByRole("button", { name: "投票セット" }).click();
   await expect(page.getByText(`現在の投票先: ${originalName}`)).toBeVisible({
     timeout: 15000,
   });
+});
+
+type RoomAssigned = {
+  participantId: number | null;
+  roomNumber: string;
+  charaShortName: string | null;
+};
+
+function roomCellLabel(room: RoomAssigned): string {
+  return `${room.roomNumber} ${room.charaShortName ?? ""}`;
+}
+
+test("部屋割から選択で投票先をセットできる (元に戻して共有 DB の状態を変えない)", async ({
+  page,
+}) => {
+  test.setTimeout(180000);
+  const candidate = await findVotedCandidate(page);
+  expect(candidate, "投票セット済みの参加者が見つからない").not.toBeNull();
+  if (candidate == null) return;
+
+  const original = candidate.vote.targetCharaId;
+  const anotherCharaId = candidate.vote.targetCharaIds.find((id) => id !== original);
+  expect(anotherCharaId).toBeTruthy();
+  if (anotherCharaId == null) return;
+
+  // 部屋割データから対象参加者の部屋セルのラベルを組み立てる
+  const situationRes = await page.request.get(
+    `${API}/villages/${candidate.villageId}/situation`,
+  );
+  expect(situationRes.ok()).toBeTruthy();
+  const situation = (await situationRes.json()) as {
+    roomAssignedRowList: { roomAssignedList: RoomAssigned[] }[] | null;
+  };
+  const rooms = (situation.roomAssignedRowList ?? []).flatMap((row) => row.roomAssignedList);
+  expect(rooms.length, "部屋割のある村でないと検証できない").toBeGreaterThan(0);
+
+  const charaIdOf = (room: RoomAssigned): number | null =>
+    candidate.village.participants.list.find((p) => p.id === room.participantId)?.chara.id ?? null;
+  const targetRoom = rooms.find((room) => charaIdOf(room) === anotherCharaId);
+  expect(targetRoom, "変更先参加者の部屋が見つからない").toBeTruthy();
+  if (targetRoom == null) return;
+  // 候補にいない参加者の部屋と空き部屋は選択不可でグレーアウトする
+  const disabledCount = rooms.filter((room) => {
+    const charaId = charaIdOf(room);
+    return charaId == null || !candidate.vote.targetCharaIds.includes(charaId);
+  }).length;
+
+  await page.goto(`village/${candidate.villageId}`);
+  await expect(page.getByRole("button", { name: "投票セット" })).toBeVisible({ timeout: 15000 });
+  await dismissInitialSkillModal(page);
+
+  await page.getByRole("button", { name: "部屋割から投票先を選択" }).click();
+  const dialog = page.getByRole("dialog", { name: "部屋割から選択" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.locator('td[aria-disabled="true"]')).toHaveCount(disabledCount);
+
+  await dialog.getByText(roomCellLabel(targetRoom), { exact: true }).click();
+  await expect(dialog).not.toBeVisible();
+  await expect(page.getByRole("combobox", { name: "投票先" })).toHaveValue(String(anotherCharaId));
+
+  await page.getByRole("button", { name: "投票セット" }).click();
+  const anotherName = resolveCharaName(candidate.village, anotherCharaId);
+  await expect(page.getByText(`現在の投票先: ${anotherName}`)).toBeVisible({ timeout: 15000 });
+
+  // 元に戻す
+  const restoreRes = await page.request.post(`${API}/villages/${candidate.villageId}/vote`, {
+    data: { targetCharaId: original },
+  });
+  expect(restoreRes.ok()).toBeTruthy();
 });

--- a/frontend/app/features/village/components/ActionPanels.tsx
+++ b/frontend/app/features/village/components/ActionPanels.tsx
@@ -88,7 +88,7 @@ export function ActionPanels({
       )}
 
       {isLatestDay && mySituation != null && mySituation.vote.canVote && (
-        <VotePanel mySituation={mySituation} />
+        <VotePanel mySituation={mySituation} roomAssignedRows={situation?.roomAssignedRowList} />
       )}
 
       {isLatestDay && mySituation != null && mySituation.myself?.skill != null && (

--- a/frontend/app/features/village/components/RoomGrid.tsx
+++ b/frontend/app/features/village/components/RoomGrid.tsx
@@ -1,0 +1,62 @@
+import type { VillageRoomAssigned, VillageRoomAssignedRow } from "~/features/village/api";
+
+/**
+ * 部屋セルをクリックして選択する用途の部屋割グリッド。
+ * 徘徊の対象部屋トグルや、部屋割からの対象者選択で共用する。
+ */
+export function RoomGrid({
+  rows,
+  isSelected = () => false,
+  isSelectable = () => true,
+  onRoomClick,
+}: {
+  rows: VillageRoomAssignedRow[];
+  isSelected?: (room: VillageRoomAssigned) => boolean;
+  /** false の部屋はグレーアウトしてクリック不可にする。 */
+  isSelectable?: (room: VillageRoomAssigned) => boolean;
+  onRoomClick: (room: VillageRoomAssigned) => void;
+}) {
+  return (
+    <table className="border-collapse border border-[#464545] text-village-sm">
+      <tbody>
+        {rows.map((row, rowIndex) => (
+          <tr key={rowIndex}>
+            {(row.roomAssignedList ?? []).map((room) => {
+              const selectable = isSelectable(room);
+              return (
+                <td
+                  key={room.roomNumber}
+                  className={`text-center align-bottom ${selectable ? "cursor-pointer" : "cursor-not-allowed"}`}
+                  aria-disabled={!selectable}
+                  style={{
+                    border: isSelected(room) ? "2px solid #0ce3ac" : "1px solid #464545",
+                    width: room.charaImgWidth ?? 50,
+                    height: room.charaImgHeight ?? 60,
+                    ...(room.charaImgUrl
+                      ? {
+                          backgroundImage: `url(${room.charaImgUrl})`,
+                          backgroundRepeat: "no-repeat",
+                          backgroundSize: "contain",
+                        }
+                      : {}),
+                    ...(!selectable || room.isDead == null || room.isDead ? { opacity: 0.3 } : {}),
+                  }}
+                  onClick={() => {
+                    if (selectable) onRoomClick(room);
+                  }}
+                >
+                  <span
+                    className="whitespace-nowrap"
+                    style={{ backgroundColor: "#222222", opacity: 0.8 }}
+                  >
+                    {room.roomNumber} {room.charaShortName ?? ""}
+                  </span>
+                </td>
+              );
+            })}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/app/features/village/components/RoomGrid.tsx
+++ b/frontend/app/features/village/components/RoomGrid.tsx
@@ -8,12 +8,15 @@ export function RoomGrid({
   rows,
   isSelected = () => false,
   isSelectable = () => true,
+  isDimmed = (room) => room.isDead == null || room.isDead,
   onRoomClick,
 }: {
   rows: VillageRoomAssignedRow[];
   isSelected?: (room: VillageRoomAssigned) => boolean;
   /** false の部屋はグレーアウトしてクリック不可にする。 */
   isSelectable?: (room: VillageRoomAssigned) => boolean;
+  /** 選択可否とは別にセルを薄く表示する条件。既定は死亡・空き部屋。 */
+  isDimmed?: (room: VillageRoomAssigned) => boolean;
   onRoomClick: (room: VillageRoomAssigned) => void;
 }) {
   return (
@@ -27,7 +30,14 @@ export function RoomGrid({
                 <td
                   key={room.roomNumber}
                   className={`text-center align-bottom ${selectable ? "cursor-pointer" : "cursor-not-allowed"}`}
+                  role={selectable ? "button" : undefined}
+                  tabIndex={selectable ? 0 : undefined}
                   aria-disabled={!selectable}
+                  aria-label={
+                    room.charaName != null
+                      ? `${room.roomNumber} ${room.charaName}`
+                      : room.roomNumber
+                  }
                   style={{
                     border: isSelected(room) ? "2px solid #0ce3ac" : "1px solid #464545",
                     width: room.charaImgWidth ?? 50,
@@ -39,10 +49,17 @@ export function RoomGrid({
                           backgroundSize: "contain",
                         }
                       : {}),
-                    ...(!selectable || room.isDead == null || room.isDead ? { opacity: 0.3 } : {}),
+                    ...(!selectable || isDimmed(room) ? { opacity: 0.3 } : {}),
                   }}
                   onClick={() => {
                     if (selectable) onRoomClick(room);
+                  }}
+                  onKeyDown={(e) => {
+                    if (!selectable) return;
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      onRoomClick(room);
+                    }
                   }}
                 >
                   <span

--- a/frontend/app/features/village/components/action/AbilityPanel.tsx
+++ b/frontend/app/features/village/components/action/AbilityPanel.tsx
@@ -59,7 +59,7 @@ export function AbilityPanel({
 
   const showToast = useToast((s) => s.show);
   const { error, submitting, execute } = useAsyncAction();
-  const [roomSelectOpen, setRoomSelectOpen] = useState(false);
+  const [roomSelectFor, setRoomSelectFor] = useState<"attacker" | "target" | null>(null);
   const hasRoomAssigned = roomAssignedRows != null && roomAssignedRows.length > 0;
 
   const submit = () =>
@@ -193,50 +193,61 @@ export function AbilityPanel({
             {isAttack && (
               <div className="mb-[5px]">
                 <span>襲撃者 </span>
-                <select
-                  className={selectClass}
-                  value={attackerCharaId}
-                  onChange={(e) => onAttackerChange(e.target.value)}
-                  aria-label="襲撃者"
-                >
-                  {ability.attackerCharaIds.map((id) => (
-                    <option key={id} value={id}>
-                      {resolveParticipantName(village, id)}
-                    </option>
-                  ))}
-                </select>
+                <div className="flex items-center gap-[5px]">
+                  <select
+                    className={`${selectClass} flex-1`}
+                    value={attackerCharaId}
+                    onChange={(e) => onAttackerChange(e.target.value)}
+                    aria-label="襲撃者"
+                  >
+                    {ability.attackerCharaIds.map((id) => (
+                      <option key={id} value={id}>
+                        {resolveParticipantName(village, id)}
+                      </option>
+                    ))}
+                  </select>
+                  {hasRoomAssigned && (
+                    <Button
+                      variant="info"
+                      className="shrink-0"
+                      aria-label="部屋割から襲撃者を選択"
+                      onClick={() => setRoomSelectFor("attacker")}
+                    >
+                      部屋割から選択
+                    </Button>
+                  )}
+                </div>
               </div>
             )}
             {(targets.length > 0 || ability.isAvailableNoTarget) && (
               <div className="mb-[5px]">
                 {ability.targetPrefix != null && <span>{ability.targetPrefix}</span>}
-                <select
-                  className={selectClass}
-                  value={targetCharaId}
-                  onChange={(e) => onTargetChange(e.target.value)}
-                  aria-label="能力の対象"
-                >
-                  {ability.isAvailableNoTarget && <option value="">なし</option>}
-                  {targets.map((target) => (
-                    <option key={target.charaId} value={target.charaId}>
-                      {target.name}
-                    </option>
-                  ))}
-                </select>
-                {ability.targetSuffix != null && <span>{ability.targetSuffix}</span>}
-                {hasRoomAssigned && targets.length > 0 && (
-                  <>
-                    {" "}
+                <div className="flex items-center gap-[5px]">
+                  <select
+                    className={`${selectClass} flex-1`}
+                    value={targetCharaId}
+                    onChange={(e) => onTargetChange(e.target.value)}
+                    aria-label="能力の対象"
+                  >
+                    {ability.isAvailableNoTarget && <option value="">なし</option>}
+                    {targets.map((target) => (
+                      <option key={target.charaId} value={target.charaId}>
+                        {target.name}
+                      </option>
+                    ))}
+                  </select>
+                  {hasRoomAssigned && targets.length > 0 && (
                     <Button
                       variant="info"
-                      size="xs"
+                      className="shrink-0"
                       aria-label="部屋割から能力の対象を選択"
-                      onClick={() => setRoomSelectOpen(true)}
+                      onClick={() => setRoomSelectFor("target")}
                     >
                       部屋割から選択
                     </Button>
-                  </>
-                )}
+                  )}
+                </div>
+                {ability.targetSuffix != null && <span>{ability.targetSuffix}</span>}
               </div>
             )}
             {needsFootstepSelect && (
@@ -286,12 +297,28 @@ export function AbilityPanel({
       </div>
       {hasRoomAssigned && (
         <RoomSelectModal
-          open={roomSelectOpen}
-          onClose={() => setRoomSelectOpen(false)}
+          open={roomSelectFor != null}
+          onClose={() => setRoomSelectFor(null)}
           rows={roomAssignedRows}
-          selectableCharaIds={targets.map((target) => target.charaId)}
-          selectedCharaId={targetCharaId === "" ? null : Number(targetCharaId)}
-          onSelect={(charaId) => onTargetChange(String(charaId))}
+          selectableCharaIds={
+            roomSelectFor === "attacker"
+              ? ability.attackerCharaIds
+              : targets.map((target) => target.charaId)
+          }
+          selectedCharaId={
+            roomSelectFor === "attacker"
+              ? attackerCharaId === ""
+                ? null
+                : Number(attackerCharaId)
+              : targetCharaId === ""
+                ? null
+                : Number(targetCharaId)
+          }
+          onSelect={(charaId) =>
+            roomSelectFor === "attacker"
+              ? onAttackerChange(String(charaId))
+              : onTargetChange(String(charaId))
+          }
         />
       )}
     </Panel>

--- a/frontend/app/features/village/components/action/AbilityPanel.tsx
+++ b/frontend/app/features/village/components/action/AbilityPanel.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Link } from "react-router";
 
 import { Alert, AlertList, ErrorMessage } from "~/components/ui/Alert";
@@ -13,6 +14,8 @@ import {
   type VillageDetailView,
   type VillageRoomAssignedRow,
 } from "~/features/village/api";
+import { RoomGrid } from "~/features/village/components/RoomGrid";
+import { RoomSelectModal } from "~/features/village/components/modal/RoomSelectModal";
 import { resolveParticipantName } from "~/features/village/participants";
 import { useVillageContext } from "~/features/village/VillageContext";
 import { useVillageInvalidate } from "~/features/village/useVillage";
@@ -56,6 +59,8 @@ export function AbilityPanel({
 
   const showToast = useToast((s) => s.show);
   const { error, submitting, execute } = useAsyncAction();
+  const [roomSelectOpen, setRoomSelectOpen] = useState(false);
+  const hasRoomAssigned = roomAssignedRows != null && roomAssignedRows.length > 0;
 
   const submit = () =>
     execute(async () => {
@@ -131,50 +136,17 @@ export function AbilityPanel({
             </p>
             {roomAssignedRows != null && (
               <div className="mt-[10px] overflow-x-auto">
-                <table className="border-collapse border border-[#464545] text-village-sm">
-                  <tbody>
-                    {roomAssignedRows.map((row, rowIndex) => (
-                      <tr key={rowIndex}>
-                        {(row.roomAssignedList ?? []).map((room) => {
-                          const selected = disturbRooms.includes(room.roomNumber ?? "");
-                          return (
-                            <td
-                              key={room.roomNumber}
-                              className="cursor-pointer text-center align-bottom"
-                              style={{
-                                border: selected ? "2px solid #0ce3ac" : "1px solid #464545",
-                                width: room.charaImgWidth ?? 50,
-                                height: room.charaImgHeight ?? 60,
-                                ...(room.charaImgUrl
-                                  ? {
-                                      backgroundImage: `url(${room.charaImgUrl})`,
-                                      backgroundRepeat: "no-repeat",
-                                      backgroundSize: "contain",
-                                    }
-                                  : {}),
-                                ...(room.isDead == null || room.isDead ? { opacity: 0.3 } : {}),
-                              }}
-                              onClick={() =>
-                                setDisturbRooms((prev) =>
-                                  prev.includes(room.roomNumber ?? "")
-                                    ? prev.filter((r) => r !== room.roomNumber)
-                                    : [...prev, room.roomNumber ?? ""],
-                                )
-                              }
-                            >
-                              <span
-                                className="whitespace-nowrap"
-                                style={{ backgroundColor: "#222222", opacity: 0.8 }}
-                              >
-                                {room.roomNumber} {room.charaShortName ?? ""}
-                              </span>
-                            </td>
-                          );
-                        })}
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+                <RoomGrid
+                  rows={roomAssignedRows}
+                  isSelected={(room) => disturbRooms.includes(room.roomNumber)}
+                  onRoomClick={(room) =>
+                    setDisturbRooms((prev) =>
+                      prev.includes(room.roomNumber)
+                        ? prev.filter((r) => r !== room.roomNumber)
+                        : [...prev, room.roomNumber],
+                    )
+                  }
+                />
               </div>
             )}
             <p className="mt-[5px]">
@@ -252,6 +224,19 @@ export function AbilityPanel({
                   ))}
                 </select>
                 {ability.targetSuffix != null && <span>{ability.targetSuffix}</span>}
+                {hasRoomAssigned && targets.length > 0 && (
+                  <>
+                    {" "}
+                    <Button
+                      variant="info"
+                      size="xs"
+                      aria-label="部屋割から能力の対象を選択"
+                      onClick={() => setRoomSelectOpen(true)}
+                    >
+                      部屋割から選択
+                    </Button>
+                  </>
+                )}
               </div>
             )}
             {needsFootstepSelect && (
@@ -299,6 +284,16 @@ export function AbilityPanel({
           </div>
         )}
       </div>
+      {hasRoomAssigned && (
+        <RoomSelectModal
+          open={roomSelectOpen}
+          onClose={() => setRoomSelectOpen(false)}
+          rows={roomAssignedRows}
+          selectableCharaIds={targets.map((target) => target.charaId)}
+          selectedCharaId={targetCharaId === "" ? null : Number(targetCharaId)}
+          onSelect={(charaId) => onTargetChange(String(charaId))}
+        />
+      )}
     </Panel>
   );
 }

--- a/frontend/app/features/village/components/action/VotePanel.tsx
+++ b/frontend/app/features/village/components/action/VotePanel.tsx
@@ -63,33 +63,32 @@ export function VotePanel({
         <hr className="border-[#464545]" />
         <p>一番票を集めた人物が処刑されます。同数の場合はランダムで決定されます。</p>
         <div>
-          <select
-            className={selectClass}
-            value={targetCharaId}
-            onChange={(e) => setTargetCharaId(e.target.value)}
-            aria-label="投票先"
-          >
-            {targetCharaId === "" && <option value="">選択してください</option>}
-            {(vote.targetCharaIds ?? []).map((charaId) => (
-              <option key={charaId} value={charaId}>
-                {resolveParticipantName(village, charaId)}
-              </option>
-            ))}
-          </select>{" "}
-          に投票する
-          {hasRoomAssigned && (
-            <>
-              {" "}
+          <div className="flex items-center gap-[5px]">
+            <select
+              className={`${selectClass} flex-1`}
+              value={targetCharaId}
+              onChange={(e) => setTargetCharaId(e.target.value)}
+              aria-label="投票先"
+            >
+              {targetCharaId === "" && <option value="">選択してください</option>}
+              {(vote.targetCharaIds ?? []).map((charaId) => (
+                <option key={charaId} value={charaId}>
+                  {resolveParticipantName(village, charaId)}
+                </option>
+              ))}
+            </select>
+            {hasRoomAssigned && (
               <Button
                 variant="info"
-                size="xs"
+                className="shrink-0"
                 aria-label="部屋割から投票先を選択"
                 onClick={() => setRoomSelectOpen(true)}
               >
                 部屋割から選択
               </Button>
-            </>
-          )}
+            )}
+          </div>
+          に投票する
         </div>
         <div className="flex justify-end">
           <Button onClick={submit} disabled={submitting || targetCharaId === ""}>

--- a/frontend/app/features/village/components/action/VotePanel.tsx
+++ b/frontend/app/features/village/components/action/VotePanel.tsx
@@ -1,9 +1,16 @@
+import { useState } from "react";
+
 import { ErrorMessage } from "~/components/ui/Alert";
 import { Button } from "~/components/ui/Button";
 import { selectClass } from "~/components/ui/Input";
 import { Panel } from "~/components/ui/Panel";
 import { useToast } from "~/components/ui/Toast";
-import { setVillageVote, type ParticipantSituationView } from "~/features/village/api";
+import {
+  setVillageVote,
+  type ParticipantSituationView,
+  type VillageRoomAssignedRow,
+} from "~/features/village/api";
+import { RoomSelectModal } from "~/features/village/components/modal/RoomSelectModal";
 import { resolveParticipantName } from "~/features/village/participants";
 import { useVillageContext } from "~/features/village/VillageContext";
 import { useVillageInvalidate } from "~/features/village/useVillage";
@@ -11,13 +18,21 @@ import { useAsyncAction } from "~/lib/useAsyncAction";
 import { useVoteState } from "./useVoteState";
 
 /** 処刑対象への投票。未セットのまま日付が更新されると突然死するため警告を出す。 */
-export function VotePanel({ mySituation }: { mySituation: ParticipantSituationView }) {
+export function VotePanel({
+  mySituation,
+  roomAssignedRows,
+}: {
+  mySituation: ParticipantSituationView;
+  roomAssignedRows: VillageRoomAssignedRow[] | null | undefined;
+}) {
   const village = useVillageContext();
   const invalidate = useVillageInvalidate();
   const vote = mySituation.vote;
   const { targetCharaId, setTargetCharaId } = useVoteState(vote);
   const showToast = useToast((s) => s.show);
   const { error, submitting, execute } = useAsyncAction();
+  const [roomSelectOpen, setRoomSelectOpen] = useState(false);
+  const hasRoomAssigned = roomAssignedRows != null && roomAssignedRows.length > 0;
 
   const submit = () => {
     if (targetCharaId === "") return;
@@ -62,6 +77,19 @@ export function VotePanel({ mySituation }: { mySituation: ParticipantSituationVi
             ))}
           </select>{" "}
           に投票する
+          {hasRoomAssigned && (
+            <>
+              {" "}
+              <Button
+                variant="info"
+                size="xs"
+                aria-label="部屋割から投票先を選択"
+                onClick={() => setRoomSelectOpen(true)}
+              >
+                部屋割から選択
+              </Button>
+            </>
+          )}
         </div>
         <div className="flex justify-end">
           <Button onClick={submit} disabled={submitting || targetCharaId === ""}>
@@ -69,6 +97,16 @@ export function VotePanel({ mySituation }: { mySituation: ParticipantSituationVi
           </Button>
         </div>
       </div>
+      {hasRoomAssigned && (
+        <RoomSelectModal
+          open={roomSelectOpen}
+          onClose={() => setRoomSelectOpen(false)}
+          rows={roomAssignedRows}
+          selectableCharaIds={vote.targetCharaIds ?? []}
+          selectedCharaId={targetCharaId === "" ? null : Number(targetCharaId)}
+          onSelect={(charaId) => setTargetCharaId(String(charaId))}
+        />
+      )}
     </Panel>
   );
 }

--- a/frontend/app/features/village/components/modal/RoomSelectModal.tsx
+++ b/frontend/app/features/village/components/modal/RoomSelectModal.tsx
@@ -1,0 +1,48 @@
+import { Modal } from "~/components/ui/Modal";
+import type { VillageRoomAssigned, VillageRoomAssignedRow } from "~/features/village/api";
+import { RoomGrid } from "~/features/village/components/RoomGrid";
+import { resolveCharaId } from "~/features/village/participants";
+import { useVillageContext } from "~/features/village/VillageContext";
+
+/** 部屋割から対象者を選ぶモーダル。候補にいない参加者の部屋・空き部屋は選択不可。 */
+export function RoomSelectModal({
+  open,
+  onClose,
+  rows,
+  selectableCharaIds,
+  selectedCharaId,
+  onSelect,
+}: {
+  open: boolean;
+  onClose: () => void;
+  rows: VillageRoomAssignedRow[];
+  /** 選択候補の charaId (select の option と同じ集合) */
+  selectableCharaIds: number[];
+  selectedCharaId: number | null;
+  onSelect: (charaId: number) => void;
+}) {
+  const village = useVillageContext();
+  const charaIdOf = (room: VillageRoomAssigned): number | null =>
+    room.participantId != null ? resolveCharaId(village, room.participantId) : null;
+
+  return (
+    <Modal open={open} onClose={onClose} title="部屋割から選択" size="wide">
+      <div className="overflow-x-auto">
+        <RoomGrid
+          rows={rows}
+          isSelectable={(room) => {
+            const charaId = charaIdOf(room);
+            return charaId != null && selectableCharaIds.includes(charaId);
+          }}
+          isSelected={(room) => selectedCharaId != null && charaIdOf(room) === selectedCharaId}
+          onRoomClick={(room) => {
+            const charaId = charaIdOf(room);
+            if (charaId == null) return;
+            onSelect(charaId);
+            onClose();
+          }}
+        />
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/app/features/village/components/modal/RoomSelectModal.tsx
+++ b/frontend/app/features/village/components/modal/RoomSelectModal.tsx
@@ -34,6 +34,8 @@ export function RoomSelectModal({
             const charaId = charaIdOf(room);
             return charaId != null && selectableCharaIds.includes(charaId);
           }}
+          // 蘇生など死亡者が候補になる能力もあるため、候補かどうかだけで減光を決める
+          isDimmed={() => false}
           isSelected={(room) => selectedCharaId != null && charaIdOf(room) === selectedCharaId}
           onRoomClick={(room) => {
             const charaId = charaIdOf(room);

--- a/frontend/app/features/village/participants.ts
+++ b/frontend/app/features/village/participants.ts
@@ -9,6 +9,11 @@ export function allParticipants(village: VillageDetailView): VillageParticipantV
   return [...(village.participants.list ?? []), ...(village.spectators.list ?? [])];
 }
 
+/** participantId から charaId を引く (部屋割データは participantId しか持たないため)。 */
+export function resolveCharaId(village: VillageDetailView, participantId: number): number | null {
+  return allParticipants(village).find((p) => p.id === participantId)?.chara.id ?? null;
+}
+
 /**
  * 部屋番号順の比較関数。backend の VillageParticipants.sortedByRoomNumber と同じセマンティクス:
  * 見学者を末尾に置き、部屋番号昇順 (部屋を持たない参加者は先頭)、同順位は chara.id 昇順。

--- a/frontend/app/routes/village-message/route.tsx
+++ b/frontend/app/routes/village-message/route.tsx
@@ -68,7 +68,7 @@ export default function VillageMessagePermalink({ params }: Route.ComponentProps
               />
             ))}
           </div>
-          {ageLimit != null && <AgeLimitModal villageId={villageId} ageLimit={ageLimit} />}
+          {ageLimit != null && <AgeLimitModal ageLimit={ageLimit} />}
         </VillageProvider>
       ) : (
         <div className="px-[15px] pb-[30px]" />

--- a/frontend/app/routes/village-scrap/route.tsx
+++ b/frontend/app/routes/village-scrap/route.tsx
@@ -137,7 +137,7 @@ export default function VillageScrap({ params }: Route.ComponentProps) {
               </div>
             </div>
           </div>
-          {ageLimit != null && <AgeLimitModal villageId={villageId} ageLimit={ageLimit} />}
+          {ageLimit != null && <AgeLimitModal ageLimit={ageLimit} />}
         </VillageProvider>
       ) : (
         <div className="px-[15px] pb-[30px]" />


### PR DESCRIPTION
closes .issues/enhance-target-select-from-room-assignment.md

## 概要

投票・役職能力の対象指定は select（名前リスト）のみで、部屋番号で状況を把握しているプレイヤーには「どの部屋の誰か」を探しにくかった。select の右横に「部屋割から選択」ボタンを追加し、部屋割モーダルから部屋セルをクリックして対象を選べるようにする。

## 変更内容

- **RoomGrid の抽出**: 部屋セルをクリックして選択する用途のグリッドを共通コンポーネント化（`features/village/components/RoomGrid.tsx`）。AbilityPanel の徘徊トグルをこれに置き換え、新規モーダルと共用（重複 4 つ目を作らない）
  - `RoomAssignedTab` はツールチップ・役職名/死亡表示・maxWidth/maxHeight ベースのセルサイズなど表示専用で構造が異なるため対象外。`AnalyzerRoomGrid` は x/y 座標系の別データモデルのため対象外
- **RoomSelectModal 新設**: `situation.roomAssignedRowList` をグリッド表示し、部屋クリックで charaId を返して閉じる。候補にいない参加者の部屋・空き部屋はグレーアウト + クリック不可（`aria-disabled`）
- **VotePanel / AbilityPanel**: 対象 select と「部屋割から選択」ボタンを flex 行にまとめ（select が flex-1、ボタン右端固定）、前後のテキストは従来どおり別行。選択値は participantId → charaId 変換（`resolveCharaId` を `participants.ts` に追加）して select に反映
  - **襲撃者 select にも同様のボタンを追加**（候補は襲撃者候補=人狼のみ）。徘徊は既に部屋グリッド直接選択のため対象外
- **e2e**: 部屋割モーダル経由で投票先をセットするテストを `village-vote.spec.ts` に追加（候補外セルの非活性数も検証）。ボタンの aria-label が select のラベルと部分一致するため、既存の select 参照を `getByRole("combobox")` に変更
- **既存 typecheck エラーの修正（別コミット）**: #115 で `AgeLimitModal` から `villageId` prop が削除された際に村ログ・スクラップ画面の呼び出し側が残っており `pnpm typecheck` が失敗していたため、参照を除去

## 動作確認

- `pnpm lint` / `pnpm format:check` / `pnpm typecheck` / `pnpm build` パス
- e2e 全 87 件パス（新規テスト「部屋割から選択で投票先をセットできる」を含む）
- Playwright 実機確認: 賢者（占い対象）・人狼（襲撃者/襲撃対象）・投票の各パネルでモーダル選択 → select 反映、候補外/空き部屋の非活性、部屋割なし村での非表示を確認。ユーザーによる UI レビュー済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAzWW9S6uojU7btEcXckeR