### PR TITLE
fix: 全角記号の連続を含む発言でスマホ画面全体が横スクロールする

### DIFF
--- a/frontend/app/features/village/components/message/MessageArea.tsx
+++ b/frontend/app/features/village/components/message/MessageArea.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect } from "react";
 import { useSearchParams } from "react-router";
 
-import { MESSAGE_STYLES } from "~/components/ui/messageStyles";
 import type { VillageMessageListContent } from "~/features/village/api";
 import { useRandomKeywordList } from "~/features/random-keywords/useRandomKeywords";
 import { applyFilterToParams, EMPTY_FILTER, type MessageFilter } from "~/features/village/filter";
@@ -9,14 +8,13 @@ import { useVillageId } from "~/features/village/VillageContext";
 import { useMyVillageSituation } from "~/features/village/useVillage";
 import { useVillageMessages } from "~/features/village/useMessages";
 import { MessageType } from "~/features/village/components/message/messageType";
+import { bubbleClass } from "~/features/village/components/message/message";
 import { MessageCard, type ReplyDraft } from "./MessageCard";
 import { MessagePagination, type PageState } from "./MessagePagination";
 
 function Announce({ text }: { text: string }) {
   return (
-    <div
-      className={`message mb-[20px] rounded-[5px] border p-[9px] break-words break-all ${MESSAGE_STYLES["message-announce"]}`}
-    >
+    <div className={`mb-[20px] ${bubbleClass("message-announce")}`}>
       {text.split("\n").map((line, i) => (
         <span key={i}>
           {i > 0 && <br />}

--- a/frontend/app/features/village/components/message/SayMessage.tsx
+++ b/frontend/app/features/village/components/message/SayMessage.tsx
@@ -88,7 +88,7 @@ function BigEarsMessage({
       <div className="flex">
         <div className="h-[77px] w-[50px] rounded-[5px] border border-white" />
         <StableHtml
-          className={`ml-[5px] flex-1 ${bubbleClass("message-owl")}`}
+          className={`ml-[5px] min-w-0 flex-1 ${bubbleClass("message-owl")}`}
           onClick={onContentClick}
           html={html}
         />
@@ -251,7 +251,7 @@ function SayBubble({
           )}
         </div>
         <div
-          className={`ml-[5px] flex-1 ${bubbleClass(sayVariant.styleKey)} ${loud ? "loud" : ""}`}
+          className={`ml-[5px] min-w-0 flex-1 ${bubbleClass(sayVariant.styleKey)} ${loud ? "loud" : ""}`}
           onClick={onContentClick}
         >
           {rainbow ? <StableHtml className="rainbow" html={html} /> : <StableHtml html={html} />}

--- a/frontend/app/features/village/components/message/message.ts
+++ b/frontend/app/features/village/components/message/message.ts
@@ -50,8 +50,9 @@ export const SYSTEM_VARIANTS: Record<string, string> = {
   [MessageType.PRIVATE_ABILITY]: "message-private-ability",
 };
 
-const bubbleBaseClass =
-  "message rounded-[5px] border p-[9px] break-words break-all font-[sans-serif]";
+// break-all は「！」「～」等の行頭禁則文字の連続に改行機会を作れず、緊急折り返し
+// (overflow-wrap) も無効化して吹き出しがはみ出すため、break-words のみで折り返す
+const bubbleBaseClass = "message rounded-[5px] border p-[9px] break-words font-[sans-serif]";
 
 export function bubbleClass(styleKey: string): string {
   return `${bubbleBaseClass} ${styleKey} ${MESSAGE_STYLES[styleKey] ?? DEFAULT_MESSAGE_STYLE}`;


### PR DESCRIPTION
closes .issues/fix-message-fullwidth-punctuation-overflow.md

## 概要

スマホで全角「！」「～」等の連続を含む発言（wolfort.dev 村 716 の 8 日目 `>>-498` 等）を表示すると、吹き出しが折り返せずページ全体に横スクロールが発生していた。legacy の `word-break: break-word` と同等の折り返しに戻す。

## 原因

- 「！」「～」等の全角約物は行頭禁則対象で、連続すると通常の改行機会がない
- 現行の吹き出しは `break-words break-all` だが、`word-break: break-all` は禁則で禁止された位置に改行機会を作らず、指定時は `overflow-wrap: break-word` の緊急折り返しも効かないため、この連続が折り返せない
- 吹き出しは flex 行内で `flex-1`（`min-width: auto`）のため、折り返せない内容が吹き出し → ページ全体を押し広げていた

## 変更内容

- `message.ts` の `bubbleBaseClass` から `break-all` を除去し `break-words`（`overflow-wrap: break-word` = legacy の `word-break: break-word` 相当）のみにする
- `SayMessage` の flex-1 吹き出し 2 箇所（通常発言・地獄耳）に `min-w-0` を追加し、折り返せない内容がページ全体へ波及しない防御を入れる
- `MessageArea` の `Announce` が重複して持っていた吹き出しクラス指定を `bubbleClass("message-announce")` に一元化（同修正がアナウンスにも効く）

## 動作確認（iPhone 幅 390px、ローカル村で A/B 検証）

| | 修正前 | 修正後 |
|---|---|---|
| ページ幅 | 515px（横スクロール発生） | 375px（スクロールなし） |
| computed style | `word-break: break-all` | `overflow-wrap: break-word` / `word-break: normal` |

- 「！」×40、「～」×13+「！」×32 の独り言が吹き出し内で折り返されること
- 通常の日本語長文・長い英単語（W×60）・長い URL の折り返しが従来どおりであること
- `pnpm lint` / `pnpm format:check` パス（typecheck / build / e2e は PR 作成後に実行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAzWW9S6uojU7btEcXckeR