### PR TITLE
fix: 抽出中に新規発言がなくても「最新発言を読み込みました」が出続ける

### DIFF
--- a/frontend/app/features/village/filter.ts
+++ b/frontend/app/features/village/filter.ts
@@ -79,11 +79,18 @@ export function applyFilterToParams(
 
 /** 何らかの抽出条件が指定されているか (footer の「抽出中」表示用)。 */
 export function isFiltering(filter: MessageFilter): boolean {
+  return isNarrowingFilter(filter) || filter.spoiled;
+}
+
+/**
+ * 一覧を絞り込む抽出条件があるか (新着検知・自動リロード抑止用)。
+ * spoiled は表示だけを変えるトグルで一覧は村全体のまま絞られないため含めない。
+ */
+export function isNarrowingFilter(filter: MessageFilter): boolean {
   return (
     filter.participantIds.length > 0 ||
     filter.toParticipantIds.length > 0 ||
     filter.types.length > 0 ||
-    filter.keywords !== "" ||
-    filter.spoiled
+    filter.keywords !== ""
   );
 }

--- a/frontend/app/features/village/useMessageSync.ts
+++ b/frontend/app/features/village/useMessageSync.ts
@@ -13,41 +13,46 @@ export function useMessageSync(
   invalidate: () => Promise<unknown>,
   showToast: (msg: string) => void,
   canAutoReload: boolean,
+  filtering: boolean,
 ) {
   const [loadedMessages, setLoadedMessages] = useState<VillageMessageListContent | null>(null);
   const hashScrolled = useRef(false);
-
-  const onMessagesLoaded = useCallback(
-    (content: VillageMessageListContent) => {
-      setLoadedMessages(content);
-      if (!hashScrolled.current && window.location.hash === "#bottom") {
-        hashScrolled.current = true;
-        setTimeout(() => scrollToBottom(false), 0);
-      }
-    },
-    [scrollToBottom],
-  );
 
   const isInLatestPage =
     latestDay != null &&
     currentDay === latestDay &&
     (loadedMessages == null || loadedMessages.isDispLatest || !loadedMessages.isExistNextPage);
 
-  const hasNewMessage = useNewMessageDetector(
+  // 抽出中は表示リストの最終日時が村全体の最新より古いため、検知基準に使わない
+  const { hasNewMessage, resetNewMessage } = useNewMessageDetector(
     villageId,
     dayParam,
-    loadedMessages?.latestMessageDatetime,
+    filtering ? null : loadedMessages?.latestMessageDatetime,
     isInLatestPage,
+  );
+
+  const onMessagesLoaded = useCallback(
+    (content: VillageMessageListContent) => {
+      setLoadedMessages(content);
+      resetNewMessage();
+      if (!hashScrolled.current && window.location.hash === "#bottom") {
+        hashScrolled.current = true;
+        setTimeout(() => scrollToBottom(false), 0);
+      }
+    },
+    [scrollToBottom, resetNewMessage],
   );
 
   const autoReload = useDisplaySettings((s) => s.autoReload);
   useEffect(() => {
-    if (hasNewMessage && autoReload && canAutoReload) {
+    // 抽出中は自動リロードしない (点滅で新着を知らせ、手動更新に委ねる)
+    if (hasNewMessage && autoReload && canAutoReload && !filtering) {
       void invalidate();
+      resetNewMessage();
       showToast("最新発言を読み込みました");
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasNewMessage, autoReload, canAutoReload]);
+  }, [hasNewMessage, autoReload, canAutoReload, filtering]);
 
-  return { onMessagesLoaded, hasNewMessage };
+  return { onMessagesLoaded, hasNewMessage, resetNewMessage };
 }

--- a/frontend/app/features/village/useMessageSync.ts
+++ b/frontend/app/features/village/useMessageSync.ts
@@ -43,6 +43,12 @@ export function useMessageSync(
     [scrollToBottom, resetNewMessage],
   );
 
+  // 抽出の適用・解除で一覧は再取得されるため、切替前の検知結果は持ち越さない
+  // (解除直後に自動リロード effect が即発火して再取得と重複するのを防ぐ)
+  useEffect(() => {
+    resetNewMessage();
+  }, [filtering, resetNewMessage]);
+
   const autoReload = useDisplaySettings((s) => s.autoReload);
   useEffect(() => {
     // 抽出中は自動リロードしない (点滅で新着を知らせ、手動更新に委ねる)

--- a/frontend/app/features/village/useMessages.ts
+++ b/frontend/app/features/village/useMessages.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useMe } from "~/features/auth/useMe";
 import { fetchLatestMessageDatetime, fetchVillageMessages, type VillageMessageSearch } from "./api";
@@ -21,36 +21,52 @@ export function useVillageMessages(id: number, search: VillageMessageSearch) {
 const POLLING_INTERVAL_MS = 30_000;
 
 /**
- * 新着発言の検知。最新ページを表示している間、30 秒ごとに最新発言日時を取得し、
- * 表示済みの日時より新しければ true を返す (更新ボタンの点滅用)。
- * 表示済み日時が更新されたら (= 再読み込みされたら) フラグを下ろす。
+ * 新着発言の検知。最新ページを表示している間、30 秒ごとに村全体 (抽出非適用・視点反映) の
+ * 最新発言日時を取得し、前回把握した日時より新しければ true を返す (更新ボタンの点滅用)。
+ *
+ * 比較基準は「前回把握した村全体の最新日時」。抽出中は表示リストの最終日時が村全体より
+ * 古いまま止まるため、表示リスト基準で比較すると新着がなくても検知し続けてしまう。
+ * `baselineDatetime` は抽出していないとき (表示リスト = 村全体) だけ渡し、
+ * ポーリングを待たず一覧ロード時点の日時を基準にできるようにする。
+ * フラグは一覧のロード完了時に `resetNewMessage` で下ろす。
  */
 export function useNewMessageDetector(
   id: number,
   day: number | undefined,
-  displayedLatestDatetime: string | null | undefined,
+  baselineDatetime: string | null | undefined,
   enabled: boolean,
-): boolean {
+): { hasNewMessage: boolean; resetNewMessage: () => void } {
   const [hasNewMessage, setHasNewMessage] = useState(false);
-  const displayedRef = useRef(displayedLatestDatetime);
+  const lastKnownRef = useRef<string | null>(null);
+
+  const resetNewMessage = useCallback(() => setHasNewMessage(false), []);
 
   useEffect(() => {
-    displayedRef.current = displayedLatestDatetime;
-    setHasNewMessage(false);
-  }, [displayedLatestDatetime]);
+    if (baselineDatetime != null) {
+      lastKnownRef.current = baselineDatetime;
+      setHasNewMessage(false);
+    }
+  }, [baselineDatetime]);
 
   useEffect(() => {
     if (!enabled) {
       setHasNewMessage(false);
+      lastKnownRef.current = null;
       return;
     }
     let active = true;
     const poll = async () => {
       try {
         const latest = await fetchLatestMessageDatetime(id, { day });
-        if (!active) return;
-        const displayed = displayedRef.current;
-        if (displayed != null && latest !== "0" && Number(latest) > Number(displayed)) {
+        if (!active || latest === "0") return;
+        const lastKnown = lastKnownRef.current;
+        if (lastKnown == null) {
+          // 基準が未確定の間 (抽出中の初回など) は保存のみ。次回以降の増分で検知する
+          lastKnownRef.current = latest;
+          return;
+        }
+        if (Number(latest) > Number(lastKnown)) {
+          lastKnownRef.current = latest;
           setHasNewMessage(true);
         }
       } catch {
@@ -64,5 +80,5 @@ export function useNewMessageDetector(
     };
   }, [id, day, enabled]);
 
-  return hasNewMessage;
+  return { hasNewMessage, resetNewMessage };
 }

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -10,6 +10,7 @@ import { useDisplaySettings } from "~/features/village/displaySettings";
 import {
   applyFilterToParams,
   isFiltering,
+  isNarrowingFilter,
   parseFilter,
   type MessageFilter,
 } from "~/features/village/filter";
@@ -153,7 +154,7 @@ export default function Village({ params }: Route.ComponentProps) {
     invalidate,
     showToast,
     sayPreview == null,
-    isFiltering(filter),
+    isNarrowingFilter(filter),
   );
 
   const pendingScroll = useRef(false);

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -140,7 +140,11 @@ export default function Village({ params }: Route.ComponentProps) {
     }
   }, [daychangeDetected, showToast, autoReload]);
 
-  const { onMessagesLoaded: onMessagesLoadedBase, hasNewMessage } = useMessageSync(
+  const {
+    onMessagesLoaded: onMessagesLoadedBase,
+    hasNewMessage,
+    resetNewMessage,
+  } = useMessageSync(
     villageId,
     dayParam,
     latestDay,
@@ -149,6 +153,7 @@ export default function Village({ params }: Route.ComponentProps) {
     invalidate,
     showToast,
     sayPreview == null,
+    isFiltering(filter),
   );
 
   const pendingScroll = useRef(false);
@@ -280,6 +285,8 @@ export default function Village({ params }: Route.ComponentProps) {
 
           <FooterMenu
             onRefresh={() => {
+              // 抽出中は再取得結果が変わらないことがあり load 経由ではフラグが下りないため、更新操作で明示的に下ろす
+              resetNewMessage();
               resetToLatest();
               pendingScroll.current = true;
               if (dayParam != null) {


### PR DESCRIPTION
## 目的

発言抽出（フィルタ）適用 + 自動更新取得 ON のとき、抽出条件に合致する新規発言がなくても「最新発言を読み込みました」トーストが表示され続ける問題を修正する（ローカル Issue 10）。

## 原因

新着判定（`useNewMessageDetector`）の比較基準が「表示中（＝抽出後）リストの最終発言日時」だったため、抽出中は基準が村全体の最新より古いまま固定される。抽出に合致しない発言が後ろにあると `村全体の最新 > 基準` が常に成立し、ポーリングのたびに誤検知して自動リロード + トーストが再発していた。

## 修正内容（firewolf の同機能に準拠）

https://github.com/h-orito/firewolf の実装（`useVillagePolling` / `useVillageRefresh`）に合わせた:

- ポーリングは従来どおり抽出条件なし（視点反映のみ）の最新日時を取得（backend 変更なし）
- 比較基準を「**前回把握した村全体の最新日時**」に変更。非抽出時は表示リストの日時でシードし従来の検知感度を維持、抽出中はポーリング初回値で初期化
- 新着フラグのリセットを「日時の変化」から「更新操作・一覧ロード完了」に変更。抽出中は再取得結果が変わらず react-query の structural sharing で load コールバックが発火しないため、フッター更新ボタン側でも明示的に下ろす
- **抽出中は自動リロードとトーストを抑止**（firewolf の `shouldAutoRefresh` の `isFiltering` 弾き相当）。新着は更新アイコンの点滅で知らせ、手動更新に委ねる

## 動作確認（dev 環境に検証用村を作成して実測）

- 抽出中（合致 0 件のキーワード）+ 抽出外の新規発言投稿 → 2 ポーリング以上観測してトースト・自動リロードなし、更新アイコン点滅 ✅
- 抽出中の手動更新 → 点滅解除（トーストなし）✅
- 抽出なし + 新規発言 → 従来どおり自動リロード + トースト 1 回、以降の再発なし ✅
- console: 新規エラーなし（401 は未ログイン /me の既存事象）
- lint / format:check / tsc: パス
- e2e `village-message-filter.spec.ts` + `village-messages.spec.ts`: 7 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)