### PR TITLE
fix: 通知設定 webhookUrl を Discord ホストに限定しブラインド SSRF を防ぐ

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/village/VillageNotificationRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/VillageNotificationRestController.kt
@@ -43,7 +43,7 @@ class VillageNotificationRestController(
         val myself =
             villageService.findVillageParticipant(village.id, principal.name)
                 ?: throw WolfMansionBusinessException("村に参加していません")
-        val webhookUrl = request.webhookUrl!!
+        val webhookUrl = request.validatedWebhookUrl()
 
         villageService.registerNotification(
             myself.copy(

--- a/backend/src/main/kotlin/com/ort/app/api/village/request/VillageNotificationRequest.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/request/VillageNotificationRequest.kt
@@ -1,7 +1,11 @@
 package com.ort.app.api.village.request
 
+import com.ort.app.fw.exception.WolfMansionValidationException
+import com.ort.app.fw.exception.WolfMansionValidationException.FieldErrorItem
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
+import java.net.URI
+import java.net.URISyntaxException
 
 /** Discord 通知設定の保存。保存時に webhook へテスト通知を送る。 */
 data class VillageNotificationRequest(
@@ -22,4 +26,33 @@ data class VillageNotificationRequest(
     /** キーワード通知 (スペース区切り) */
     @field:Size(max = 30)
     val keyword: String? = null,
-)
+) {
+    companion object {
+        private val ALLOWED_HOSTS = listOf("discord.com", "discordapp.com")
+        private const val INVALID_MESSAGE = "Discord の Webhook URL (https://discord.com/api/webhooks/...) を指定してください"
+    }
+
+    /**
+     * 検証済みの webhookUrl を返す。保存した URL へはサーバから外向き POST を送るため、
+     * Discord 以外のホストを許可すると内部サービスを標的にしたブラインド SSRF に悪用できる。
+     * https かつ Discord のホストに限定する。
+     */
+    fun validatedWebhookUrl(): String {
+        val url = webhookUrl!!
+        val uri =
+            try {
+                URI(url)
+            } catch (e: URISyntaxException) {
+                throw WolfMansionValidationException(listOf(FieldErrorItem("webhookUrl", INVALID_MESSAGE)))
+            }
+        val host = uri.host?.lowercase()
+        val isAllowed =
+            uri.scheme.equals("https", ignoreCase = true) &&
+                host != null &&
+                ALLOWED_HOSTS.any { host == it || host.endsWith(".$it") }
+        if (!isAllowed) {
+            throw WolfMansionValidationException(listOf(FieldErrorItem("webhookUrl", INVALID_MESSAGE)))
+        }
+        return url
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/api/village/request/VillageNotificationRequest.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/village/request/VillageNotificationRequest.kt
@@ -1,11 +1,10 @@
 package com.ort.app.api.village.request
 
+import com.ort.app.domain.model.discord.DiscordWebhookUrl
 import com.ort.app.fw.exception.WolfMansionValidationException
 import com.ort.app.fw.exception.WolfMansionValidationException.FieldErrorItem
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
-import java.net.URI
-import java.net.URISyntaxException
 
 /** Discord 通知設定の保存。保存時に webhook へテスト通知を送る。 */
 data class VillageNotificationRequest(
@@ -28,29 +27,13 @@ data class VillageNotificationRequest(
     val keyword: String? = null,
 ) {
     companion object {
-        private val ALLOWED_HOSTS = listOf("discord.com", "discordapp.com")
         private const val INVALID_MESSAGE = "Discord の Webhook URL (https://discord.com/api/webhooks/...) を指定してください"
     }
 
-    /**
-     * 検証済みの webhookUrl を返す。保存した URL へはサーバから外向き POST を送るため、
-     * Discord 以外のホストを許可すると内部サービスを標的にしたブラインド SSRF に悪用できる。
-     * https かつ Discord のホストに限定する。
-     */
+    /** 検証済みの webhookUrl を返す。検証理由は [DiscordWebhookUrl] を参照。 */
     fun validatedWebhookUrl(): String {
-        val url = webhookUrl!!
-        val uri =
-            try {
-                URI(url)
-            } catch (e: URISyntaxException) {
-                throw WolfMansionValidationException(listOf(FieldErrorItem("webhookUrl", INVALID_MESSAGE)))
-            }
-        val host = uri.host?.lowercase()
-        val isAllowed =
-            uri.scheme.equals("https", ignoreCase = true) &&
-                host != null &&
-                ALLOWED_HOSTS.any { host == it || host.endsWith(".$it") }
-        if (!isAllowed) {
+        val url = webhookUrl!!.trim()
+        if (!DiscordWebhookUrl.isValid(url)) {
             throw WolfMansionValidationException(listOf(FieldErrorItem("webhookUrl", INVALID_MESSAGE)))
         }
         return url

--- a/backend/src/main/kotlin/com/ort/app/domain/model/discord/DiscordWebhookUrl.kt
+++ b/backend/src/main/kotlin/com/ort/app/domain/model/discord/DiscordWebhookUrl.kt
@@ -1,0 +1,25 @@
+package com.ort.app.domain.model.discord
+
+import java.net.URI
+import java.net.URISyntaxException
+
+/**
+ * Discord Webhook URL の検証。保存した URL へはサーバから外向き POST を送るため、
+ * Discord 以外のホストを許可すると内部サービスを標的にしたブラインド SSRF に悪用できる。
+ * https かつ Discord のホスト (サブドメイン含む) に限定する。
+ */
+object DiscordWebhookUrl {
+    private val ALLOWED_HOSTS = listOf("discord.com", "discordapp.com")
+
+    fun isValid(url: String): Boolean {
+        val uri =
+            try {
+                URI(url)
+            } catch (e: URISyntaxException) {
+                return false
+            }
+        val host = uri.host?.lowercase() ?: return false
+        return uri.scheme.equals("https", ignoreCase = true) &&
+            ALLOWED_HOSTS.any { host == it || host.endsWith(".$it") }
+    }
+}

--- a/backend/src/main/kotlin/com/ort/app/infrastructure/discord/DiscordRepositoryImpl.kt
+++ b/backend/src/main/kotlin/com/ort/app/infrastructure/discord/DiscordRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.ort.app.infrastructure.discord
 
 import com.ort.app.domain.model.discord.DiscordRepository
+import com.ort.app.domain.model.discord.DiscordWebhookUrl
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpEntity
@@ -67,6 +68,11 @@ class DiscordRepositoryImpl : DiscordRepository {
         message: String,
         shouldContainVillageUrl: Boolean,
     ) {
+        // 検証導入前に保存された URL が残っている可能性があるため、送信側でも検証する (SSRF 対策)
+        if (!DiscordWebhookUrl.isValid(webhookUrl)) {
+            logger.warn("Discord 以外の webhook URL への通知をスキップしました: villageId={}", villageId)
+            return
+        }
         try {
             val restTemplate = restTemplate()
             val content =

--- a/backend/src/test/kotlin/com/ort/app/api/village/request/VillageNotificationRequestTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/api/village/request/VillageNotificationRequestTest.kt
@@ -10,57 +10,28 @@ internal class VillageNotificationRequestTest {
 
     @Test
     fun `正規の Discord Webhook URL は通る`() {
-        listOf(
+        val url = "https://discord.com/api/webhooks/123/abc"
+        assertEquals(url, request(url).validatedWebhookUrl())
+    }
+
+    @Test
+    fun `前後の空白は取り除いて検証・保存する`() {
+        assertEquals(
             "https://discord.com/api/webhooks/123/abc",
-            "https://discordapp.com/api/webhooks/123/abc",
-            "https://ptb.discord.com/api/webhooks/123/abc",
-            "https://canary.discord.com/api/webhooks/123/abc",
-        ).forEach { url ->
-            assertEquals(url, request(url).validatedWebhookUrl())
-        }
+            request(" https://discord.com/api/webhooks/123/abc ").validatedWebhookUrl(),
+        )
     }
 
     @Test
-    fun `Discord 以外のホストは 400 (ValidationException)`() {
+    fun `Discord の Webhook URL でなければ 400 (ValidationException)`() {
         listOf(
-            "https://example.com/api/webhooks/123/abc",
             "https://169.254.169.254/latest/meta-data/",
-            "https://localhost:8089/wolf-mansion/",
-        ).forEach { url ->
-            assertThrows<WolfMansionValidationException> { request(url).validatedWebhookUrl() }
-        }
-    }
-
-    @Test
-    fun `https 以外のスキームは 400 (ValidationException)`() {
-        listOf(
             "http://discord.com/api/webhooks/123/abc",
-            "ftp://discord.com/api/webhooks/123/abc",
-        ).forEach { url ->
-            assertThrows<WolfMansionValidationException> { request(url).validatedWebhookUrl() }
-        }
-    }
-
-    @Test
-    fun `ホスト偽装を狙った URL は 400 (ValidationException)`() {
-        listOf(
-            // suffix が似ているだけの別ドメイン
-            "https://evildiscord.com/api/webhooks/123/abc",
-            "https://discord.com.evil.com/api/webhooks/123/abc",
-            // userinfo 部に discord.com を置いた実ホスト evil.com
             "https://discord.com@evil.com/api/webhooks/123/abc",
-        ).forEach { url ->
-            assertThrows<WolfMansionValidationException> { request(url).validatedWebhookUrl() }
-        }
-    }
-
-    @Test
-    fun `URL として不正な文字列は 400 (ValidationException)`() {
-        listOf(
             "not a url",
-            "https://",
         ).forEach { url ->
-            assertThrows<WolfMansionValidationException> { request(url).validatedWebhookUrl() }
+            val e = assertThrows<WolfMansionValidationException> { request(url).validatedWebhookUrl() }
+            assertEquals("webhookUrl", e.fieldErrors.single().field)
         }
     }
 }

--- a/backend/src/test/kotlin/com/ort/app/api/village/request/VillageNotificationRequestTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/api/village/request/VillageNotificationRequestTest.kt
@@ -1,0 +1,66 @@
+package com.ort.app.api.village.request
+
+import com.ort.app.fw.exception.WolfMansionValidationException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class VillageNotificationRequestTest {
+    private fun request(url: String) = VillageNotificationRequest(webhookUrl = url)
+
+    @Test
+    fun `正規の Discord Webhook URL は通る`() {
+        listOf(
+            "https://discord.com/api/webhooks/123/abc",
+            "https://discordapp.com/api/webhooks/123/abc",
+            "https://ptb.discord.com/api/webhooks/123/abc",
+            "https://canary.discord.com/api/webhooks/123/abc",
+        ).forEach { url ->
+            assertEquals(url, request(url).validatedWebhookUrl())
+        }
+    }
+
+    @Test
+    fun `Discord 以外のホストは 400 (ValidationException)`() {
+        listOf(
+            "https://example.com/api/webhooks/123/abc",
+            "https://169.254.169.254/latest/meta-data/",
+            "https://localhost:8089/wolf-mansion/",
+        ).forEach { url ->
+            assertThrows<WolfMansionValidationException> { request(url).validatedWebhookUrl() }
+        }
+    }
+
+    @Test
+    fun `https 以外のスキームは 400 (ValidationException)`() {
+        listOf(
+            "http://discord.com/api/webhooks/123/abc",
+            "ftp://discord.com/api/webhooks/123/abc",
+        ).forEach { url ->
+            assertThrows<WolfMansionValidationException> { request(url).validatedWebhookUrl() }
+        }
+    }
+
+    @Test
+    fun `ホスト偽装を狙った URL は 400 (ValidationException)`() {
+        listOf(
+            // suffix が似ているだけの別ドメイン
+            "https://evildiscord.com/api/webhooks/123/abc",
+            "https://discord.com.evil.com/api/webhooks/123/abc",
+            // userinfo 部に discord.com を置いた実ホスト evil.com
+            "https://discord.com@evil.com/api/webhooks/123/abc",
+        ).forEach { url ->
+            assertThrows<WolfMansionValidationException> { request(url).validatedWebhookUrl() }
+        }
+    }
+
+    @Test
+    fun `URL として不正な文字列は 400 (ValidationException)`() {
+        listOf(
+            "not a url",
+            "https://",
+        ).forEach { url ->
+            assertThrows<WolfMansionValidationException> { request(url).validatedWebhookUrl() }
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/ort/app/domain/model/discord/DiscordWebhookUrlTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/domain/model/discord/DiscordWebhookUrlTest.kt
@@ -1,0 +1,63 @@
+package com.ort.app.domain.model.discord
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class DiscordWebhookUrlTest {
+    @Test
+    fun `正規の Discord Webhook URL は valid`() {
+        listOf(
+            "https://discord.com/api/webhooks/123/abc",
+            "https://discordapp.com/api/webhooks/123/abc",
+            "https://ptb.discord.com/api/webhooks/123/abc",
+            "https://canary.discord.com/api/webhooks/123/abc",
+        ).forEach { url ->
+            assertTrue(DiscordWebhookUrl.isValid(url), url)
+        }
+    }
+
+    @Test
+    fun `Discord 以外のホストは invalid`() {
+        listOf(
+            "https://example.com/api/webhooks/123/abc",
+            "https://169.254.169.254/latest/meta-data/",
+            "https://localhost:8089/wolf-mansion/",
+        ).forEach { url ->
+            assertFalse(DiscordWebhookUrl.isValid(url), url)
+        }
+    }
+
+    @Test
+    fun `https 以外のスキームは invalid`() {
+        listOf(
+            "http://discord.com/api/webhooks/123/abc",
+            "ftp://discord.com/api/webhooks/123/abc",
+        ).forEach { url ->
+            assertFalse(DiscordWebhookUrl.isValid(url), url)
+        }
+    }
+
+    @Test
+    fun `ホスト偽装を狙った URL は invalid`() {
+        listOf(
+            // suffix が似ているだけの別ドメイン
+            "https://evildiscord.com/api/webhooks/123/abc",
+            "https://discord.com.evil.com/api/webhooks/123/abc",
+            // userinfo 部に discord.com を置いた実ホスト evil.com
+            "https://discord.com@evil.com/api/webhooks/123/abc",
+        ).forEach { url ->
+            assertFalse(DiscordWebhookUrl.isValid(url), url)
+        }
+    }
+
+    @Test
+    fun `URL として不正な文字列は invalid`() {
+        listOf(
+            "not a url",
+            "https://",
+        ).forEach { url ->
+            assertFalse(DiscordWebhookUrl.isValid(url), url)
+        }
+    }
+}


### PR DESCRIPTION
## 目的

REST API 認可監査 (PR #136) で検出した low 指摘 L-3 の対応 (Issue 11)。

通知設定の `webhookUrl` は `@NotBlank` のみで URL 形式・ホストを検証しておらず、保存直後のテスト通知および以後の実ゲーム通知で任意 URL へサーバから外向き POST を発行できた (ブラインド SSRF)。内部サービスやメタデータエンドポイント (例: `169.254.169.254`) を標的にされうるため、ホワイトリスト検証で塞ぐ。

## 変更内容

- ドメイン層に `DiscordWebhookUrl.isValid()` を追加。https かつホストが `discord.com` / `discordapp.com` (サブドメイン `ptb.` / `canary.` 等含む) 以外を不正と判定
- **保存時**: `VillageNotificationRequest.validatedWebhookUrl()` が前後空白を trim して検証し、不正なら `WolfMansionValidationException` → 400 (validation_error / fieldErrors)。`VillageNotificationRestController.save` で保存・テスト通知の前に実行
- **送信時 (defense in depth)**: 検証導入前に保存された既存 URL への手当てとして、`DiscordRepositoryImpl.postToWebhook` でも同じ検証を行い、不正 URL はスキップ + warn ログ (URL 自体はログに出さない)
- 単体テスト追加: `DiscordWebhookUrlTest` (正規 URL 通過 / 他ホスト・他スキーム・ホスト偽装 (`discord.com@evil.com` の userinfo トリック、`evildiscord.com` 等)・不正文字列の拒否) / `VillageNotificationRequestTest` (例外変換・trim)

## 動作確認

- `cd backend && ./gradlew ktlintCheck` / `./gradlew test` green (82 テスト、失敗 0)
- ローカル稼働 backend (8089) に対して実測:
  - master でログイン → `POST /api/v1/villages/88/notification-setting` に `webhookUrl=http://169.254.169.254/latest/meta-data/` → **400** (validation_error, fieldErrors に webhookUrl)。DB 未更新
  - `webhookUrl=https://discord.com/api/webhooks/123/...` (前後空白付き) → **204**、trim 済みの値が `village_player_notification.discord_webhook_url` に保存されることを DB で確認 (確認後テストデータは削除済み)
  - ローカル DB の既存 `discord_webhook_url` に Discord 以外のホストが無いことを棚卸し済み (0 件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)