### PR TITLE
refactor: UI 色トークンを意味ベースに再編し hex 直書きを排除 (Step 12.1)

### DIFF
--- a/frontend/app/app.css
+++ b/frontend/app/app.css
@@ -5,13 +5,39 @@
     ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
     "Noto Color Emoji";
 
-  /* WOLF MANSION ブランド配色 (既存 bootstrap-override.css 由来。`:8091` 忠実再現用トークン) */
-  --color-wm-base: #222222; /* ページ全体の地色 (既存 body 背景) */
+  /* WOLF MANSION ブランド配色 */
+  --color-wm-base: #222222; /* ページ全体の地色 (body 背景) */
   --color-wm-band: #333333; /* メニュー帯・タイル枠 */
   --color-wm-tile: #0b162a; /* タイル背景 */
   --color-wm-tile-hover: #22224a; /* タイル hover 背景 */
   --color-wm-accent: #0ce3ac; /* アクセント (hover 文字・枠 / 誰歓タグ) */
-  --color-wm-danger: #ff0000; /* R15/R18 タグ・ロゴの赤 */
+  --color-wm-danger: #ff0000; /* R15/R18 タグ・ロゴの赤・未投票警告 */
+
+  /*
+   * 意味ベースの UI トークン。
+   * 発言 (メッセージ) の背景色・文字色はゲーム上の意味を持つ学習資産のためトークン化しない
+   * (messageStyles.ts / MessageBubble.tsx / SystemMessage.tsx に hex 直書きのまま保持する)。
+   */
+  --color-surface: #303030; /* パネル・モーダル本体の背景 */
+  --color-surface-raised: #464545; /* パネルヘッダー・タブ・デフォルトボタン等の持ち上がった面 */
+  --color-surface-alt: #3a3a3a; /* テーブルヘッダー等の淡い持ち上げ */
+  --color-surface-dim: #2a2a2a; /* 縞テーブルの片側の行等の沈んだ面 */
+  --color-border: #464545; /* 標準の境界線 */
+  --color-border-soft: #cccccc; /* 白地の上の淡い境界線 */
+  --color-success: #00bc8c; /* 主ボタン・成功 */
+  --color-success-light: #00dba3; /* success の hover / active */
+  --color-success-dark: #009c6c; /* success 面同士の区切り線 */
+  --color-success-muted: #007053; /* success 系の無効状態 */
+  --color-success-tint: #334033; /* 成功通知の背景 (濃緑) */
+  --color-danger: #e74c3c; /* 危険ボタン・エラー文字 */
+  --color-danger-soft: #d9534f; /* 強調文字の赤 (判定表・ルール強調) */
+  --color-info: #3498db;
+  --color-warning: #f39c12;
+  --color-warning-soft: #f0ad4e; /* 強調文字の橙 (判定表) */
+  --color-ink: #555555; /* 白地フォーム部品の上の文字 */
+  --color-ink-strong: #464545; /* 白地フォーム部品の上の文字 (濃) */
+  --color-attention: #ffff00; /* 返信引用・プレビューの注意枠 */
+  --color-disabled: #aaaaaa; /* 無効化された入力の背景 */
 
   --font-size-village-sm: 0.75em;
 }

--- a/frontend/app/app.css
+++ b/frontend/app/app.css
@@ -23,7 +23,7 @@
   --color-surface-alt: #3a3a3a; /* テーブルヘッダー等の淡い持ち上げ */
   --color-surface-dim: #2a2a2a; /* 縞テーブルの片側の行等の沈んだ面 */
   --color-border: #464545; /* 標準の境界線 */
-  --color-border-soft: #cccccc; /* 白地の上の淡い境界線 */
+  --color-border-soft: #cccccc; /* ダーク面上の淡い区切り線 (チェックリストの行区切り等) */
   --color-success: #00bc8c; /* 主ボタン・成功 */
   --color-success-light: #00dba3; /* success の hover / active */
   --color-success-dark: #009c6c; /* success 面同士の区切り線 */

--- a/frontend/app/components/layout/Footer.tsx
+++ b/frontend/app/components/layout/Footer.tsx
@@ -9,7 +9,7 @@ const footerLink = "cursor-pointer text-wm-accent hover:underline";
 const modalLink = "text-wm-accent hover:underline";
 // 投げ銭モーダルの導線ボタン (既存 btn-sm btn-success)。
 const successBtn =
-  "inline-block rounded bg-[#00bc8c] px-3 py-1 text-[13px] text-white hover:opacity-90";
+  "inline-block rounded bg-success px-3 py-1 text-[13px] text-white hover:opacity-90";
 
 export function Footer({ noAd = false }: { noAd?: boolean }) {
   const [kampaOpen, setKampaOpen] = useState(false);
@@ -83,7 +83,7 @@ function KampaContent() {
           </a>
         </div>
       </section>
-      <hr className="border-[#464545]" />
+      <hr className="border-border" />
       <section>
         <h4 className="font-bold">Amazonギフト券（Eメールタイプ）を送る</h4>
         <ul className="list-disc pl-5">
@@ -103,7 +103,7 @@ function KampaContent() {
           </a>
         </div>
       </section>
-      <hr className="border-[#464545]" />
+      <hr className="border-border" />
       <section>
         <h4 className="font-bold">Amazonアソシエイト経由で買い物をする</h4>
         <ul className="list-disc pl-5">
@@ -117,7 +117,7 @@ function KampaContent() {
           </a>
         </div>
       </section>
-      <hr className="border-[#464545]" />
+      <hr className="border-border" />
       <section>
         <h4 className="font-bold">Pixiv Fanbox</h4>
         <div className="text-right">
@@ -126,7 +126,7 @@ function KampaContent() {
           </a>
         </div>
       </section>
-      <hr className="border-[#464545]" />
+      <hr className="border-border" />
       <section>
         <h4 className="font-bold">補足</h4>
         <ul className="list-disc pl-5">

--- a/frontend/app/components/ui/Alert.tsx
+++ b/frontend/app/components/ui/Alert.tsx
@@ -2,14 +2,14 @@ import type { ReactNode } from "react";
 
 export function ErrorMessage({ error }: { error: string | null }) {
   if (error == null) return null;
-  return <p className="text-[#e74c3c]">{error}</p>;
+  return <p className="text-danger">{error}</p>;
 }
 
 type AlertVariant = "info" | "warning" | "default";
 
 const variantStyles: Record<AlertVariant, string> = {
-  info: "border-[#3498db] text-[#3498db]",
-  warning: "border-[#f39c12] text-[#f39c12]",
+  info: "border-info text-info",
+  warning: "border-warning text-warning",
   default: "border-white",
 };
 

--- a/frontend/app/components/ui/Button.tsx
+++ b/frontend/app/components/ui/Button.tsx
@@ -5,10 +5,10 @@ type ButtonVariant = "success" | "default" | "danger" | "info";
 type ButtonSize = "sm" | "xs";
 
 const variantStyle: Record<ButtonVariant, string> = {
-  success: "border-[#00bc8c] bg-[#00bc8c]",
-  default: "border-[#464545] bg-[#464545]",
-  danger: "border-[#e74c3c] bg-[#e74c3c]",
-  info: "border-[#3498db] bg-[#3498db]",
+  success: "border-success bg-success",
+  default: "border-border bg-surface-raised",
+  danger: "border-danger bg-danger",
+  info: "border-info bg-info",
 };
 
 const sizeStyle: Record<ButtonSize, string> = {

--- a/frontend/app/components/ui/Button.tsx
+++ b/frontend/app/components/ui/Button.tsx
@@ -6,7 +6,7 @@ type ButtonSize = "sm" | "xs";
 
 const variantStyle: Record<ButtonVariant, string> = {
   success: "border-success bg-success",
-  default: "border-border bg-surface-raised",
+  default: "border-surface-raised bg-surface-raised",
   danger: "border-danger bg-danger",
   info: "border-info bg-info",
 };

--- a/frontend/app/components/ui/ButtonCheckboxGroup.tsx
+++ b/frontend/app/components/ui/ButtonCheckboxGroup.tsx
@@ -5,10 +5,10 @@ export type ButtonCheckboxOption<T> = {
 };
 
 const buttonClass = (selected: boolean) =>
-  `not-first:-ml-px flex-1 cursor-pointer border border-[#00bc8c] px-[9px] py-[5px] text-[13px] first:rounded-l-[3px] last:rounded-r-[3px] hover:opacity-90 ${
+  `not-first:-ml-px flex-1 cursor-pointer border border-success px-[9px] py-[5px] text-[13px] first:rounded-l-[3px] last:rounded-r-[3px] hover:opacity-90 ${
     selected
-      ? "bg-[#00bc8c] text-white shadow-[inset_0_3px_5px_rgba(0,0,0,0.125)]"
-      : "bg-[#222222] text-[#00bc8c]"
+      ? "bg-success text-white shadow-[inset_0_3px_5px_rgba(0,0,0,0.125)]"
+      : "bg-wm-base text-success"
   }`;
 
 /**

--- a/frontend/app/components/ui/ButtonRadioGroup.tsx
+++ b/frontend/app/components/ui/ButtonRadioGroup.tsx
@@ -8,15 +8,15 @@ export type ButtonRadioOption<T> = {
 type ButtonRadioVariant = "solid" | "outline";
 
 const solidButtonClass = (selected: boolean) =>
-  `border-r border-white/20 bg-[#00bc8c] px-[9px] py-[5px] text-[13px] text-white last:border-r-0 hover:opacity-90 ${
+  `border-r border-white/20 bg-success px-[9px] py-[5px] text-[13px] text-white last:border-r-0 hover:opacity-90 ${
     selected ? "shadow-[inset_0_3px_5px_rgba(0,0,0,0.225)] brightness-90" : ""
   }`;
 
 const outlineButtonClass = (selected: boolean) =>
-  `not-first:-ml-px border border-[#00bc8c] px-[9px] py-[5px] text-[13px] first:rounded-l-[3px] last:rounded-r-[3px] hover:opacity-90 ${
+  `not-first:-ml-px border border-success px-[9px] py-[5px] text-[13px] first:rounded-l-[3px] last:rounded-r-[3px] hover:opacity-90 ${
     selected
-      ? "bg-[#00bc8c] text-white shadow-[inset_0_3px_5px_rgba(0,0,0,0.125)]"
-      : "bg-[#222222] text-[#00bc8c]"
+      ? "bg-success text-white shadow-[inset_0_3px_5px_rgba(0,0,0,0.125)]"
+      : "bg-wm-base text-success"
   }`;
 
 const buttonClass: Record<ButtonRadioVariant, (selected: boolean) => string> = {

--- a/frontend/app/components/ui/CollapsiblePanel.tsx
+++ b/frontend/app/components/ui/CollapsiblePanel.tsx
@@ -13,8 +13,8 @@ export function CollapsiblePanel({
   const [open, setOpen] = useState(defaultOpen);
   const bodyId = useId();
   return (
-    <div className="mb-[15px] rounded border border-[#464545] bg-[#303030]">
-      <div className="rounded-t bg-[#464545] px-[15px] py-[10px]">
+    <div className="mb-[15px] rounded border border-border bg-surface">
+      <div className="rounded-t bg-surface-raised px-[15px] py-[10px]">
         <button
           type="button"
           aria-expanded={open}

--- a/frontend/app/components/ui/Divider.tsx
+++ b/frontend/app/components/ui/Divider.tsx
@@ -1,4 +1,4 @@
 /** セクション区切りの罫線。 */
 export function Divider() {
-  return <hr className="my-[21px] border-[#464545]" />;
+  return <hr className="my-[21px] border-border" />;
 }

--- a/frontend/app/components/ui/FileUpload.tsx
+++ b/frontend/app/components/ui/FileUpload.tsx
@@ -107,7 +107,7 @@ export function FileUpload({
       {children}
       <div
         className={`flex cursor-pointer flex-col items-center rounded border-2 border-dashed px-[10px] py-[15px] text-center transition-colors ${
-          dragging ? "border-[#00bc8c] bg-[#00bc8c]/10" : "border-gray-500 hover:border-gray-400"
+          dragging ? "border-success bg-success/10" : "border-gray-500 hover:border-gray-400"
         }`}
         onClick={() => inputRef.current?.click()}
         onDragOver={handleDragOver}
@@ -135,7 +135,7 @@ export function FileUpload({
               <p className="text-[13px]">{fileName}</p>
               <button
                 type="button"
-                className="mt-[3px] text-[12px] text-[#e74c3c] hover:underline"
+                className="mt-[3px] text-[12px] text-danger hover:underline"
                 onClick={(e) => {
                   e.stopPropagation();
                   clear();
@@ -151,7 +151,7 @@ export function FileUpload({
           </p>
         )}
       </div>
-      {error && <div className="text-[13px] text-[#e74c3c]">{error}</div>}
+      {error && <div className="text-[13px] text-danger">{error}</div>}
     </div>
   );
 }

--- a/frontend/app/components/ui/Input.tsx
+++ b/frontend/app/components/ui/Input.tsx
@@ -3,7 +3,7 @@
  * フォーム部品はダークテーマ画面共通でこれを使う。
  */
 
-const baseClass = "rounded border border-gray-400 bg-white px-[10px] py-[5px] text-[#555555]";
+const baseClass = "rounded border border-gray-400 bg-white px-[10px] py-[5px] text-ink";
 
 /** 1 行テキスト入力 (フォーム行いっぱいに広げる)。 */
 export const inputClass = `min-h-[30px] w-full ${baseClass}`;

--- a/frontend/app/components/ui/Modal.tsx
+++ b/frontend/app/components/ui/Modal.tsx
@@ -41,10 +41,10 @@ export function Modal({
       <div
         // 既存 (:8091 の bootstrap modal・ダークテーマ) に合わせる:
         // ダイアログ #303030 / 白文字 / border 1px rgba(0,0,0,.2) / radius 6px、区切り線 #464545。
-        className={`my-8 w-full ${sizeClass[size]} rounded-[6px] border border-black/20 bg-[#303030] text-white shadow-lg`}
+        className={`my-8 w-full ${sizeClass[size]} rounded-[6px] border border-black/20 bg-surface text-white shadow-lg`}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between border-b border-[#464545] p-[15px]">
+        <div className="flex items-center justify-between border-b border-border p-[15px]">
           <h4 className="text-lg font-bold">{title}</h4>
           <button
             type="button"

--- a/frontend/app/components/ui/Modal.tsx
+++ b/frontend/app/components/ui/Modal.tsx
@@ -39,8 +39,6 @@ export function Modal({
       }}
     >
       <div
-        // 既存 (:8091 の bootstrap modal・ダークテーマ) に合わせる:
-        // ダイアログ #303030 / 白文字 / border 1px rgba(0,0,0,.2) / radius 6px、区切り線 #464545。
         className={`my-8 w-full ${sizeClass[size]} rounded-[6px] border border-black/20 bg-surface text-white shadow-lg`}
         onClick={(e) => e.stopPropagation()}
       >

--- a/frontend/app/components/ui/MultiSelect.tsx
+++ b/frontend/app/components/ui/MultiSelect.tsx
@@ -22,7 +22,7 @@ export function MultiSelect({
       aria-label={ariaLabel}
       value={value}
       onChange={(e) => onChange(Array.from(e.target.selectedOptions, (o) => o.value))}
-      className="h-[74px] w-full rounded border border-gray-400 bg-white px-[10px] py-[5px] text-[#555555]"
+      className="h-[74px] w-full rounded border border-gray-400 bg-white px-[10px] py-[5px] text-ink"
     >
       {options.map((o) => (
         <option key={o.value} value={o.value}>

--- a/frontend/app/components/ui/Pagination.tsx
+++ b/frontend/app/components/ui/Pagination.tsx
@@ -1,12 +1,12 @@
 import type { ReactNode } from "react";
 
 const itemBaseClass =
-  "-ml-px rounded-none border border-transparent px-[14px] py-[2px] text-white border-l-[#009c6c] mb-[2px]";
+  "-ml-px rounded-none border border-transparent px-[14px] py-[2px] text-white border-l-success-dark mb-[2px]";
 
 export const paginationStyles = {
-  enabled: `${itemBaseClass} cursor-pointer bg-[#00bc8c] hover:bg-[#00dba3]`,
-  active: `${itemBaseClass} bg-[#00dba3]`,
-  disabled: `${itemBaseClass} cursor-not-allowed bg-[#007053]`,
+  enabled: `${itemBaseClass} cursor-pointer bg-success hover:bg-success-light`,
+  active: `${itemBaseClass} bg-success-light`,
+  disabled: `${itemBaseClass} cursor-not-allowed bg-success-muted`,
 };
 
 export function Pagination({

--- a/frontend/app/components/ui/Panel.tsx
+++ b/frontend/app/components/ui/Panel.tsx
@@ -55,7 +55,7 @@ function useStorageString(key: string): string {
 
 export function Panel({
   title,
-  headerClassName = "bg-[#464545]",
+  headerClassName = "bg-surface-raised",
   headerExtra,
   storageKey,
   defaultOpen = true,
@@ -92,7 +92,7 @@ export function Panel({
 
   return (
     <div
-      className={`mb-[20px] rounded border border-[#464545] bg-[#303030] ${isFixed ? bottomFixedPanelClass : ""}`}
+      className={`mb-[20px] rounded border border-border bg-surface ${isFixed ? bottomFixedPanelClass : ""}`}
     >
       <div className={`flex items-center rounded-t px-[15px] py-[10px] ${headerClassName}`}>
         <div className="flex-1">

--- a/frontend/app/components/ui/Toast.tsx
+++ b/frontend/app/components/ui/Toast.tsx
@@ -40,9 +40,9 @@ export const useToast = create<ToastState>((set) => ({
 }));
 
 const VARIANT_STYLE: Record<ToastItem["variant"], string> = {
-  success: "bg-[#00bc8c]",
-  info: "bg-[#3498db]",
-  error: "bg-[#e74c3c]",
+  success: "bg-success",
+  info: "bg-info",
+  error: "bg-danger",
 };
 
 function ToastEntry({ item }: { item: ToastItem }) {

--- a/frontend/app/features/village-form/RandomOrganizationTable.tsx
+++ b/frontend/app/features/village-form/RandomOrganizationTable.tsx
@@ -4,8 +4,8 @@ import { fieldErrorClass } from "~/components/ui/Form";
 import { inlineInputClass } from "~/components/ui/Input";
 import type { CampAllocationInput, NewVillageFormInput } from "./schema";
 
-const headerTdClass = "bg-[#e74c3c] text-white";
-const campTdClass = "bg-[#3498db] text-white";
+const headerTdClass = "bg-danger text-white";
+const campTdClass = "bg-info text-white";
 
 /** 配分セル (数値入力 + エラー表示)。 */
 function AllocationCell({
@@ -36,7 +36,7 @@ function AllocationCell({
 /** 闇鍋編成の配分テーブル (人狼カウント + 陣営ごと + 役職ごと)。 */
 export function RandomOrganizationTable({ camps }: { camps: CampAllocationInput[] }) {
   return (
-    <table className="border-collapse text-[10.32px] [&_td]:border [&_td]:border-[#464545] [&_td]:p-[5px]">
+    <table className="border-collapse text-[10.32px] [&_td]:border [&_td]:border-border [&_td]:p-[5px]">
       <tbody>
         <tr>
           <td className={headerTdClass} colSpan={9}>

--- a/frontend/app/features/village-form/SayRestrictionTable.tsx
+++ b/frontend/app/features/village-form/SayRestrictionTable.tsx
@@ -10,11 +10,11 @@ export type SayRestrictRowLabel = { key: string; label: string };
 
 const tableClass =
   "border-collapse text-[10.32px] " +
-  "[&_th]:border [&_th]:border-[#464545] [&_th]:p-[5px] [&_th]:text-left [&_th]:align-middle " +
-  "[&_td]:border [&_td]:border-[#464545] [&_td]:p-[5px] [&_td]:align-middle";
+  "[&_th]:border [&_th]:border-border [&_th]:p-[5px] [&_th]:text-left [&_th]:align-middle " +
+  "[&_td]:border [&_td]:border-border [&_td]:p-[5px] [&_td]:align-middle";
 
 const numberInputClass =
-  "h-[30px] w-[135px] bg-white px-[10px] py-[5px] text-[#464545] disabled:bg-[#aaaaaa]";
+  "h-[30px] w-[135px] bg-white px-[10px] py-[5px] text-ink-strong disabled:bg-disabled";
 
 function toNullableNumber(value: unknown): number | null {
   return value === "" || value == null ? null : Number(value);
@@ -87,7 +87,7 @@ function SayRestrictRow({
             aria-label={`${label} 発言文字数`}
             {...register(`${name}.${index}.length`, { setValueAs: toNullableNumber })}
           />
-          <span className="flex items-center bg-[#464545] p-[5px] text-[12px]">{" * "}</span>
+          <span className="flex items-center bg-surface-raised p-[5px] text-[12px]">{" * "}</span>
           <input
             type="number"
             className={`${numberInputClass} rounded-r-[4px]`}

--- a/frontend/app/features/village-form/fields.tsx
+++ b/frontend/app/features/village-form/fields.tsx
@@ -10,7 +10,7 @@ import type { NewVillageFormInput } from "./schema";
 
 /** 村作成後に変更できない項目に付ける印。 */
 export function RequiredAfterCreationMark() {
-  return <span className="text-[#e74c3c]">*</span>;
+  return <span className="text-danger">*</span>;
 }
 
 /** 区切り線 + セクション見出し。 */

--- a/frontend/app/features/village/components/ActionPanels.tsx
+++ b/frontend/app/features/village/components/ActionPanels.tsx
@@ -68,7 +68,7 @@ export function ActionPanels({
     <>
       {mySituation?.say.isAvailableSay && (
         <div id="say-panel">
-          {sayError != null && <p className="mb-[5px] text-[#e74c3c]">{sayError}</p>}
+          {sayError != null && <p className="mb-[5px] text-danger">{sayError}</p>}
           <SayPanel
             mySituation={mySituation}
             reply={reply}

--- a/frontend/app/features/village/components/RoomGrid.tsx
+++ b/frontend/app/features/village/components/RoomGrid.tsx
@@ -39,7 +39,9 @@ export function RoomGrid({
                       : room.roomNumber
                   }
                   style={{
-                    border: isSelected(room) ? "2px solid #0ce3ac" : "1px solid #464545",
+                    border: isSelected(room)
+                      ? "2px solid var(--color-wm-accent)"
+                      : "1px solid var(--color-border)",
                     width: room.charaImgWidth ?? 50,
                     height: room.charaImgHeight ?? 60,
                     ...(room.charaImgUrl
@@ -64,7 +66,7 @@ export function RoomGrid({
                 >
                   <span
                     className="whitespace-nowrap"
-                    style={{ backgroundColor: "#222222", opacity: 0.8 }}
+                    style={{ backgroundColor: "var(--color-wm-base)", opacity: 0.8 }}
                   >
                     {room.roomNumber} {room.charaShortName ?? ""}
                   </span>

--- a/frontend/app/features/village/components/RoomGrid.tsx
+++ b/frontend/app/features/village/components/RoomGrid.tsx
@@ -20,7 +20,7 @@ export function RoomGrid({
   onRoomClick: (room: VillageRoomAssigned) => void;
 }) {
   return (
-    <table className="border-collapse border border-[#464545] text-village-sm">
+    <table className="border-collapse border border-border text-village-sm">
       <tbody>
         {rows.map((row, rowIndex) => (
           <tr key={rowIndex}>

--- a/frontend/app/features/village/components/action/ActionPanel.tsx
+++ b/frontend/app/features/village/components/action/ActionPanel.tsx
@@ -72,13 +72,13 @@ export function ActionPanel({
         </select>
         <input
           type="text"
-          className="mt-[10px] w-full rounded border border-[#464545] bg-white p-[6px] text-[#555]"
+          className="mt-[10px] w-full rounded border border-border bg-white p-[6px] text-ink"
           value={message}
           onChange={(e) => setMessage(e.target.value)}
           aria-label="アクション本文"
           placeholder="自由入力"
         />
-        <div className={`mt-[5px] ${overLimit ? "text-[#e74c3c]" : ""}`}>
+        <div className={`mt-[5px] ${overLimit ? "text-danger" : ""}`}>
           {leftCount != null && maxCount != null && `残り${leftCount}/${maxCount}回, `}
           文字数: {totalLength}/{maxLength}
         </div>

--- a/frontend/app/features/village/components/action/SayPanel.tsx
+++ b/frontend/app/features/village/components/action/SayPanel.tsx
@@ -227,10 +227,10 @@ export function SayPanel({
                 <button
                   key={t.code}
                   type="button"
-                  className={`not-first:-ml-px cursor-pointer border border-[#00bc8c] px-[9px] py-[5px] first:rounded-l-[3px] last:rounded-r-[3px] hover:opacity-90 ${
+                  className={`not-first:-ml-px cursor-pointer border border-success px-[9px] py-[5px] first:rounded-l-[3px] last:rounded-r-[3px] hover:opacity-90 ${
                     active
-                      ? "bg-[#00bc8c] text-white shadow-[inset_0_3px_5px_rgba(0,0,0,0.125)]"
-                      : "bg-[#222222] text-[#00bc8c]"
+                      ? "bg-success text-white shadow-[inset_0_3px_5px_rgba(0,0,0,0.125)]"
+                      : "bg-wm-base text-success"
                   }`}
                   onClick={() => changeType(t.code)}
                 >
@@ -271,7 +271,7 @@ export function SayPanel({
               <button
                 key={tag.name}
                 type="button"
-                className="not-first:-ml-px cursor-pointer border border-[#00bc8c] bg-[#222222] px-[9px] py-[5px] text-[#00bc8c] first:rounded-l-[3px] last:rounded-r-[3px] hover:opacity-90"
+                className="not-first:-ml-px cursor-pointer border border-success bg-wm-base px-[9px] py-[5px] text-success first:rounded-l-[3px] last:rounded-r-[3px] hover:opacity-90"
                 style={tag.color != null ? { color: tag.color } : undefined}
                 onClick={() => addDecoration(tag.name)}
               >
@@ -280,7 +280,7 @@ export function SayPanel({
             ))}
             <button
               type="button"
-              className="not-first:-ml-px cursor-pointer border border-[#00bc8c] bg-[#222222] px-[9px] py-[5px] text-[#00bc8c] first:rounded-l-[3px] last:rounded-r-[3px] hover:opacity-90"
+              className="not-first:-ml-px cursor-pointer border border-success bg-wm-base px-[9px] py-[5px] text-success first:rounded-l-[3px] last:rounded-r-[3px] hover:opacity-90"
               onClick={() => insertAtCursor("[[]]")}
             >
               [[]]
@@ -321,7 +321,7 @@ export function SayPanel({
           </div>
           <textarea
             ref={textareaRef}
-            className={`ml-[5px] min-h-[150px] flex-1 rounded border border-[#464545] p-[9px] font-[sans-serif] ${textareaStyle}`}
+            className={`ml-[5px] min-h-[150px] flex-1 rounded border border-border p-[9px] font-[sans-serif] ${textareaStyle}`}
             value={message}
             onChange={(e) => setMessage(e.target.value)}
             aria-label="発言"
@@ -330,7 +330,7 @@ export function SayPanel({
 
         {/* 文字数・行数・残数 / 装飾・変換無効 / 確認画面へ */}
         <div className="mt-[5px]" style={{ marginLeft: (myself?.chara.size.width ?? 55) + 5 }}>
-          <span className={overLimit ? "text-[#e74c3c]" : ""}>
+          <span className={overLimit ? "text-danger" : ""}>
             {leftCount != null && maxCount != null && `残り${leftCount}/${maxCount}回, `}
             文字数: {length}/{maxLength}, 行数: {lineCount}/{maxLine}
           </span>
@@ -357,7 +357,7 @@ export function SayPanel({
 
         {/* 返信元の引用 */}
         {reply != null && (
-          <div className="mt-[5px] rounded border border-[#ffff00] bg-[#303030] p-[10px]">
+          <div className="mt-[5px] rounded border border-attention bg-surface p-[10px]">
             <div className="mb-[5px] flex justify-end">
               <Button variant="default" size="xs" onClick={onClearReply}>
                 ×
@@ -373,7 +373,7 @@ export function SayPanel({
           onClick={() => setFaceModalOpen(false)}
         >
           <div
-            className="my-8 w-full max-w-lg rounded-[6px] border border-black/20 bg-[#303030] p-[15px] text-white shadow-lg"
+            className="my-8 w-full max-w-lg rounded-[6px] border border-black/20 bg-surface p-[15px] text-white shadow-lg"
             onClick={(e) => e.stopPropagation()}
           >
             <h4 className="mb-[10px] font-bold">表情選択</h4>
@@ -381,7 +381,7 @@ export function SayPanel({
               {displayImages.map((image) => (
                 <div
                   key={image.faceType.code}
-                  className="inline-block border border-[#464545] p-[5px] text-center"
+                  className="inline-block border border-border p-[5px] text-center"
                 >
                   <img
                     src={image.url}

--- a/frontend/app/features/village/components/action/SayPreviewArea.tsx
+++ b/frontend/app/features/village/components/action/SayPreviewArea.tsx
@@ -57,7 +57,7 @@ export function SayPreviewArea({
   return (
     <div
       id="message-confirm-area"
-      className="mb-[20px] rounded border border-[#ffff00] bg-[#303030] p-[10px]"
+      className="mb-[20px] rounded border border-attention bg-surface p-[10px]"
     >
       <p className="mb-[10px]">以下の内容で発言してよろしいですか？（まだ発言されていません）</p>
       <MessageCard message={preview.message} randomKeywords={randomKeywords} />

--- a/frontend/app/features/village/components/action/VotePanel.tsx
+++ b/frontend/app/features/village/components/action/VotePanel.tsx
@@ -49,7 +49,7 @@ export function VotePanel({
       title="投票"
       storageKey="voteform"
       fixable
-      headerClassName={isUnset ? "bg-[#ff0000]" : "bg-[#464545]"}
+      headerClassName={isUnset ? "bg-wm-danger" : "bg-surface-raised"}
       headerExtra={isUnset ? "(未セットのままだと突然死します)" : null}
     >
       <div className="space-y-[10px]">
@@ -60,7 +60,7 @@ export function VotePanel({
             ? resolveParticipantName(village, vote.targetCharaId)
             : "なし"}
         </p>
-        <hr className="border-[#464545]" />
+        <hr className="border-border" />
         <p>一番票を集めた人物が処刑されます。同数の場合はランダムで決定されます。</p>
         <div>
           <div className="flex items-center gap-[5px]">

--- a/frontend/app/features/village/components/admin/AdminPanel.tsx
+++ b/frontend/app/features/village/components/admin/AdminPanel.tsx
@@ -103,20 +103,18 @@ function PlayersSection() {
           </Button>
         </div>
         {players != null && (
-          <table className="mt-[10px] w-full border-collapse border border-[#464545]">
+          <table className="mt-[10px] w-full border-collapse border border-border">
             <thead>
               <tr>
-                <th className="border border-[#464545] px-[8px] py-[4px] text-left">キャラ名</th>
-                <th className="border border-[#464545] px-[8px] py-[4px] text-left">
-                  プレイヤー名
-                </th>
+                <th className="border border-border px-[8px] py-[4px] text-left">キャラ名</th>
+                <th className="border border-border px-[8px] py-[4px] text-left">プレイヤー名</th>
               </tr>
             </thead>
             <tbody>
               {players.players.map((p) => (
                 <tr key={p.charaName}>
-                  <td className="border border-[#464545] px-[8px] py-[4px]">{p.charaName}</td>
-                  <td className="border border-[#464545] px-[8px] py-[4px]">{p.playerName}</td>
+                  <td className="border border-border px-[8px] py-[4px]">{p.charaName}</td>
+                  <td className="border border-border px-[8px] py-[4px]">{p.playerName}</td>
                 </tr>
               ))}
             </tbody>

--- a/frontend/app/features/village/components/admin/CreatorPanel.tsx
+++ b/frontend/app/features/village/components/admin/CreatorPanel.tsx
@@ -88,12 +88,12 @@ function KickSection() {
     <div className="space-y-[10px]">
       <ErrorMessage error={error} />
       <VillageFormRow label="最終アクセス日時" align="start">
-        <table className="w-full border-collapse border border-[#464545]">
+        <table className="w-full border-collapse border border-border">
           <tbody>
             {members.map((m) => (
               <tr key={m.charaName}>
-                <td className="border border-[#464545] px-[8px] py-[4px]">{m.charaName}</td>
-                <td className="border border-[#464545] px-[8px] py-[4px]">{m.lastAccess ?? ""}</td>
+                <td className="border border-border px-[8px] py-[4px]">{m.charaName}</td>
+                <td className="border border-border px-[8px] py-[4px]">{m.lastAccess ?? ""}</td>
               </tr>
             ))}
           </tbody>
@@ -183,7 +183,7 @@ function CreatorSaySection({
       <ErrorMessage error={error} />
       <VillageFormRow label="村建て発言" align="start">
         <textarea
-          className="min-h-[77px] w-full rounded border border-[#464545] bg-white p-[9px] font-[sans-serif] text-[#555]"
+          className="min-h-[77px] w-full rounded border border-border bg-white p-[9px] font-[sans-serif] text-ink"
           rows={5}
           value={message}
           onChange={(e) => setMessage(e.target.value)}
@@ -193,7 +193,7 @@ function CreatorSaySection({
       <VillageFormRow>
         <div className="flex items-center justify-between">
           <div>
-            <span className={overLimit ? "text-[#e74c3c]" : ""}>
+            <span className={overLimit ? "text-danger" : ""}>
               文字数: {length}/{maxLength}, 行数: {lineCount}/{maxLine}
             </span>
             <label className="ml-[10px] inline-flex cursor-pointer items-center gap-[5px]">

--- a/frontend/app/features/village/components/analyzer/AnalyzerFootsteps.tsx
+++ b/frontend/app/features/village/components/analyzer/AnalyzerFootsteps.tsx
@@ -14,7 +14,7 @@ function FootstepRow({
 }) {
   return (
     <tr>
-      <td className="w-[28px] border border-[#464545] p-[3px] text-center align-middle">
+      <td className="w-[28px] border border-border p-[3px] text-center align-middle">
         <input
           type="checkbox"
           checked={fs.show}
@@ -23,15 +23,15 @@ function FootstepRow({
         />
       </td>
       <td
-        className="min-w-[100px] border border-[#464545] p-[3px] align-middle text-village-sm whitespace-nowrap"
+        className="min-w-[100px] border border-border p-[3px] align-middle text-village-sm whitespace-nowrap"
         style={{ color: `#${fs.color}` }}
       >
         {fs.footstep}
       </td>
-      <td className="w-[34px] border border-[#464545] p-[3px] text-center align-middle">
+      <td className="w-[34px] border border-border p-[3px] text-center align-middle">
         <ColorPicker value={fs.color} onChange={(color) => onChange({ ...fs, color })} />
       </td>
-      <td className="border border-[#464545] p-[3px] align-middle">
+      <td className="border border-border p-[3px] align-middle">
         <input
           type="text"
           value={fs.memo}

--- a/frontend/app/features/village/components/analyzer/AnalyzerRoomGrid.tsx
+++ b/frontend/app/features/village/components/analyzer/AnalyzerRoomGrid.tsx
@@ -128,7 +128,7 @@ export function AnalyzerRoomGrid({
                     return (
                       <td
                         key={room.roomNumber}
-                        className={`relative border border-[#464545] p-0 text-center ${room.participantId != null ? "cursor-pointer" : ""}`}
+                        className={`relative border border-border p-0 text-center ${room.participantId != null ? "cursor-pointer" : ""}`}
                         style={{ width: cellW, minWidth: cellW, height: cellH }}
                         onClick={() =>
                           room.participantId != null && onParticipantClick(room.participantId)

--- a/frontend/app/features/village/components/analyzer/AnalyzerTab.tsx
+++ b/frontend/app/features/village/components/analyzer/AnalyzerTab.tsx
@@ -181,7 +181,7 @@ export function AnalyzerTab({ situation: initialSituation }: { situation: Villag
       )}
 
       {/* Bottom section: Vote + Whole memo */}
-      <div className="mt-[10px] border-t border-[#464545]">
+      <div className="mt-[10px] border-t border-border">
         <div className="flex flex-col lg:flex-row lg:gap-[10px]">
           {initialSituation.vote != null && (
             <div className="min-w-0 flex-shrink-0 lg:max-w-[60%]">

--- a/frontend/app/features/village/components/analyzer/ColorPicker.tsx
+++ b/frontend/app/features/village/components/analyzer/ColorPicker.tsx
@@ -24,11 +24,11 @@ export function ColorPicker({
       <button
         type="button"
         onClick={() => setShowPalette((v) => !v)}
-        className="h-[24px] w-[24px] cursor-pointer rounded border border-[#464545]"
+        className="h-[24px] w-[24px] cursor-pointer rounded border border-border"
         style={{ backgroundColor: `#${value}` }}
       />
       {showPalette && (
-        <div className="absolute top-[30px] left-0 z-10 flex gap-[3px] rounded border border-[#464545] bg-[#303030] p-[6px]">
+        <div className="absolute top-[30px] left-0 z-10 flex gap-[3px] rounded border border-border bg-surface p-[6px]">
           {TEMPLATE_COLORS.map((c) => (
             <button
               key={c}
@@ -37,14 +37,14 @@ export function ColorPicker({
                 onChange(c);
                 setShowPalette(false);
               }}
-              className="h-[20px] w-[20px] cursor-pointer rounded-[2px] border border-[#464545]"
+              className="h-[20px] w-[20px] cursor-pointer rounded-[2px] border border-border"
               style={{ backgroundColor: `#${c}` }}
             />
           ))}
           <button
             type="button"
             onClick={() => inputRef.current?.click()}
-            className="flex h-[20px] w-[20px] cursor-pointer items-center justify-center rounded-[2px] border border-[#464545] bg-[#404040] text-[10px] text-white"
+            className="flex h-[20px] w-[20px] cursor-pointer items-center justify-center rounded-[2px] border border-border bg-[#404040] text-[10px] text-white"
             title="カスタム色"
           >
             ...

--- a/frontend/app/features/village/components/analyzer/ParticipantMemoModal.tsx
+++ b/frontend/app/features/village/components/analyzer/ParticipantMemoModal.tsx
@@ -45,7 +45,7 @@ export function ParticipantMemoModal({
         value={memo?.memo ?? ""}
         onChange={(e) => update({ memo: e.target.value })}
         rows={5}
-        className="mb-[10px] w-full rounded border border-[#464545] bg-[#303030] p-[8px] text-village-sm text-white"
+        className="mb-[10px] w-full rounded border border-border bg-surface p-[8px] text-village-sm text-white"
         placeholder="メモを入力..."
       />
       <div className="flex justify-end">

--- a/frontend/app/features/village/components/info/MemberListTab.tsx
+++ b/frontend/app/features/village/components/info/MemberListTab.tsx
@@ -2,7 +2,7 @@ import type { VillageParticipantView } from "~/features/village/api";
 import { useVillageContext } from "~/features/village/VillageContext";
 import { allParticipants, compareByRoomNumber } from "~/features/village/participants";
 
-const cellBorderClass = "border border-[#464545]";
+const cellBorderClass = "border border-border";
 
 type MemberGroup = {
   status: string;

--- a/frontend/app/features/village/components/info/ParticipantsTable.tsx
+++ b/frontend/app/features/village/components/info/ParticipantsTable.tsx
@@ -3,7 +3,7 @@ import { UserPageLink } from "../message/MessageCard";
 
 type VillageParticipantView = components["schemas"]["VillageParticipantView"];
 
-const cellBorderClass = "border border-[#464545]";
+const cellBorderClass = "border border-border";
 
 function deadStatus(p: VillageParticipantView): string {
   if (p.isSpectator) return "";

--- a/frontend/app/features/village/components/info/RoomAssignedTab.tsx
+++ b/frontend/app/features/village/components/info/RoomAssignedTab.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import type { VillageRoomAssignedRow, VillageSituationContent } from "~/features/village/api";
 import { deadMark } from "./dead";
 
-const cellBorderClass = "border border-[#464545]";
+const cellBorderClass = "border border-border";
 
 /** 役職名は 5 文字を超えると先頭 4 文字 + 省略記号にする (部屋セル幅に収めるため)。 */
 function shortenSkillName(skillName: string): string {

--- a/frontend/app/features/village/components/info/SituationPanel.tsx
+++ b/frontend/app/features/village/components/info/SituationPanel.tsx
@@ -59,9 +59,9 @@ export function SituationPanel({
 
   return (
     <div
-      className={`mb-[20px] rounded border border-[#464545] bg-[#303030] ${isFixed ? bottomFixedPanelClass : ""}`}
+      className={`mb-[20px] rounded border border-border bg-surface ${isFixed ? bottomFixedPanelClass : ""}`}
     >
-      <div className="flex items-center rounded-t bg-[#464545] px-[15px] py-[10px]">
+      <div className="flex items-center rounded-t bg-surface-raised px-[15px] py-[10px]">
         <div className="flex-1">
           <button
             type="button"
@@ -87,7 +87,7 @@ export function SituationPanel({
       >
         <div className="overflow-hidden">
           <div className="p-[15px]">
-            <ul className="flex flex-wrap border-b border-[#464545]">
+            <ul className="flex flex-wrap border-b border-border">
               {tabs.map((tab) => (
                 <li key={tab.key} className="-mb-px">
                   <button
@@ -95,8 +95,8 @@ export function SituationPanel({
                     onClick={() => setActiveTab(tab.key)}
                     className={`mr-[2px] block rounded-t-[4px] border px-[10px] py-[8px] text-[13px] sm:px-[15px] sm:py-[10px] sm:text-[14px] ${
                       activeTab === tab.key
-                        ? "bg-wm-base border-[#464545] border-b-transparent text-[#00bc8c]"
-                        : "text-wm-accent cursor-pointer border-transparent hover:border-[#464545] hover:bg-[#303030]"
+                        ? "bg-wm-base border-border border-b-transparent text-success"
+                        : "text-wm-accent cursor-pointer border-transparent hover:border-border hover:bg-surface"
                     }`}
                   >
                     {tab.label}

--- a/frontend/app/features/village/components/info/VoteTab.tsx
+++ b/frontend/app/features/village/components/info/VoteTab.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState } from "react";
 import type { VillageRoomAssignedRow, VillageVoteContent } from "~/features/village/api";
 import { RoomLegend } from "./RoomLegend";
 
-const cellBorderClass = "border border-[#464545]";
+const cellBorderClass = "border border-border";
 
 /**
  * 投票表。日付見出しをクリックするとその日の投票先でソートし、セルをクリックすると
@@ -83,9 +83,7 @@ export function VoteTab({
               <tr key={member.charaName}>
                 <td
                   className={`${cellBorderClass} cursor-pointer p-[5px] ${
-                    highlightTarget != null && member.charaName === highlightTarget
-                      ? "bg-[#3498db]"
-                      : ""
+                    highlightTarget != null && member.charaName === highlightTarget ? "bg-info" : ""
                   }`}
                   onClick={() => onCellClick(member.charaName ?? "")}
                 >
@@ -95,7 +93,7 @@ export function VoteTab({
                   <td
                     key={targetIndex}
                     className={`${cellBorderClass} cursor-pointer p-[5px] ${
-                      highlightTarget != null && target === highlightTarget ? "bg-[#3498db]" : ""
+                      highlightTarget != null && target === highlightTarget ? "bg-info" : ""
                     }`}
                     onClick={() => onCellClick(target)}
                   >

--- a/frontend/app/features/village/components/layout/FooterMenu.tsx
+++ b/frontend/app/features/village/components/layout/FooterMenu.tsx
@@ -15,7 +15,7 @@ import {
 } from "~/features/village/useVillageScroll";
 
 const buttonBaseClass =
-  "flex flex-1 items-center justify-center gap-[2px] border border-[#00bc8c] px-[5px] py-[10px] min-[768px]:py-[4px] first:rounded-l-[3px] last:rounded-r-[3px]";
+  "flex flex-1 items-center justify-center gap-[2px] border border-success px-[5px] py-[10px] min-[768px]:py-[4px] first:rounded-l-[3px] last:rounded-r-[3px]";
 
 function MenuButton({
   icon,
@@ -35,8 +35,8 @@ function MenuButton({
     <button
       type="button"
       className={`${buttonBaseClass} ${
-        active ? "bg-[#00bc8c] text-white" : "bg-wm-base text-[#00bc8c]"
-      } ${disabled ? "opacity-50" : "cursor-pointer hover:bg-[#00bc8c] hover:text-white"}`}
+        active ? "bg-success text-white" : "bg-wm-base text-success"
+      } ${disabled ? "opacity-50" : "cursor-pointer hover:bg-success hover:text-white"}`}
       onClick={onClick}
       disabled={disabled}
     >
@@ -90,7 +90,7 @@ export function FooterMenu({
 
   return (
     <div id={FOOTER_MENU_ID} ref={rootRef} className="fixed bottom-0 left-0 z-20 w-screen">
-      <div className="flex rounded-[4px] bg-[#303030] p-[3px] pb-[calc(3px+env(safe-area-inset-bottom))] pl-[calc(3px+env(safe-area-inset-left))] pr-[calc(3px+env(safe-area-inset-right))]">
+      <div className="flex rounded-[4px] bg-surface p-[3px] pb-[calc(3px+env(safe-area-inset-bottom))] pl-[calc(3px+env(safe-area-inset-left))] pr-[calc(3px+env(safe-area-inset-right))]">
         <MenuButton
           icon={<ArrowUpIcon className={iconClass} />}
           label="最上部へ"

--- a/frontend/app/features/village/components/layout/LeftTime.tsx
+++ b/frontend/app/features/village/components/layout/LeftTime.tsx
@@ -10,7 +10,7 @@ export function LeftTime() {
 
   if (leftTime == null) return null;
   return (
-    <div className="fixed top-[5px] right-[5px] z-[100] rounded bg-[#3498db] p-[5px] text-white">
+    <div className="fixed top-[5px] right-[5px] z-[100] rounded bg-info p-[5px] text-white">
       更新まで <span>{leftTime}</span>
     </div>
   );

--- a/frontend/app/features/village/components/message/MessageArea.tsx
+++ b/frontend/app/features/village/components/message/MessageArea.tsx
@@ -91,7 +91,7 @@ export function MessageArea({
 
   return (
     <div className="relative">
-      {showOverlay && <div className="absolute inset-0 z-10 bg-[#222222]/60" />}
+      {showOverlay && <div className="absolute inset-0 z-10 bg-wm-base/60" />}
       <MessagePagination content={data} onChange={setPage} />
       {(data.messageList ?? []).map((message, index) => (
         <MessageCard

--- a/frontend/app/features/village/components/message/MessageCard.tsx
+++ b/frontend/app/features/village/components/message/MessageCard.tsx
@@ -127,14 +127,11 @@ export function MessageCard({
       {expandedAnchors
         .filter((a) => a.visible)
         .map((a) => (
-          <div
-            key={a.key}
-            className="mb-[10px] rounded border border-[#464545] bg-[#303030] p-[10px]"
-          >
+          <div key={a.key} className="mb-[10px] rounded border border-border bg-surface p-[10px]">
             <div className="flex justify-end">
               <button
                 type="button"
-                className="cursor-pointer rounded border border-[#464545] bg-[#464545] px-[8px] py-[2px] text-white"
+                className="cursor-pointer rounded border border-border bg-surface-raised px-[8px] py-[2px] text-white"
                 onClick={() =>
                   setExpandedAnchors((prev) =>
                     prev.map((x) => (x.key === a.key ? { ...x, visible: false } : x)),

--- a/frontend/app/features/village/components/message/MessageCard.tsx
+++ b/frontend/app/features/village/components/message/MessageCard.tsx
@@ -131,7 +131,7 @@ export function MessageCard({
             <div className="flex justify-end">
               <button
                 type="button"
-                className="cursor-pointer rounded border border-border bg-surface-raised px-[8px] py-[2px] text-white"
+                className="cursor-pointer rounded border border-surface-raised bg-surface-raised px-[8px] py-[2px] text-white"
                 onClick={() =>
                   setExpandedAnchors((prev) =>
                     prev.map((x) => (x.key === a.key ? { ...x, visible: false } : x)),

--- a/frontend/app/features/village/components/modal/AgeLimitModal.tsx
+++ b/frontend/app/features/village/components/modal/AgeLimitModal.tsx
@@ -52,10 +52,10 @@ export function AgeLimitModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="mx-[10px] w-full max-w-[600px] rounded border border-[#464545] bg-[#303030] p-[15px] text-white">
+      <div className="mx-[10px] w-full max-w-[600px] rounded border border-border bg-surface p-[15px] text-white">
         <h5 className="mb-[10px] text-[14px]">年齢制限確認</h5>
         <p className="mb-[15px]">
-          この村は年齢制限が <strong className="text-[20px] text-[#e74c3c]">{ageLimit}</strong>{" "}
+          この村は年齢制限が <strong className="text-[20px] text-danger">{ageLimit}</strong>{" "}
           に設定されており、
           <br />
           暴力表現や性描写などが含まれる可能性があります。

--- a/frontend/app/features/village/components/modal/FilterModal.tsx
+++ b/frontend/app/features/village/components/modal/FilterModal.tsx
@@ -103,11 +103,11 @@ function ParticipantCheckList({
           反転
         </TextButton>
       </div>
-      <div className="grid grid-cols-1 border-b border-[#ccc] min-[768px]:grid-cols-2 min-[1200px]:grid-cols-3">
+      <div className="grid grid-cols-1 border-b border-border-soft min-[768px]:grid-cols-2 min-[1200px]:grid-cols-3">
         {participants.map((participant) => (
           <label
             key={participant.id}
-            className="flex cursor-pointer items-center border-t border-[#ccc] px-[10px] py-[5px]"
+            className="flex cursor-pointer items-center border-t border-border-soft px-[10px] py-[5px]"
           >
             <input
               type="checkbox"
@@ -129,7 +129,7 @@ function ParticipantCheckList({
               <p
                 className={
                   participant.deadStatus !== "生存" && participant.deadStatus !== "見学"
-                    ? "text-[#e74c3c]"
+                    ? "text-danger"
                     : ""
                 }
               >
@@ -232,7 +232,7 @@ export function FilterModal({
               </>
             )}
           </div>
-          <hr className="my-[15px] border-[#464545]" />
+          <hr className="my-[15px] border-border" />
         </div>
 
         <div className="mt-[15px]">

--- a/frontend/app/features/village/components/modal/SettingsModal.tsx
+++ b/frontend/app/features/village/components/modal/SettingsModal.tsx
@@ -48,7 +48,7 @@ function CheckRow({
 function SectionTitle({ children }: { children: ReactNode }) {
   return (
     <>
-      <hr className="my-[15px] border-[#464545]" />
+      <hr className="my-[15px] border-border" />
       <h5 className="mb-[10px] text-[14px] font-bold">{children}</h5>
     </>
   );
@@ -135,7 +135,7 @@ export function SettingsModal({
 
         {mySituation?.myself != null && <NotificationSection mySituation={mySituation} />}
 
-        <hr className="my-[15px] border-[#464545]" />
+        <hr className="my-[15px] border-border" />
         <div className="flex justify-end">
           <Button variant="default" onClick={onClose}>
             閉じる
@@ -187,10 +187,10 @@ function NotificationSection({ mySituation }: { mySituation: ParticipantSituatio
 
   return (
     <div className="space-y-[10px]">
-      <hr className="my-[15px] border-[#464545]" />
+      <hr className="my-[15px] border-border" />
       <h4 className="text-[16px] font-bold">Discord通知設定</h4>
       <ErrorMessage error={error} />
-      {saved && <p className="text-[#00bc8c]">保存しました。テスト通知を確認してください。</p>}
+      {saved && <p className="text-success">保存しました。テスト通知を確認してください。</p>}
       <SettingRow label="WebhookURL">
         <input
           type="text"

--- a/frontend/app/features/village/components/modal/VillageInfoModal.tsx
+++ b/frontend/app/features/village/components/modal/VillageInfoModal.tsx
@@ -7,10 +7,10 @@ import type { VillageSettingsContent } from "~/features/village/api";
 import { useVillageContext } from "~/features/village/VillageContext";
 import { formatStartDatetime } from "~/lib/datetime";
 
-const thClass = "w-[40%] border border-[#464545] bg-[#3a3a3a] p-[5px] text-left align-top";
-const tdClass = "border border-[#464545] p-[5px]";
-const innerThClass = "border border-[#464545] bg-[#3a3a3a] p-[3px] text-left";
-const innerTdClass = "border border-[#464545] p-[3px]";
+const thClass = "w-[40%] border border-border bg-surface-alt p-[5px] text-left align-top";
+const tdClass = "border border-border p-[5px]";
+const innerThClass = "border border-border bg-surface-alt p-[3px] text-left";
+const innerTdClass = "border border-border p-[3px]";
 
 export function Row({ label, children }: { label: string; children: ReactNode }) {
   return (
@@ -72,7 +72,7 @@ function RandomOrganizationTable({ settings }: { settings: VillageSettingsConten
     <table className="border-collapse text-[10.32px]">
       <tbody>
         <tr>
-          <td className="border border-[#464545] bg-[#e74c3c] p-[3px] text-white" colSpan={9}>
+          <td className="border border-border bg-danger p-[3px] text-white" colSpan={9}>
             <strong>人狼カウント</strong>
           </td>
         </tr>
@@ -87,7 +87,7 @@ function RandomOrganizationTable({ settings }: { settings: VillageSettingsConten
         {(settings.campAllocationList ?? []).map((camp) => (
           <Fragment key={camp.campCode}>
             <tr>
-              <td className="border border-[#464545] bg-[#3498db] p-[3px] text-white" colSpan={9}>
+              <td className="border border-border bg-info p-[3px] text-white" colSpan={9}>
                 <strong>{camp.campName}</strong>
               </td>
             </tr>

--- a/frontend/app/features/village/components/participate/InitialSkillModal.tsx
+++ b/frontend/app/features/village/components/participate/InitialSkillModal.tsx
@@ -60,7 +60,7 @@ export function InitialSkillModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/50 p-4">
-      <div className="my-8 w-full max-w-lg rounded-[6px] border border-black/20 bg-[#303030] p-[15px] text-[12px] text-white shadow-lg">
+      <div className="my-8 w-full max-w-lg rounded-[6px] border border-black/20 bg-surface p-[15px] text-[12px] text-white shadow-lg">
         <h5 className="mb-[10px] text-[14px] font-bold">
           村が開始されました。役職とルールは以下の通りです。
         </h5>

--- a/frontend/app/features/village/components/participate/ParticipatePanel.tsx
+++ b/frontend/app/features/village/components/participate/ParticipatePanel.tsx
@@ -152,7 +152,7 @@ export function ParticipatePanel({ mySituation }: { mySituation: ParticipantSitu
   return (
     <Panel title="入村" storageKey="participateform">
       <div className="space-y-[10px]">
-        {participateError != null && <p className="mb-[5px] text-[#e74c3c]">{participateError}</p>}
+        {participateError != null && <p className="mb-[5px] text-danger">{participateError}</p>}
         {participate.isAvailableSpectate && (
           <VillageFormRow label="見学" labelWidth="wide">
             <label className="flex cursor-pointer items-center gap-[5px]">
@@ -301,7 +301,7 @@ export function ParticipatePanel({ mySituation }: { mySituation: ParticipantSitu
             aria-label="入村発言"
             placeholder="人狼なんているわけないじゃん。みんな大げさだなあ"
           />
-          <div className={`mt-[3px] ${overLimit ? "text-[#e74c3c]" : ""}`}>
+          <div className={`mt-[3px] ${overLimit ? "text-danger" : ""}`}>
             文字数: {length}/400, 行数: {lineCount}/20
           </div>
         </VillageFormRow>
@@ -341,13 +341,13 @@ export function ParticipatePanel({ mySituation }: { mySituation: ParticipantSitu
           onClick={() => setCharaModalOpen(false)}
         >
           <div
-            className="my-8 w-full max-w-2xl rounded-[6px] border border-black/20 bg-[#303030] p-[15px] text-white shadow-lg"
+            className="my-8 w-full max-w-2xl rounded-[6px] border border-black/20 bg-surface p-[15px] text-white shadow-lg"
             onClick={(e) => e.stopPropagation()}
           >
             <h4 className="mb-[10px] font-bold">キャラクター選択</h4>
             <div className="grid grid-cols-2 gap-[5px] sm:grid-cols-3">
               {charas.map((c) => (
-                <div key={c.id} className="border border-[#464545] p-[5px] text-center">
+                <div key={c.id} className="border border-border p-[5px] text-center">
                   <div className="flex justify-center">
                     <img
                       src={defaultImageUrl(c)}
@@ -384,7 +384,7 @@ export function ParticipatePanel({ mySituation }: { mySituation: ParticipantSitu
           onClick={() => setStep("input")}
         >
           <div
-            className="my-8 w-full max-w-2xl rounded-[6px] border border-black/20 bg-[#303030] p-[15px] text-white shadow-lg"
+            className="my-8 w-full max-w-2xl rounded-[6px] border border-black/20 bg-surface p-[15px] text-white shadow-lg"
             onClick={(e) => e.stopPropagation()}
           >
             <h4 className="mb-[10px] font-bold">入村確認</h4>

--- a/frontend/app/routes/change-password.tsx
+++ b/frontend/app/routes/change-password.tsx
@@ -50,7 +50,7 @@ function ChangePasswordForm() {
   return (
     <AuthLayout title="パスワード変更">
       {done && (
-        <p className="mb-4 rounded bg-[#334033] px-3 py-2 text-wm-accent">
+        <p className="mb-4 rounded bg-success-tint px-3 py-2 text-wm-accent">
           パスワードを変更しました。
         </p>
       )}

--- a/frontend/app/routes/chara-group-detail/route.tsx
+++ b/frontend/app/routes/chara-group-detail/route.tsx
@@ -69,7 +69,7 @@ function CharaGroupDetailContent({ charachipId }: { charachipId: number }) {
           {charachip.charas.list.map((chara) => (
             <div
               key={chara.id}
-              className="box-border w-full border border-[#464545] p-[5px] min-[768px]:w-1/2"
+              className="box-border w-full border border-border p-[5px] min-[768px]:w-1/2"
             >
               <span className="block text-center">
                 {chara.images.list.map((img, i) => (
@@ -137,7 +137,7 @@ function RoomAssignmentTable({
               return (
                 <td
                   key={cell.roomNumber}
-                  className="relative border border-[#464545] p-0 text-center align-middle"
+                  className="relative border border-border p-0 text-center align-middle"
                   style={{
                     width: `${maxWidth}px`,
                     minWidth: `${maxWidth}px`,
@@ -154,7 +154,7 @@ function RoomAssignmentTable({
                     }}
                   />
                   <div className="absolute bottom-0 left-1/2 -translate-x-1/2 opacity-80">
-                    <span className="whitespace-nowrap bg-[#222222]">
+                    <span className="whitespace-nowrap bg-wm-base">
                       {String(cell.roomNumber).padStart(2, "0")} {cell.chara?.shortName ?? ""}
                     </span>
                   </div>

--- a/frontend/app/routes/chara-group/route.tsx
+++ b/frontend/app/routes/chara-group/route.tsx
@@ -22,29 +22,27 @@ export default function CharaGroupList() {
             <table className="w-full border-collapse text-xs">
               <thead>
                 <tr>
-                  <th className="border border-[#464545] p-[5px] align-middle">キャラチップ名</th>
-                  <th className="border border-[#464545] p-[5px] align-middle">作者名</th>
-                  <th className="border border-[#464545] p-[5px] align-middle">
+                  <th className="border border-border p-[5px] align-middle">キャラチップ名</th>
+                  <th className="border border-border p-[5px] align-middle">作者名</th>
+                  <th className="border border-border p-[5px] align-middle">
                     キャラ
                     <br />
                     チップ数
                   </th>
-                  <th className="border border-[#464545] p-[5px] align-middle">例</th>
+                  <th className="border border-border p-[5px] align-middle">例</th>
                 </tr>
               </thead>
               <tbody>
                 {charachips.map((chip) => (
                   <tr key={chip.id}>
-                    <td className="border border-[#464545] p-[5px] align-middle">
+                    <td className="border border-border p-[5px] align-middle">
                       <TextLink to={`/chara-group/${chip.id}`}>{chip.name}</TextLink>
                     </td>
-                    <td className="border border-[#464545] p-[5px] align-middle">
+                    <td className="border border-border p-[5px] align-middle">
                       {chip.designerName}
                     </td>
-                    <td className="border border-[#464545] p-[5px] align-middle">
-                      {chip.charaNum}人
-                    </td>
-                    <td className="border border-[#464545] p-[5px] align-middle">
+                    <td className="border border-border p-[5px] align-middle">{chip.charaNum}人</td>
+                    <td className="border border-border p-[5px] align-middle">
                       <img
                         src={chip.dummyImgUrl}
                         width={chip.dummyImgWidth}

--- a/frontend/app/routes/faq/route.tsx
+++ b/frontend/app/routes/faq/route.tsx
@@ -176,11 +176,11 @@ function FaqItem({ q, a }: { q: ReactNode | ReactNode[]; a: ReactNode }) {
     <div className="mb-[10px]">
       {questions.map((question, i) => (
         <Fragment key={i}>
-          <span className={`${iconStyle} bg-[#3498db]`}>Q</span>
+          <span className={`${iconStyle} bg-info`}>Q</span>
           <p className="mb-[10.5px] pl-[25px]">{question}</p>
         </Fragment>
       ))}
-      <span className={`${iconStyle} bg-[#e74c3c]`}>A</span>
+      <span className={`${iconStyle} bg-danger`}>A</span>
       <p className="mb-[10.5px] pl-[25px]">{a}</p>
     </div>
   );

--- a/frontend/app/routes/new-village/ConfirmModal.tsx
+++ b/frontend/app/routes/new-village/ConfirmModal.tsx
@@ -9,13 +9,13 @@ import type { NewVillageFormInput } from "~/features/village-form/schema";
 
 const tableClass =
   "w-full border-collapse " +
-  "[&_th]:border [&_th]:border-[#464545] [&_th]:p-[5px] [&_th]:text-left [&_th]:align-middle " +
-  "[&_td]:border [&_td]:border-[#464545] [&_td]:p-[5px] [&_td]:align-middle";
+  "[&_th]:border [&_th]:border-border [&_th]:p-[5px] [&_th]:text-left [&_th]:align-middle " +
+  "[&_td]:border [&_td]:border-border [&_td]:p-[5px] [&_td]:align-middle";
 
 const nestedTableClass =
   "border-collapse text-[10.32px] " +
-  "[&_th]:border [&_th]:border-[#464545] [&_th]:p-[5px] [&_th]:text-left [&_th]:align-middle " +
-  "[&_td]:border [&_td]:border-[#464545] [&_td]:p-[5px] [&_td]:align-middle";
+  "[&_th]:border [&_th]:border-border [&_th]:p-[5px] [&_th]:text-left [&_th]:align-middle " +
+  "[&_td]:border [&_td]:border-border [&_td]:p-[5px] [&_td]:align-middle";
 
 function pad2(value: number): string {
   return String(value).padStart(2, "0");
@@ -117,7 +117,7 @@ function ReadOnlyRandomOrganizationTable({ values }: { values: NewVillageFormInp
     <table className={nestedTableClass}>
       <tbody>
         <tr>
-          <td className="bg-[#e74c3c] text-white" colSpan={9}>
+          <td className="bg-danger text-white" colSpan={9}>
             <strong>人狼カウント</strong>
           </td>
         </tr>
@@ -141,7 +141,7 @@ function ReadOnlyCampRows({ camp }: { camp: NewVillageFormInput["campAllocationL
   return (
     <>
       <tr>
-        <td className="bg-[#3498db] text-white" colSpan={9}>
+        <td className="bg-info text-white" colSpan={9}>
           <strong>{camp.campName}</strong>
         </td>
       </tr>

--- a/frontend/app/routes/random-message/route.tsx
+++ b/frontend/app/routes/random-message/route.tsx
@@ -16,8 +16,8 @@ export function meta(_: Route.MetaArgs) {
 /** 折りたたみ時に表示する変換後文字列の行数。 */
 const VISIBLE_LINES = 5;
 
-const thClass = "border border-[#464545] p-[5px] text-left align-bottom";
-const cellClass = "border border-[#464545] p-[5px]";
+const thClass = "border border-border p-[5px] text-left align-bottom";
+const cellClass = "border border-border p-[5px]";
 
 /** 変換後文字列セル。先頭 5 行のみ表示し、残りは「全て表示」で展開する。 */
 function ContentCell({ keyword }: { keyword: RandomKeyword }) {

--- a/frontend/app/routes/rule/route.tsx
+++ b/frontend/app/routes/rule/route.tsx
@@ -108,7 +108,7 @@ export default function RulePage() {
 
 function TableOfContents({ campGroups }: { campGroups: CampGroup[] }) {
   return (
-    <div className="rounded bg-[#303030] px-[5px] pt-[5px] pb-[15px]">
+    <div className="rounded bg-surface px-[5px] pt-[5px] pb-[15px]">
       <ul className="list-none pl-0">
         <li>
           <a href="#basic" className="text-wm-accent hover:underline">
@@ -297,7 +297,7 @@ function JudgeSection({ judges }: { judges: JudgeView[] }) {
     <div id="judge" className="overflow-x-auto">
       <table className="w-full border-collapse text-[12px]">
         <thead>
-          <tr className="border-b border-[#464545]">
+          <tr className="border-b border-border">
             <th className="p-[5px] text-left align-middle">役職</th>
             <th className="p-[5px] text-left align-middle">占結果</th>
             <th className="p-[5px] text-left align-middle">霊結果</th>
@@ -311,7 +311,7 @@ function JudgeSection({ judges }: { judges: JudgeView[] }) {
         </thead>
         <tbody>
           {judges.map((judge, i) => (
-            <tr key={i} className="border-b border-[#464545]">
+            <tr key={i} className="border-b border-border">
               <td className="p-[5px] align-middle">
                 {judge.skills.map((skill, j) => (
                   <span key={skill.code}>
@@ -321,22 +321,22 @@ function JudgeSection({ judges }: { judges: JudgeView[] }) {
                 ))}
               </td>
               <td
-                className={`p-[5px] align-middle ${judge.divineResultWolf ? "text-[#d9534f]" : ""}`}
+                className={`p-[5px] align-middle ${judge.divineResultWolf ? "text-danger-soft" : ""}`}
               >
                 {judge.divineResultWolf ? "人狼" : "人間"}
               </td>
               <td
-                className={`p-[5px] align-middle ${judge.psychicResultWolf ? "text-[#d9534f]" : ""}`}
+                className={`p-[5px] align-middle ${judge.psychicResultWolf ? "text-danger-soft" : ""}`}
               >
                 {judge.psychicResultWolf ? "人狼" : "人間"}
               </td>
               <td
-                className={`p-[5px] align-middle ${judge.noDeadByAttack ? "text-[#f0ad4e]" : ""}`}
+                className={`p-[5px] align-middle ${judge.noDeadByAttack ? "text-warning-soft" : ""}`}
               >
                 {judge.noDeadByAttack ? "死亡しない" : "なし"}
               </td>
               <td
-                className={`p-[5px] align-middle ${judge.countType === "WOLF" ? "text-[#d9534f]" : judge.countType === "NO_COUNT" ? "text-[#f0ad4e]" : ""}`}
+                className={`p-[5px] align-middle ${judge.countType === "WOLF" ? "text-danger-soft" : judge.countType === "NO_COUNT" ? "text-warning-soft" : ""}`}
               >
                 {COUNT_TYPE_LABELS[judge.countType]}
               </td>

--- a/frontend/app/routes/rule/sections/CampSection.tsx
+++ b/frontend/app/routes/rule/sections/CampSection.tsx
@@ -17,14 +17,14 @@ function CampTable({ campGroups }: { campGroups: CampGroup[] }) {
       <h3 className="my-[10.5px] text-[14px] font-bold">陣営</h3>
       <table className="w-full border-collapse text-[12px]">
         <thead>
-          <tr className="border-b border-[#464545]">
+          <tr className="border-b border-border">
             <th className="p-[5px] text-left align-middle">陣営</th>
             <th className="p-[5px] text-left align-middle">陣営に所属する役職</th>
           </tr>
         </thead>
         <tbody>
           {campGroups.map((camp) => (
-            <tr key={camp.campCode} className="border-b border-[#464545]">
+            <tr key={camp.campCode} className="border-b border-border">
               <td className="p-[5px] align-middle">{camp.campName}</td>
               <td className="p-[5px] align-middle">
                 {camp.skills.map((skill, i) => (
@@ -66,7 +66,7 @@ function PersonalWinCondition() {
       <h3 className="my-[10.5px] text-[14px] font-bold">個人ごとの勝敗判定</h3>
       <table className="w-full border-collapse text-[12px]">
         <thead>
-          <tr className="border-b border-[#464545]">
+          <tr className="border-b border-border">
             <th className="p-[5px] text-left align-middle">
               個人ごとの勝敗判定（上にあるものほど優先度高）
             </th>
@@ -84,7 +84,7 @@ function PersonalWinCondition() {
             ["役職が愉快犯陣営に属している", "最後まで生存"],
             ["それ以外", "役職が属する陣営の勝利"],
           ].map(([condition, result]) => (
-            <tr key={condition} className="border-b border-[#464545]">
+            <tr key={condition} className="border-b border-border">
               <td className="p-[5px] align-middle">{condition}</td>
               <td className="p-[5px] align-middle">{result}</td>
             </tr>
@@ -101,12 +101,12 @@ function CampWinCondition() {
       <h3 className="my-[10.5px] text-[14px] font-bold">陣営の勝敗判定</h3>
       <table className="w-full border-collapse text-[12px]">
         <thead>
-          <tr className="border-b border-[#464545]">
+          <tr className="border-b border-border">
             <th colSpan={2} className="p-[5px] text-left align-middle">
               陣営の勝敗判定（同時に満たした場合は上にあるものほど優先度高）
             </th>
           </tr>
-          <tr className="border-b border-[#464545]">
+          <tr className="border-b border-border">
             <th className="p-[5px] text-left align-middle">陣営</th>
             <th className="p-[5px] text-left align-middle">勝利条件</th>
           </tr>
@@ -125,7 +125,7 @@ function CampWinCondition() {
               "なし（個人ごとに追加勝利判定を行うため、愉快犯陣営自体が勝利することはない）",
             ],
           ].map(([camp, condition]) => (
-            <tr key={camp} className="border-b border-[#464545]">
+            <tr key={camp} className="border-b border-border">
               <td className="p-[5px] align-middle">{camp}</td>
               <td className="p-[5px] align-middle">{condition}</td>
             </tr>

--- a/frontend/app/routes/rule/sections/MansionSection.tsx
+++ b/frontend/app/routes/rule/sections/MansionSection.tsx
@@ -5,7 +5,7 @@ export function MansionSection() {
   return (
     <ul id="mansion" className="mb-[10.5px] list-disc pl-[40px]">
       <li>
-        <strong className="text-[#d9534f]">
+        <strong className="text-danger-soft">
           全員に見える発言での推理発言、まとめ行為、CO禁止です。（グレラン村）
         </strong>
         <ul className="list-disc pl-[20px]">
@@ -13,7 +13,7 @@ export function MansionSection() {
         </ul>
       </li>
       <li>
-        <strong className="text-[#d9534f]">
+        <strong className="text-danger-soft">
           ただし、導師と探偵のみCOおよび能力行使結果を白ログで報告することができます。（結果騙りもOKとします。）
         </strong>
         <ul className="list-disc pl-[20px]">

--- a/frontend/app/routes/rule/sections/RoomSection.tsx
+++ b/frontend/app/routes/rule/sections/RoomSection.tsx
@@ -20,7 +20,7 @@ export function RoomSection() {
       <p className="mb-[10.5px]">21名〜99名の部屋構成については管理者までお問い合わせください。</p>
       <table className="w-full border-collapse text-[12px]">
         <thead>
-          <tr className="border-b border-[#464545]">
+          <tr className="border-b border-border">
             <th className="p-[5px] text-left align-middle">人数</th>
             <th className="p-[5px] text-left align-middle">
               空き部屋の位置
@@ -31,7 +31,7 @@ export function RoomSection() {
         </thead>
         <tbody>
           {ROOMS.map((room) => (
-            <tr key={room.count} className="border-b border-[#464545]">
+            <tr key={room.count} className="border-b border-border">
               <td className="p-[5px] align-middle">{room.count}</td>
               <td className="p-[5px] align-middle font-mono">
                 {room.layout.split("\n").map((line, i) => (

--- a/frontend/app/routes/rule/sections/StatusSection.tsx
+++ b/frontend/app/routes/rule/sections/StatusSection.tsx
@@ -176,7 +176,7 @@ export function StatusSection() {
 
 function StatusAlert({ text }: { text: string }) {
   return (
-    <div className="my-[5px] mb-[10px] rounded border border-[#00bc8c] p-[9px] text-[#00bc8c]">
+    <div className="my-[5px] mb-[10px] rounded border border-success p-[9px] text-success">
       {text}
     </div>
   );

--- a/frontend/app/routes/skill/SearchPanel.tsx
+++ b/frontend/app/routes/skill/SearchPanel.tsx
@@ -42,7 +42,7 @@ export function SearchPanel({
         <FormRow label="役職名" labelWidth="wide">
           <input
             type="text"
-            className="w-full rounded border-0 bg-white px-[12px] py-[6px] text-[#464545]"
+            className="w-full rounded border-0 bg-white px-[12px] py-[6px] text-ink-strong"
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="役職名（部分一致）"
@@ -57,7 +57,7 @@ export function SearchPanel({
                   type="button"
                   onClick={() => toggleTag(tag)}
                   className={`cursor-pointer rounded-[3px] px-[10px] py-[10px] text-[9px] leading-[9px] text-white ${
-                    selectedTags.includes(tag) ? "bg-[#00bc8c]" : "bg-[#464545]"
+                    selectedTags.includes(tag) ? "bg-success" : "bg-surface-raised"
                   }`}
                 >
                   {tag}
@@ -70,7 +70,7 @@ export function SearchPanel({
 
         <FormRow label="村に登場する役職" labelWidth="wide">
           <select
-            className="w-full rounded border-0 bg-white px-[12px] py-[6px] text-[#464545]"
+            className="w-full rounded border-0 bg-white px-[12px] py-[6px] text-ink-strong"
             value={villageId ?? ""}
             onChange={(e) => setVillageId(e.target.value ? Number(e.target.value) : null)}
           >

--- a/frontend/app/routes/skill/route.tsx
+++ b/frontend/app/routes/skill/route.tsx
@@ -90,7 +90,7 @@ function CampMenu({
   visibleCodes: Set<string> | null;
 }) {
   return (
-    <div className="rounded bg-[#303030] px-[5px] pt-[5px] pb-[15px]">
+    <div className="rounded bg-surface px-[5px] pt-[5px] pb-[15px]">
       {campGroups.map((camp) => {
         const visible = camp.skills.filter(
           (s) => visibleCodes === null || visibleCodes.has(s.code),

--- a/frontend/app/routes/user-list/route.tsx
+++ b/frontend/app/routes/user-list/route.tsx
@@ -47,15 +47,13 @@ export default function UserList() {
             <table className="w-full border-collapse text-[10.5px]">
               <thead>
                 <tr>
-                  <th className="border border-[#464545] p-[5px] text-left font-bold">
-                    ユーザー名
-                  </th>
+                  <th className="border border-border p-[5px] text-left font-bold">ユーザー名</th>
                 </tr>
               </thead>
               <tbody>
                 {players.map((p) => (
                   <tr key={p.name}>
-                    <td className="border border-[#464545] p-[5px]">
+                    <td className="border border-border p-[5px]">
                       <Link to={`/user/${p.name}`} className="text-wm-accent hover:underline">
                         {p.name}
                       </Link>

--- a/frontend/app/routes/user-profile/route.tsx
+++ b/frontend/app/routes/user-profile/route.tsx
@@ -71,7 +71,7 @@ function ProfileContent({
         </div>
       )}
       {data.introduction != null && (
-        <p className="mb-[10px] rounded border border-[#464545] p-[10px] whitespace-pre-line">
+        <p className="mb-[10px] rounded border border-border p-[10px] whitespace-pre-line">
           {data.introduction}
         </p>
       )}
@@ -173,7 +173,7 @@ function EditDetailModal({
   return (
     <Modal open title="自己紹介編集" onClose={onClose}>
       <div className="space-y-[15px]">
-        {error != null && <p className="text-[#e74c3c]">{error}</p>}
+        {error != null && <p className="text-danger">{error}</p>}
         <div>
           <label className="mb-[5px] block">Twitterユーザ名</label>
           <input
@@ -210,14 +210,14 @@ function formatRate(rate: number): string {
   return `${(rate * 100).toFixed(1)}%`;
 }
 
-const cellClass = "border border-[#464545] px-[8px] py-[4px]";
+const cellClass = "border border-border px-[8px] py-[4px]";
 const headerClass = `${cellClass} text-left`;
 const rightCellClass = `${cellClass} text-right`;
 
 function StatsTable({ rows }: { rows: { label: string; value: string }[] }) {
   return (
     <div className="mb-[10px] overflow-x-auto">
-      <table className="w-full border-collapse border border-[#464545]">
+      <table className="w-full border-collapse border border-border">
         <thead>
           <tr>
             <th className={headerClass}>項目</th>
@@ -226,7 +226,7 @@ function StatsTable({ rows }: { rows: { label: string; value: string }[] }) {
         </thead>
         <tbody>
           {rows.map((r) => (
-            <tr key={r.label} className="odd:bg-[#2a2a2a]">
+            <tr key={r.label} className="odd:bg-surface-dim">
               <td className={cellClass}>{r.label}</td>
               <td className={rightCellClass}>{r.value}</td>
             </tr>
@@ -240,7 +240,7 @@ function StatsTable({ rows }: { rows: { label: string; value: string }[] }) {
 function RecordTable({ headers, rows }: { headers: string[]; rows: string[][] }) {
   return (
     <div className="mb-[10px] overflow-x-auto">
-      <table className="w-full border-collapse border border-[#464545]">
+      <table className="w-full border-collapse border border-border">
         <thead>
           <tr>
             {headers.map((h, i) => (
@@ -252,7 +252,7 @@ function RecordTable({ headers, rows }: { headers: string[]; rows: string[][] })
         </thead>
         <tbody>
           {rows.map((row, i) => (
-            <tr key={i} className="odd:bg-[#2a2a2a]">
+            <tr key={i} className="odd:bg-surface-dim">
               {row.map((cell, j) => (
                 <td key={j} className={j === 0 ? cellClass : rightCellClass}>
                   {cell}
@@ -275,7 +275,7 @@ function VillageTable({
 }) {
   return (
     <div className="mb-[10px] overflow-x-auto">
-      <table className="min-w-full border-collapse border border-[#464545]">
+      <table className="min-w-full border-collapse border border-border">
         <thead>
           <tr>
             <th className={`${cellClass} text-right whitespace-nowrap`}>村番号</th>
@@ -293,7 +293,7 @@ function VillageTable({
         </thead>
         <tbody>
           {villages.map((v) => (
-            <tr key={v.villageId} className="odd:bg-[#2a2a2a]">
+            <tr key={v.villageId} className="odd:bg-surface-dim">
               <td className={`${rightCellClass} align-middle whitespace-nowrap`}>
                 <TextLink to={`/village/${v.villageId}`}>
                   {String(v.villageId).padStart(4, "0")}

--- a/frontend/app/routes/village-list/route.tsx
+++ b/frontend/app/routes/village-list/route.tsx
@@ -74,10 +74,10 @@ export default function VillageList() {
               </colgroup>
               <thead>
                 <tr>
-                  <th className="border border-[#464545] p-[5px] text-left font-bold">村番号</th>
-                  <th className="border border-[#464545] p-[5px] text-left font-bold">村名</th>
-                  <th className="border border-[#464545] p-[5px] text-left font-bold">人数</th>
-                  <th className="border border-[#464545] p-[5px] text-left font-bold">状態</th>
+                  <th className="border border-border p-[5px] text-left font-bold">村番号</th>
+                  <th className="border border-border p-[5px] text-left font-bold">村名</th>
+                  <th className="border border-border p-[5px] text-left font-bold">人数</th>
+                  <th className="border border-border p-[5px] text-left font-bold">状態</th>
                 </tr>
               </thead>
               <tbody>
@@ -94,7 +94,7 @@ export default function VillageList() {
 }
 
 function VillageRow({ village }: { village: SimpleVillageView }) {
-  const cell = "border border-[#464545] p-[5px]";
+  const cell = "border border-border p-[5px]";
   return (
     <tr>
       <td className={cell}>{villageNumber(village.id)}</td>

--- a/frontend/app/routes/village-message/route.tsx
+++ b/frontend/app/routes/village-message/route.tsx
@@ -59,7 +59,7 @@ export default function VillageMessagePermalink({ params }: Route.ComponentProps
             <h1 className="my-[10.5px] text-[15px] font-normal">
               {String(village.id).padStart(4, "0")}. {village.name}
             </h1>
-            <hr className="mt-[5px] mb-[10px] border-[#464545]" />
+            <hr className="mt-[5px] mb-[10px] border-border" />
             {(data?.messageList ?? []).map((message, index) => (
               <MessageCard
                 key={`${message.messageType}-${message.messageNumber ?? index}`}

--- a/frontend/app/routes/village-scrap/route.tsx
+++ b/frontend/app/routes/village-scrap/route.tsx
@@ -95,7 +95,7 @@ export default function VillageScrap({ params }: Route.ComponentProps) {
             <h1 className="my-[10.5px] text-[15px] font-normal">
               {String(village.id).padStart(4, "0")}. {village.name}
             </h1>
-            <hr className="mt-[5px] mb-[10px] border-[#464545]" />
+            <hr className="mt-[5px] mb-[10px] border-border" />
 
             {messages.map((message, index) => (
               <MessageCard

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -72,7 +72,7 @@ function XPostButton() {
       href={url}
       target="_blank"
       rel="noreferrer"
-      className="inline-flex items-center gap-[5px] rounded-full bg-black px-[12px] py-[4px] font-bold text-white hover:bg-[#333]"
+      className="inline-flex items-center gap-[5px] rounded-full bg-black px-[12px] py-[4px] font-bold text-white hover:bg-wm-band"
     >
       <svg viewBox="0 0 24 24" className="h-[14px] w-[14px] fill-current" aria-hidden="true">
         <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
@@ -220,7 +220,7 @@ export default function Village({ params }: Route.ComponentProps) {
                 <XPostButton />
               </div>
             </div>
-            <hr className="mt-[5px] mb-[10px] border-[#464545]" />
+            <hr className="mt-[5px] mb-[10px] border-border" />
 
             <DayList currentDay={currentDay} onInfo={() => setInfoOpen(true)} />
 
@@ -251,7 +251,7 @@ export default function Village({ params }: Route.ComponentProps) {
               />
             )}
             <div id="bottom" />
-            <hr className="mt-[5px] mb-[10px] border-[#464545]" />
+            <hr className="mt-[5px] mb-[10px] border-border" />
 
             {situation != null && (
               <SituationPanel situation={situation} day={currentDay} spoiled={filter.spoiled} />
@@ -332,7 +332,7 @@ export default function Village({ params }: Route.ComponentProps) {
           <LeftTime />
           {me != null && !sessionExpired && (
             <Link to={`/user/${me.name}`} target="_blank">
-              <div className="fixed top-[5px] left-[5px] z-[100] rounded bg-[#3498db] p-[5px] text-white">
+              <div className="fixed top-[5px] left-[5px] z-[100] rounded bg-info p-[5px] text-white">
                 ユーザID: {me.name}
               </div>
             </Link>

--- a/frontend/app/routes/village/route.tsx
+++ b/frontend/app/routes/village/route.tsx
@@ -72,7 +72,7 @@ function XPostButton() {
       href={url}
       target="_blank"
       rel="noreferrer"
-      className="inline-flex items-center gap-[5px] rounded-full bg-black px-[12px] py-[4px] font-bold text-white hover:bg-wm-band"
+      className="inline-flex items-center gap-[5px] rounded-full bg-black px-[12px] py-[4px] font-bold text-white hover:bg-[#333]"
     >
       <svg viewBox="0 0 24 24" className="h-[14px] w-[14px] fill-current" aria-hidden="true">
         <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />


### PR DESCRIPTION
## 概要

Step 12（視覚モダナイズ）の土台として、`app.css` の `@theme` に意味ベースの色トークンを定義し、UI クロームの Tailwind arbitrary hex（約 250 箇所・65 ファイル）をトークン参照に置換する。

**このPRでは見た目を一切変えない**（値はすべて従来のまま。トークン名の導入のみ）。今後の配色変更（Step 12.2 以降）を `@theme` の値差し替えだけで行えるようにする準備。

> **注**: 採用可否は保留中のため、レビュー後もマージせず保持する想定。

## トークン設計

- `surface` / `surface-raised` / `surface-alt` / `surface-dim` — パネル・持ち上げ面・縞
- `border` / `border-soft` — 境界線
- `success`（+ light / dark / muted / tint）/ `danger`（+ soft）/ `info` / `warning`（+ soft）
- `ink` / `ink-strong` — 白地フォーム上の文字
- `attention` / `disabled`

`border` / `surface-raised` / `ink-strong` は現状すべて #464545 だが、役割が異なるため別トークンに分離（今後の配色変更で独立に調整可能）。「持ち上がった面の縁」（Button default 等の border=bg 同色ペア）は `border` ではなく `surface-raised` を参照し、境界線トークンの独立調整に追従させない。

## 対象外（意図的に hex を温存）

- **発言（メッセージ）の背景色・文字色**（ユーザー指示: 今後も変更しない）: `messageStyles.ts` / `MessageBubble.tsx` / `SystemMessage.tsx`、発言プレビューのバブル（ConfirmModal / SayPanel / ParticipatePanel の該当行）
- データ的な色: 発言文字色装飾のパレット（SayPanel）、死因アイコン色（dead.ts）、ゲーム内記法の説明文（OtherSection）、AprilThread（ネタページ）
- UI クロームだが意図的に温存: ColorPicker のカスタム色ボタン背景 `#404040`（近似トークンなし）、X ポストボタンの hover `#333`（X ブランドボタンの色でありトークンに追従させない）
- `root.tsx` の `theme-color` meta（CSS 変数を参照できないため。配色変更時に手動追従）
- radius / spacing のスケール化は視覚差分が出るため Step 12.2 に先送り

## レビュー

pr-reviewer による独立レビュー 1 巡目: must-fix 0 / should-fix 3 / nits 2 → should-fix 3 件と nit 1 件を反映済み（RoomGrid inline style の CSS 変数化 / Button default の縁トークン / Modal の再現コメント削除 / X ボタン hover の hex 復帰）。nit 残 1 件（ColorPicker）は上記「対象外」に明記して対応とした。

## 動作確認

- `pnpm lint` / `pnpm format:check` / `pnpm typecheck` / `pnpm build` すべて green（レビュー反映後に再実行）
- **ピクセル一致検証**: 置換前後で同一ページ・同一ビューポートのスクリーンショットを全ピクセル比較
  - 初回置換後: ルールページ 1280×900 / 村ページ（プロローグ）1280×900 / 村ページ 375×812 の 3 ページとも完全一致（IDENTICAL）
  - レビュー反映後: 村ページ再比較で UI 領域はゼロ差分（全体 0.006% の差はヘッダー写真の画像リサンプリング揺らぎで、位置特定により UI 外と確認）
- **e2e**: 全 87 テスト passed。レビュー反映後に `village-vote.spec.ts`（RoomGrid を実際に操作する「部屋割から選択」を含む 5 件）を再実行し green
- CSS 変数の解決を実ブラウザで確認（`--color-border` 等が :root で従来 hex に解決）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XesQVfTMck7csXQA6ahKre