### PR TITLE
fix: 複数タブ同時 refresh の二重提示 401 を Web Locks で排他し rotation grace を延長

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/application/coordinator/AuthCoordinator.kt
+++ b/backend/src/main/kotlin/com/ort/app/application/coordinator/AuthCoordinator.kt
@@ -107,7 +107,11 @@ class AuthCoordinator(
                 ?: throw WolfMansionAuthException(INVALID_REFRESH)
         if (refreshToken.isUsed) {
             val usedAt = refreshToken.usedDatetime
-            if (usedAt != null && java.time.Duration.between(usedAt, now) <= ROTATION_GRACE_PERIOD) {
+            // revoke 済み (漏洩検知・logout) のトークンは grace で救済しない (revoke-all のバイパスになるため)
+            if (usedAt != null &&
+                !refreshToken.isRevoked &&
+                java.time.Duration.between(usedAt, now) <= ROTATION_GRACE_PERIOD
+            ) {
                 // Broken pipe 等でレスポンスが届かなかった可能性が高い。新しいトークンを再発行する
                 logger.info(
                     "refresh token reused within grace period. reissuing. playerId={}, usedAt={}",

--- a/backend/src/main/kotlin/com/ort/app/application/coordinator/AuthCoordinator.kt
+++ b/backend/src/main/kotlin/com/ort/app/application/coordinator/AuthCoordinator.kt
@@ -10,6 +10,7 @@ import com.ort.app.fw.exception.WolfMansionTooManyRequestsException
 import com.ort.app.fw.security.jwt.JwtPrincipal
 import com.ort.app.fw.security.jwt.JwtTokenProvider
 import com.ort.app.fw.security.jwt.RefreshTokenFactory
+import org.slf4j.LoggerFactory
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -31,6 +32,8 @@ class AuthCoordinator(
     private val playerService: PlayerService,
     private val loginRateLimiter: LoginRateLimiter,
 ) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
     // 失敗試行の記録 (recordFailure) は 401 を投げた後もコミットさせる必要があるため、
     // WolfMansionAuthException ではロールバックしない。429 は記録前に投げるので書き込みは無い。
     @Transactional(
@@ -106,12 +109,22 @@ class AuthCoordinator(
             val usedAt = refreshToken.usedDatetime
             if (usedAt != null && java.time.Duration.between(usedAt, now) <= ROTATION_GRACE_PERIOD) {
                 // Broken pipe 等でレスポンスが届かなかった可能性が高い。新しいトークンを再発行する
+                logger.info(
+                    "refresh token reused within grace period. reissuing. playerId={}, usedAt={}",
+                    refreshToken.playerId,
+                    usedAt,
+                )
                 val playerAuth =
                     playerAuthRepository.findById(refreshToken.playerId)
                         ?: throw WolfMansionAuthException(INVALID_REFRESH)
                 return issueTokens(playerAuth)
             }
             // grace period 超過の再提示 = 漏洩疑い。当該プレイヤーの未失効トークンを全て失効させる
+            logger.warn(
+                "refresh token reused after grace period. revoking all tokens. playerId={}, usedAt={}",
+                refreshToken.playerId,
+                usedAt,
+            )
             refreshTokenRepository.revokeAllByPlayer(refreshToken.playerId, now)
             throw WolfMansionAuthException(INVALID_REFRESH)
         }
@@ -125,6 +138,7 @@ class AuthCoordinator(
         // 使い捨て: 未使用のものだけをアトミックに使用済みにする。
         // 並行リクエストに先を越された (= 二重消費) 場合は false → このリクエストは拒否する。
         if (!refreshTokenRepository.markUsed(refreshToken.id, now)) {
+            logger.warn("refresh token concurrent consumption detected. playerId={}", refreshToken.playerId)
             throw WolfMansionAuthException(INVALID_REFRESH)
         }
         return issueTokens(playerAuth)
@@ -173,6 +187,9 @@ class AuthCoordinator(
 
     companion object {
         private const val INVALID_REFRESH = "リフレッシュトークンが無効です"
-        private val ROTATION_GRACE_PERIOD = java.time.Duration.ofSeconds(60)
+
+        // rotation のレスポンス消失 (端末スリープ・タブ破棄・回線断) 後の再提示を漏洩と誤検知して
+        // 全トークン失効させないための猶予。長いほど誤検知に強いが、本物の漏洩トークンの検知が遅れる
+        private val ROTATION_GRACE_PERIOD = java.time.Duration.ofMinutes(5)
     }
 }

--- a/backend/src/main/kotlin/com/ort/app/application/coordinator/AuthCoordinator.kt
+++ b/backend/src/main/kotlin/com/ort/app/application/coordinator/AuthCoordinator.kt
@@ -123,11 +123,12 @@ class AuthCoordinator(
                         ?: throw WolfMansionAuthException(INVALID_REFRESH)
                 return issueTokens(playerAuth)
             }
-            // grace period 超過の再提示 = 漏洩疑い。当該プレイヤーの未失効トークンを全て失効させる
+            // grace period 超過 (または revoke 済み) の再提示 = 漏洩疑い。当該プレイヤーの未失効トークンを全て失効させる
             logger.warn(
-                "refresh token reused after grace period. revoking all tokens. playerId={}, usedAt={}",
+                "refresh token reuse detected. revoking all tokens. playerId={}, usedAt={}, revoked={}",
                 refreshToken.playerId,
                 usedAt,
+                refreshToken.isRevoked,
             )
             refreshTokenRepository.revokeAllByPlayer(refreshToken.playerId, now)
             throw WolfMansionAuthException(INVALID_REFRESH)
@@ -193,7 +194,10 @@ class AuthCoordinator(
         private const val INVALID_REFRESH = "リフレッシュトークンが無効です"
 
         // rotation のレスポンス消失 (端末スリープ・タブ破棄・回線断) 後の再提示を漏洩と誤検知して
-        // 全トークン失効させないための猶予。長いほど誤検知に強いが、本物の漏洩トークンの検知が遅れる
+        // 全トークン失効させないための猶予。長いほど誤検知に強いが、本物の漏洩トークンの検知が遅れる。
+        // 受容済みトレードオフ: logout は提示されたトークンしか revoke しないため、grace 内に使用済みの
+        // 前世代トークンが窃取されていた場合、logout 後もこの猶予内は再発行が成功しうる。
+        // 厳密に塞ぐにはトークン系列 (family) ID を導入して logout で系列ごと失効させる必要がある
         private val ROTATION_GRACE_PERIOD = java.time.Duration.ofMinutes(5)
     }
 }

--- a/backend/src/test/kotlin/com/ort/app/application/coordinator/AuthCoordinatorTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/application/coordinator/AuthCoordinatorTest.kt
@@ -193,9 +193,9 @@ internal class AuthCoordinatorTest {
         val first = coordinator.login("alice", "correct-horse", CLIENT_IP)
         val second = coordinator.refresh(first.refreshToken) // first は使用済みに
 
-        // grace period 超過を再現: usedDatetime を 2 分前に巻き戻す
+        // grace period 超過を再現: usedDatetime を 6 分前に巻き戻す
         val firstStored = repo.findByHash(refreshFactory.hash(first.refreshToken))!!
-        repo.overwriteUsedDatetime(firstStored.id, LocalDateTime.now().minusMinutes(2))
+        repo.overwriteUsedDatetime(firstStored.id, LocalDateTime.now().minusMinutes(6))
 
         // grace period 外の再提示 → 漏洩疑いで例外 + 全失効
         assertThrows<WolfMansionAuthException> { coordinator.refresh(first.refreshToken) }

--- a/backend/src/test/kotlin/com/ort/app/application/coordinator/AuthCoordinatorTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/application/coordinator/AuthCoordinatorTest.kt
@@ -206,6 +206,18 @@ internal class AuthCoordinatorTest {
     }
 
     @Test
+    fun reusing_revoked_token_within_grace_period_is_rejected() {
+        val repo = FakeRefreshTokenRepository()
+        val coordinator = newCoordinator(repo)
+        val first = coordinator.login("alice", "correct-horse", CLIENT_IP)
+        coordinator.refresh(first.refreshToken) // first は使用済みに
+
+        // revoke 済みトークンは使用から grace period 内でも再発行しない (revoke-all のバイパス防止)
+        repo.revokeAllByPlayer(1, LocalDateTime.now())
+        assertThrows<WolfMansionAuthException> { coordinator.refresh(first.refreshToken) }
+    }
+
+    @Test
     fun logout_revokes_presented_token() {
         val repo = FakeRefreshTokenRepository()
         val coordinator = newCoordinator(repo)

--- a/frontend/app/lib/api.ts
+++ b/frontend/app/lib/api.ts
@@ -102,6 +102,8 @@ function postRefresh(): Promise<boolean> {
   return fetch(`${API_BASE}/api/v1/auth/refresh`, {
     method: "POST",
     credentials: "include",
+    // ロック保持中にハングすると全タブの 401 リトライがブロックされるため打ち切る
+    signal: AbortSignal.timeout(15_000),
   })
     .then(async (res) => {
       // body を消費しないとリクエストが完了扱いにならず残り続ける (中身は使わない)
@@ -113,7 +115,8 @@ function postRefresh(): Promise<boolean> {
 
 async function postRefreshWithCrossTabLock(): Promise<boolean> {
   if (typeof navigator === "undefined" || navigator.locks == null) return postRefresh();
-  return navigator.locks.request(REFRESH_LOCK_NAME, postRefresh);
+  // ロック取得自体の失敗 (document が inactive 等) も「refresh 失敗 = 未ログイン扱い」に丸める
+  return navigator.locks.request(REFRESH_LOCK_NAME, postRefresh).catch(() => false);
 }
 
 function refreshTokens(): Promise<boolean> {

--- a/frontend/app/lib/api.ts
+++ b/frontend/app/lib/api.ts
@@ -102,8 +102,11 @@ function postRefresh(): Promise<boolean> {
   return fetch(`${API_BASE}/api/v1/auth/refresh`, {
     method: "POST",
     credentials: "include",
-    // ロック保持中にハングすると全タブの 401 リトライがブロックされるため打ち切る
-    signal: AbortSignal.timeout(15_000),
+    // ロック保持中にハングすると全タブの 401 リトライがブロックされるため打ち切る (非対応環境は打ち切りなし)
+    signal:
+      typeof AbortSignal !== "undefined" && AbortSignal.timeout
+        ? AbortSignal.timeout(15_000)
+        : undefined,
   })
     .then(async (res) => {
       // body を消費しないとリクエストが完了扱いにならず残り続ける (中身は使わない)

--- a/frontend/app/lib/api.ts
+++ b/frontend/app/lib/api.ts
@@ -85,14 +85,21 @@ type ApiFetchOptions = {
 };
 
 /**
- * access token (15分) 切れの 401 を refresh token で立て直す。並行リクエストが同時に 401 に
- * なっても refresh は 1 回だけ走らせる (rotation 方式のため同じ refresh token の二重提示は
- * 漏洩検知で全失効してしまう)。refresh 自体が失敗したら未ログインとして扱う。
+ * access token (15分) 切れの 401 を refresh token で立て直す。rotation 方式のため同じ refresh
+ * token を並行して二重提示すると片方が拒否される (先勝ち)。これを防ぐため 2 段で直列化する:
+ *
+ * - タブ内: singleton promise で同時 401 でも refresh は 1 回だけ走らせる
+ * - タブ間: Web Locks API で排他する。Cookie はタブ間共有なので、先行タブの rotation 完了を
+ *   待ってから提示すれば常に最新の refresh token を提示でき、二重消費 401 にならない
+ *
+ * refresh 自体が失敗したら未ログインとして扱う。
  */
 let refreshPromise: Promise<boolean> | null = null;
 
-function refreshTokens(): Promise<boolean> {
-  refreshPromise ??= fetch(`${API_BASE}/api/v1/auth/refresh`, {
+const REFRESH_LOCK_NAME = "wolf-mansion-auth-refresh";
+
+function postRefresh(): Promise<boolean> {
+  return fetch(`${API_BASE}/api/v1/auth/refresh`, {
     method: "POST",
     credentials: "include",
   })
@@ -101,10 +108,18 @@ function refreshTokens(): Promise<boolean> {
       await res.text().catch(() => {});
       return res.ok;
     })
-    .catch(() => false)
-    .finally(() => {
-      refreshPromise = null;
-    });
+    .catch(() => false);
+}
+
+async function postRefreshWithCrossTabLock(): Promise<boolean> {
+  if (typeof navigator === "undefined" || navigator.locks == null) return postRefresh();
+  return navigator.locks.request(REFRESH_LOCK_NAME, postRefresh);
+}
+
+function refreshTokens(): Promise<boolean> {
+  refreshPromise ??= postRefreshWithCrossTabLock().finally(() => {
+    refreshPromise = null;
+  });
   return refreshPromise;
 }
 


### PR DESCRIPTION
## 目的

村画面を複数タブ（または PWA 併用）で開いたまま放置すると、access token（15 分）失効後の同時 refresh で 401 が発生し、発言の自動取得がログイン視点で機能しなくなる問題を修正する（Issue #11）。

## 根本原因

refresh token は使い捨て rotation 方式のため、同じ token の並行二重提示は先勝ちで片方が拒否される。frontend の refresh 排他（singleton promise）は**タブ内でしか効かず**、複数タブが同時に 401 → refresh すると負けた側が 401 → `me` が null に落ちて**匿名視点に silent 劣化**していた（秘匿発言が自動取得されなくなる）。また rotation のレスポンス消失（端末スリープ・回線断）後に旧 token を 60 秒超で再提示すると、漏洩誤検知で全トークン失効 → 全デバイス強制ログアウトに至るケースもあった。

## 変更内容

- **frontend** (`app/lib/api.ts`): refresh を Web Locks API（`navigator.locks`）でタブ間排他。タブ内 singleton と合わせて 2 段直列化し、後続タブは先行タブの rotation 完了後に常に最新 token を提示する。非対応環境は従来動作にフォールバック
- **backend** (`AuthCoordinator.kt`): rotation grace period を 60 秒 → 5 分に延長（レスポンス消失後の再提示の漏洩誤検知による全失効を緩和）
- **backend**: 再利用検知（grace 内再発行 = info / grace 超過全失効 = warn）と並行二重消費（warn）にログを追加（従来はログなしで本番調査が不可能だった）

## 動作確認

access token を 1 分に短縮したローカル環境（backend 18089 / frontend 15173）で実測:

- ✅ **単一タブ失効回復**: 失効後リロード → `auth/me` 401 → `refresh` 200 → 再送 200 → `situation/me` 200 でログイン視点復帰
- ✅ **2 タブ同時 refresh 競合**: 両タブに同一 epoch の setTimeout リロードを仕込み同時発火。Cookie 実測で直列化を確認 — tab2 が旧 token を提示して新 token を受領、tab3 は Web Lock 待機後に **tab2 が受領した新 token を提示**して正常 rotation（同一秒内）。両タブともログイン視点で復帰し、backend ログに二重消費 warn / revoke-all は 0 件
- ✅ **refresh token 完全失効時**: DB で全 revoke → `refresh` 401 → 匿名視点に劣化（クラッシュなし、公開発言は取得継続、ログイン導線表示）
- ✅ **grace period / revoke-all**: AuthCoordinatorTest（grace 内再発行・6 分後の全失効）
- ✅ backend `./gradlew build`（test + ktlint）/ frontend lint・format:check・typecheck・build
- ✅ e2e 回帰: 87 passed / 0 failed
- 未検証: タブ非アクティブ中の 5 分 interval 停止からのトースト経路（既存挙動でコード変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUfyzDuo6HdDdKdvfNLf8x