### PR TITLE
fix: 発言欄ランダムタグの並びを net 版と同じキーワード名昇順にする

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/api/randomkeyword/RandomKeywordRestController.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/randomkeyword/RandomKeywordRestController.kt
@@ -32,7 +32,7 @@ class RandomKeywordRestController(
     @GetMapping
     fun list(
         @ParameterObject request: RandomKeywordSearchRequest,
-    ): RandomKeywords = randomKeywordService.findRandomKeywords(request.q)
+    ): RandomKeywords = randomKeywordService.findRandomKeywords(request.q, request.isOrderByKeyword())
 
     @GetMapping("/{id}")
     fun detail(

--- a/backend/src/main/kotlin/com/ort/app/api/randomkeyword/request/RandomKeywordSearchRequest.kt
+++ b/backend/src/main/kotlin/com/ort/app/api/randomkeyword/request/RandomKeywordSearchRequest.kt
@@ -6,4 +6,8 @@ package com.ort.app.api.randomkeyword.request
 data class RandomKeywordSearchRequest(
     /** 検索語。キーワードまたは変換後文字列の部分一致。未指定なら全件。 */
     val q: String? = null,
-)
+    /** 並び順。`keyword`=キーワード名昇順 / それ以外 (未指定含む)=登録順。 */
+    val order: String? = null,
+) {
+    fun isOrderByKeyword(): Boolean = "keyword".equals(order, ignoreCase = true)
+}

--- a/backend/src/main/kotlin/com/ort/app/application/service/RandomKeywordService.kt
+++ b/backend/src/main/kotlin/com/ort/app/application/service/RandomKeywordService.kt
@@ -11,9 +11,13 @@ import org.springframework.transaction.annotation.Transactional
 class RandomKeywordService(
     val randomKeywordRepository: RandomKeywordRepository,
 ) {
-    fun findRandomKeywords(text: String? = null): RandomKeywords {
+    fun findRandomKeywords(
+        text: String? = null,
+        orderByKeyword: Boolean = false,
+    ): RandomKeywords {
         val keywords = randomKeywordRepository.findRandomKeywords()
-        return if (text.isNullOrBlank()) keywords else keywords.filterBy(text)
+        val filtered = if (text.isNullOrBlank()) keywords else keywords.filterBy(text)
+        return if (orderByKeyword) filtered.sortedByKeyword() else filtered
     }
 
     fun findRandomKeyword(id: Int): RandomKeyword? = randomKeywordRepository.findRandomKeyword(id)

--- a/backend/src/main/kotlin/com/ort/app/domain/model/randomkeyword/RandomKeywords.kt
+++ b/backend/src/main/kotlin/com/ort/app/domain/model/randomkeyword/RandomKeywords.kt
@@ -11,4 +11,7 @@ data class RandomKeywords(
                     keyword.keyword.contains(text) || keyword.contents.any { it.message.contains(text) }
                 },
         )
+
+    /** キーワード名昇順に並べ替える。 */
+    fun sortedByKeyword(): RandomKeywords = RandomKeywords(list = list.sortedBy { it.keyword })
 }

--- a/backend/src/test/kotlin/com/ort/app/api/randomkeyword/request/RandomKeywordRequestTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/api/randomkeyword/request/RandomKeywordRequestTest.kt
@@ -60,4 +60,12 @@ internal class RandomKeywordRequestTest {
             RandomKeywordUpdateRequest(messages = listOf("ほげ", "ほげ")).toContents()
         }
     }
+
+    @Test
+    fun `search - order=keyword のときのみキーワード名昇順`() {
+        assertEquals(true, RandomKeywordSearchRequest(order = "keyword").isOrderByKeyword())
+        assertEquals(true, RandomKeywordSearchRequest(order = "KEYWORD").isOrderByKeyword())
+        assertEquals(false, RandomKeywordSearchRequest(order = null).isOrderByKeyword())
+        assertEquals(false, RandomKeywordSearchRequest(order = "id").isOrderByKeyword())
+    }
 }

--- a/backend/src/test/kotlin/com/ort/app/domain/model/randomkeyword/RandomKeywordsTest.kt
+++ b/backend/src/test/kotlin/com/ort/app/domain/model/randomkeyword/RandomKeywordsTest.kt
@@ -27,4 +27,9 @@ internal class RandomKeywordsTest {
     fun `filterBy - どちらにも一致しなければ空`() {
         assertEquals(emptyList<Int>(), keywords.filterBy("該当なし").list)
     }
+
+    @Test
+    fun `sortedByKeyword - キーワード名昇順に並べ替える`() {
+        assertEquals(listOf("coin", "omikuji"), keywords.sortedByKeyword().list.map { it.keyword })
+    }
 }

--- a/frontend/app/api/openapi.json
+++ b/frontend/app/api/openapi.json
@@ -295,6 +295,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/frontend/app/api/types.ts
+++ b/frontend/app/api/types.ts
@@ -2420,6 +2420,7 @@ export interface operations {
     parameters: {
       query?: {
         q?: string;
+        order?: string;
       };
       header?: never;
       path?: never;

--- a/frontend/app/features/random-keywords/api.ts
+++ b/frontend/app/features/random-keywords/api.ts
@@ -3,9 +3,15 @@ import { apiFetch } from "~/lib/api";
 
 export type RandomKeyword = components["schemas"]["RandomKeyword"];
 
-/** 一覧取得。`q` はキーワード/変換後文字列の部分一致 (API 側絞り込み)。 */
-export function fetchRandomKeywords(q?: string): Promise<RandomKeyword[]> {
-  const query = q ? `?${new URLSearchParams({ q })}` : "";
+/**
+ * 一覧取得。`q` はキーワード/変換後文字列の部分一致、`order` は並び順
+ * (`keyword`=キーワード名昇順 / 未指定=登録順)。いずれも API 側で処理する。
+ */
+export function fetchRandomKeywords(q?: string, order?: "keyword"): Promise<RandomKeyword[]> {
+  const params = new URLSearchParams();
+  if (q) params.set("q", q);
+  if (order) params.set("order", order);
+  const query = params.size > 0 ? `?${params}` : "";
   return apiFetch<components["schemas"]["RandomKeywords"]>(`/api/v1/random-keywords${query}`).then(
     (r) => r.list,
   );

--- a/frontend/app/features/random-keywords/useRandomKeywords.ts
+++ b/frontend/app/features/random-keywords/useRandomKeywords.ts
@@ -4,16 +4,17 @@ import { fetchRandomKeyword, fetchRandomKeywords } from "./api";
 
 const QUERY_KEY_PREFIX = ["random-keywords"] as const;
 
-export function useRandomKeywords(q: string = "") {
+export function useRandomKeywords(q: string = "", order?: "keyword") {
   return useQuery({
-    queryKey: [...QUERY_KEY_PREFIX, "list", q],
-    queryFn: () => fetchRandomKeywords(q || undefined),
+    queryKey: [...QUERY_KEY_PREFIX, "list", q, order ?? ""],
+    queryFn: () => fetchRandomKeywords(q || undefined, order),
     retry: false,
   });
 }
 
+/** キーワード名一覧。発言欄のランダムタグプルダウンの表示順に合わせてキーワード名昇順で取得する。 */
 export function useRandomKeywordList(): string[] {
-  const { data } = useRandomKeywords();
+  const { data } = useRandomKeywords("", "keyword");
   return (data ?? []).map((k) => k.keyword ?? "").filter(Boolean);
 }
 

--- a/frontend/app/routes/village-message/route.tsx
+++ b/frontend/app/routes/village-message/route.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import { useSearchParams } from "react-router";
 
 import { PageLayout } from "~/components/layout/PageLayout";
-import { useRandomKeywords } from "~/features/random-keywords/useRandomKeywords";
+import { useRandomKeywordList } from "~/features/random-keywords/useRandomKeywords";
 import { fetchAnchorMessages } from "~/features/village/api";
 import { useVillage } from "~/features/village/useVillage";
 import { VillageProvider } from "~/features/village/VillageContext";
@@ -27,7 +27,7 @@ export default function VillageMessagePermalink({ params }: Route.ComponentProps
   const anchors = searchParams.get("anchors") ?? "";
 
   const { data: village, error: villageError } = useVillage(villageId);
-  const { data: randomKeywords } = useRandomKeywords();
+  const randomKeywords = useRandomKeywordList();
   const { data } = useQuery({
     queryKey: ["village-anchor-messages", villageId, anchors],
     queryFn: () => fetchAnchorMessages(villageId, anchors),
@@ -64,7 +64,7 @@ export default function VillageMessagePermalink({ params }: Route.ComponentProps
               <MessageCard
                 key={`${message.messageType}-${message.messageNumber ?? index}`}
                 message={message}
-                randomKeywords={(randomKeywords ?? []).map((k) => k.keyword ?? "").filter(Boolean)}
+                randomKeywords={randomKeywords}
               />
             ))}
           </div>

--- a/frontend/app/routes/village-scrap/route.tsx
+++ b/frontend/app/routes/village-scrap/route.tsx
@@ -5,7 +5,7 @@ import { useSearchParams } from "react-router";
 import { PageLayout } from "~/components/layout/PageLayout";
 import { Button, LinkButton } from "~/components/ui/Button";
 import { inputClass } from "~/components/ui/Input";
-import { useRandomKeywords } from "~/features/random-keywords/useRandomKeywords";
+import { useRandomKeywordList } from "~/features/random-keywords/useRandomKeywords";
 import { fetchAnchorMessages } from "~/features/village/api";
 import { useVillage } from "~/features/village/useVillage";
 import { VillageProvider } from "~/features/village/VillageContext";
@@ -46,14 +46,13 @@ export default function VillageScrap({ params }: Route.ComponentProps) {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const { data: village, error: villageError } = useVillage(villageId);
-  const { data: randomKeywords } = useRandomKeywords();
+  const keywordList = useRandomKeywordList();
   const { data } = useQuery({
     queryKey: ["village-anchor-messages", villageId, anchors],
     queryFn: () => fetchAnchorMessages(villageId, anchors),
     enabled: anchors !== "",
     retry: false,
   });
-  const keywordList = (randomKeywords ?? []).map((k) => k.keyword ?? "").filter(Boolean);
 
   useEffect(() => {
     if (village != null) document.title = `WOLF MANSION | ${village.name}`;


### PR DESCRIPTION
## 目的

dev 版の発言欄「ランダムタグ」プルダウンで、ユーザー登録キーワードが登録順 (RandomKeywordId 昇順) で表示されており、net 版 (キーワード名昇順) と並びが異なっていた。net 版と同じ並びにする。

- net 版は say-form 描画時に `sortedBy { it.keyword }` でキーワード名昇順に整列していた (旧 `VillageContent`)
- dev 版は `GET /api/v1/random-keywords` が登録順で返し、SayPanel がそのまま表示していた
- net 版のランダムキーワード一覧ページ (random-message) は登録順表示のため、API のデフォルト並びは変えない

## 変更内容

- backend: `RandomKeywordSearchRequest` に `order` パラメータを追加 (`keyword`=キーワード名昇順 / 未指定=従来の登録順)。並び替えは `RandomKeywords.sortedByKeyword()` (net の `sortedBy { it.keyword }` と同等) で行う
- frontend: `useRandomKeywordList` (発言欄プルダウン・メッセージ表示共用) が `order=keyword` を指定して取得。frontend 側でのソートはしない
- `pnpm gen:api` で types.ts / openapi.json を再生成
- `RandomKeywordsTest` / `RandomKeywordRequestTest` にテスト追加

## 動作確認

- `./gradlew test` green (96 件 + 追加 2 件)、`./gradlew ktlintCheck` green
- `pnpm lint` / `pnpm format:check` / `pnpm build` green
- API 実測: 無指定 → `['zebra', 'banana', 'みかん', 'apple']` (登録順) / `order=keyword` → `['apple', 'banana', 'zebra', 'みかん']` / `order=keyword&q=an` → `['banana']` (絞り込み併用可)
- UI 実測 (backend 8089 + frontend 5173、テスト用キーワード 4 件登録): 発言欄プルダウンが「fortune / 1d6 / or / who / allwho / gwho / apple / banana / zebra / みかん」の順で表示されることをスクリーンショットで確認
- /random-message 一覧は従来どおり登録順 (zebra → banana → みかん → apple) のまま
- e2e (`random-keyword` / `village-say` / `village-messages` spec): 11 passed / 1 flaky (village-say の発言パネル描画待ちがリトライで成功。本変更とは無関係のタイミング起因)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGWv3p2HafNyBKGnDWvS2r