### PR TITLE
fix: 発言抽出のキャラチップを通常差分で表示する

### DIFF
--- a/backend/src/main/kotlin/com/ort/app/infrastructure/datasource/CharaDataSource.kt
+++ b/backend/src/main/kotlin/com/ort/app/infrastructure/datasource/CharaDataSource.kt
@@ -176,8 +176,10 @@ class CharaDataSource(
                 .loadChara {
                     it.query().addOrderBy_DefaultJoinMessage_Asc().withNullsLast()
                     it.query().addOrderBy_CharaId_Asc()
-                }.withNestedReferrer { charaLoader ->
-                    charaLoader.loadCharaImage {}
+                }.withNestedReferrer { charaLoader: LoaderOfChara ->
+                    charaLoader.loadCharaImage { charaImageCB: CharaImageCB ->
+                        charaImageCB.query().queryFaceType().addOrderBy_DispOrder_Asc()
+                    }
                 }
         }
         return groupList

--- a/frontend/app/features/charachips/charaImage.ts
+++ b/frontend/app/features/charachips/charaImage.ts
@@ -1,0 +1,9 @@
+/**
+ * キャラ画像リストから通常差分を選ぶ。通常差分を持たない場合
+ * (オリジナルキャラチップは faceType.code が独自 ID になる) は先頭にフォールバックする。
+ */
+export function findNormalImage<T extends { faceType: { code: string } }>(
+  images: T[] | undefined,
+): T | undefined {
+  return images?.find((i) => i.faceType.code === "NORMAL") ?? images?.[0];
+}

--- a/frontend/app/features/village/components/analyzer/AnalyzerRoomGrid.tsx
+++ b/frontend/app/features/village/components/analyzer/AnalyzerRoomGrid.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import type { AnalyzerDayRoom, AnalyzerVillageData } from "~/features/village/analyzer/analyzerApi";
 import type { DayFootstep, ParticipantMemo } from "~/features/village/analyzer/types";
 import { TextButton } from "~/components/ui/TextButton";
+import { findNormalImage } from "~/features/charachips/charaImage";
 import { deadColor, deadMark } from "~/features/village/components/info/dead";
 import { FootstepGapLines } from "./FootstepGapLines";
 import { FootstepLines } from "./FootstepLines";
@@ -66,7 +67,7 @@ function charaImageUrl(
 ): { url: string; width: number; height: number } | null {
   const chara = participantIdToChara[String(participantId)];
   if (!chara) return null;
-  const img = chara.images.list.find((i) => i.faceType.code === "NORMAL") ?? chara.images.list[0];
+  const img = findNormalImage(chara.images.list);
   if (!img) return null;
   const url = img.url.startsWith("http") ? img.url : `https://wolfort.net${img.url}`;
   return { url, width: chara.size.width, height: chara.size.height };

--- a/frontend/app/features/village/components/modal/FilterModal.tsx
+++ b/frontend/app/features/village/components/modal/FilterModal.tsx
@@ -5,6 +5,7 @@ import { ButtonCheckboxGroup } from "~/components/ui/ButtonCheckboxGroup";
 import { inputClass } from "~/components/ui/Input";
 import { Modal } from "~/components/ui/Modal";
 import { TextButton } from "~/components/ui/TextButton";
+import { findNormalImage } from "~/features/charachips/charaImage";
 import type { VillageParticipantView } from "~/features/village/api";
 import { useVillageContext } from "~/features/village/VillageContext";
 import { allParticipants, sortByRoomNumber } from "~/features/village/participants";
@@ -29,10 +30,7 @@ function toFilterParticipant(p: VillageParticipantView): FilterParticipant {
     name: p.name,
     imgWidth: p.chara.size.width,
     imgHeight: p.chara.size.height,
-    imgUrl:
-      p.chara.images.list.find((i) => i.faceType.code === "NORMAL")?.url ??
-      p.chara.images.list[0]?.url ??
-      "",
+    imgUrl: findNormalImage(p.chara.images.list)?.url ?? "",
     deadStatus: toDeadStatus(p),
   };
 }

--- a/frontend/app/features/village/components/modal/FilterModal.tsx
+++ b/frontend/app/features/village/components/modal/FilterModal.tsx
@@ -29,7 +29,10 @@ function toFilterParticipant(p: VillageParticipantView): FilterParticipant {
     name: p.name,
     imgWidth: p.chara.size.width,
     imgHeight: p.chara.size.height,
-    imgUrl: p.chara.images.list[0]?.url ?? "",
+    imgUrl:
+      p.chara.images.list.find((i) => i.faceType.code === "NORMAL")?.url ??
+      p.chara.images.list[0]?.url ??
+      "",
     deadStatus: toDeadStatus(p),
   };
 }

--- a/frontend/app/features/village/components/participate/ParticipatePanel.tsx
+++ b/frontend/app/features/village/components/participate/ParticipatePanel.tsx
@@ -6,6 +6,7 @@ import { FileUpload } from "~/components/ui/FileUpload";
 import { VillageFormRow } from "~/components/ui/Form";
 import { inputClass, selectClass, textareaClass } from "~/components/ui/Input";
 import { Panel } from "~/components/ui/Panel";
+import { findNormalImage } from "~/features/charachips/charaImage";
 import {
   confirmVillageParticipate,
   participateVillage,
@@ -29,9 +30,7 @@ type CharaLike = {
 };
 
 function defaultImageUrl(c: CharaLike): string {
-  return (
-    c.images.list.find((i) => i.faceType.code === "NORMAL")?.url ?? c.images.list[0]?.url ?? ""
-  );
+  return findNormalImage(c.images.list)?.url ?? "";
 }
 
 type Step = "input" | "confirm";

--- a/frontend/app/routes/chara-group-detail/route.tsx
+++ b/frontend/app/routes/chara-group-detail/route.tsx
@@ -5,6 +5,7 @@ import { Heading } from "~/components/ui/Heading";
 import { ExternalLink } from "~/components/ui/TextLink";
 import { PageLayout } from "~/components/layout/PageLayout";
 import type { Chara, RoomAssignmentResponse } from "~/features/charachips/api";
+import { findNormalImage } from "~/features/charachips/charaImage";
 import { useCharachipDetail, useRoomAssignment } from "~/features/charachips/useCharachips";
 import { siteMeta } from "~/lib/meta";
 import type { Route } from "./+types/route";
@@ -131,9 +132,7 @@ function RoomAssignmentTable({
         {grid.map((row, rowIndex) => (
           <tr key={rowIndex}>
             {row.map((cell) => {
-              const defaultImg =
-                cell.chara?.images.list.find((img) => img.faceType.code === "NORMAL") ??
-                cell.chara?.images.list[0];
+              const defaultImg = findNormalImage(cell.chara?.images.list);
               return (
                 <td
                   key={cell.roomNumber}

--- a/frontend/app/routes/new-village/CharachipSection.tsx
+++ b/frontend/app/routes/new-village/CharachipSection.tsx
@@ -7,6 +7,7 @@ import { inputClass, selectClass, textareaClass } from "~/components/ui/Input";
 import { MultiSelect } from "~/components/ui/MultiSelect";
 import { TextLink } from "~/components/ui/TextLink";
 import type { Chara } from "~/features/charachips/api";
+import { findNormalImage } from "~/features/charachips/charaImage";
 import { useCharachipDetails, useCharachipList } from "~/features/charachips/useCharachips";
 import { assetUrl } from "~/lib/api";
 import {
@@ -308,7 +309,7 @@ function DummyCharaImage({
     );
   }
   if (!chara) return null;
-  const image = chara.images.list.find((i) => i.faceType.code === "NORMAL") ?? chara.images.list[0];
+  const image = findNormalImage(chara.images.list);
   if (!image) return null;
   return (
     <img src={image.url} width={chara.size.width} height={chara.size.height} alt={chara.name} />

--- a/frontend/app/routes/new-village/ConfirmModal.tsx
+++ b/frontend/app/routes/new-village/ConfirmModal.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { Button } from "~/components/ui/Button";
 import { Modal } from "~/components/ui/Modal";
 import type { Chara } from "~/features/charachips/api";
+import { findNormalImage } from "~/features/charachips/charaImage";
 import { useCharachipDetails, useCharachipList } from "~/features/charachips/useCharachips";
 import { assetUrl } from "~/lib/api";
 import type { NewVillageFormInput } from "~/features/village-form/schema";
@@ -57,8 +58,7 @@ function MessagePreview({
     original || !chara
       ? { url: originalImageUrl ?? assetUrl("/app/images/placeholder.png"), width: 60, height: 60 }
       : {
-          url: (chara.images.list.find((i) => i.faceType.code === "NORMAL") ?? chara.images.list[0])
-            ?.url,
+          url: findNormalImage(chara.images.list)?.url,
           width: chara.size.width,
           height: chara.size.height,
         };


### PR DESCRIPTION
## 目的

dev 版の発言抽出モーダルで、キャラチップ画像が通常差分以外（墓下差分や恋差分など、チップが持つ差分により異なる）で表示されることがあった。net 版と同様に常に通常差分で表示する。

根本原因:

- `FilterModal` が `chara.images.list[0]` を無条件採用していた
- その images は `CharaDataSource.selectCharaGroups` の `loadCharaImage {}`（村参加者向け `findCharachips(ids)` 経路）だけ並び順指定が漏れており、PK（CHARA_ID, FACE_TYPE_CODE）順 = 表情コードのアルファベット順（GRAVE → LOVER → … → NORMAL）で返っていた
- そのため墓下・恋などの差分を持つキャラは先頭が通常差分にならない（死亡キャラに限らず、差分を持つキャラ全員が対象）

## 変更内容

- backend: `selectCharaGroups` の `loadCharaImage` に同ファイルの他ローダーと同じ `FACE_TYPE.DISP_ORDER` 昇順を指定。この経路は発言欄の表情切替プルダウンにも使われており、並びが net 同等（通常→囁き→墓下→…）になる
- frontend: `FilterModal` も `ParticipatePanel` / `AnalyzerRoomGrid` と同様に `faceType.code === "NORMAL"` を明示選択（並び順に依存しない防御的な二重化）

## 動作確認

- `./gradlew test` / `./gradlew ktlintCheck` green
- `pnpm lint` / `pnpm format:check` / `pnpm build` green
- API 実測（墓下差分等ありのキャラセット 4 で検証用村を作成し、debug API で死亡者 3 名を発生）: 参加者 API の `chara.images` が `['NORMAL', 'WEREWOLF', 'GRAVE', 'MONOLOGUE', 'SECRET']` の DISP_ORDER 順で返る（修正前は PK 順で GRAVE が先頭）
- UI 実測: 発言抽出モーダルの発言者・宛先チップが、死亡者 3 名（無惨死 ×2・処刑死 ×1）含む全員 `charaNNN.png`（通常差分。墓下は `_gr.png`）で表示されることを DOM の src とスクリーンショットで確認
- 同村の発言欄で表情切替プルダウンが「通常→囁き→墓下→独り言→秘話」の順になることを確認
- e2e（`village-message-filter` / `village-say` spec）: 7 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGWv3p2HafNyBKGnDWvS2r