### PR TITLE
fix: 発言ログのページ変更時に最上部までスクロールする

### DIFF
--- a/frontend/app/features/village/components/message/MessageArea.tsx
+++ b/frontend/app/features/village/components/message/MessageArea.tsx
@@ -7,6 +7,7 @@ import { applyFilterToParams, EMPTY_FILTER, type MessageFilter } from "~/feature
 import { useVillageId } from "~/features/village/VillageContext";
 import { useMyVillageSituation } from "~/features/village/useVillage";
 import { useVillageMessages } from "~/features/village/useMessages";
+import { useVillageScroll } from "~/features/village/useVillageScroll";
 import { MessageType } from "~/features/village/components/message/messageType";
 import { bubbleClass } from "~/features/village/components/message/message";
 import { MessageCard, type ReplyDraft } from "./MessageCard";
@@ -67,6 +68,15 @@ export function MessageArea({
     },
     [setSearchParams],
   );
+  const { scrollToTop } = useVillageScroll();
+  // net 版はページ遷移 (フルリロード) で常に最上部から表示されていたため、SPA でも同じ体験にする
+  const changePage = useCallback(
+    (next: PageState) => {
+      setPage(next);
+      scrollToTop();
+    },
+    [setPage, scrollToTop],
+  );
   const { data, isLoading, isFetching } = useVillageMessages(villageId, {
     day,
     pageSize: isPaging ? pageSize : undefined,
@@ -92,7 +102,7 @@ export function MessageArea({
   return (
     <div className="relative">
       {showOverlay && <div className="absolute inset-0 z-10 bg-wm-base/60" />}
-      <MessagePagination content={data} onChange={setPage} />
+      <MessagePagination content={data} onChange={changePage} />
       {(data.messageList ?? []).map((message, index) => (
         <MessageCard
           key={`${message.messageType}-${message.messageNumber ?? index}`}
@@ -110,7 +120,7 @@ export function MessageArea({
       {data.suddenlyDeathMessage != null && <Announce text={data.suddenlyDeathMessage} />}
       {data.villageStatusMessage != null && <Announce text={data.villageStatusMessage} />}
       {data.commitStatusMessage != null && <Announce text={data.commitStatusMessage} />}
-      <MessagePagination content={data} onChange={setPage} />
+      <MessagePagination content={data} onChange={changePage} />
     </div>
   );
 }


### PR DESCRIPTION
## 目的

dev 版で発言ログのページング（ページ番号 / 前へ / 次へ / 最新）をクリックしてもスクロール位置が残り、新しいページを読むには手動で最上部へ戻る必要があった。net 版は SSR のページ遷移（フルリロード）で常に最上部から表示されていたため、dev 版でも同じ体験にする。

## 変更内容

- `MessageArea` でページネーションの `onChange` をラップし、ページ変更時に既存の `useVillageScroll().scrollToTop`（フッターの「最上部へ」と同じスムーススクロール）を呼ぶ
- スクロールするのはページネーションクリック時のみ。発言抽出条件の変更・日付切替・表示設定変更によるページリセット（`useMessagePaging` の `useEffect`）は従来どおりスクロールしない

## 動作確認

- 村 114 プロローグ（pageSize 10 で 3 ページ）にて実測:
  - 最下部のページネーションで「2」をクリック → scrollY 2394 → 0、ページ 2 の先頭発言が表示される（スクリーンショット確認）
  - 「最新」をクリック → scrollY 2334 → 0
  - ページング以外の経路（抽出・日付切替）は `MessagePagination` の `onChange` のみをラップしているため影響なし（コード構造上スクロール処理を通らない）
- `pnpm lint` / `pnpm format:check` / `pnpm build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGWv3p2HafNyBKGnDWvS2r