### PR TITLE
enhance: 状況パネルの投票タブを推理補助タブから独立させる

### DIFF
--- a/frontend/app/features/village/components/analyzer/AnalyzerTab.tsx
+++ b/frontend/app/features/village/components/analyzer/AnalyzerTab.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
-import type { VillageSituationView } from "~/features/village/api";
 import {
   fetchAnalyzerVillage,
   type AnalyzerDaySituation,
@@ -12,12 +11,11 @@ import { useMe } from "~/features/auth/useMe";
 import { useVillageContext } from "~/features/village/VillageContext";
 import { useAnalyzerMemos } from "~/features/village/analyzer/useAnalyzerMemos";
 import { dayLabel } from "~/features/village/components/info/dayLabel";
-import { VoteTab } from "~/features/village/components/info/VoteTab";
 import { AnalyzerFootsteps } from "./AnalyzerFootsteps";
 import { AnalyzerRoomGrid } from "./AnalyzerRoomGrid";
 import { ParticipantMemoModal } from "./ParticipantMemoModal";
 
-export function AnalyzerTab({ situation: initialSituation }: { situation: VillageSituationView }) {
+export function AnalyzerTab() {
   const { me } = useMe();
   const village = useVillageContext();
 
@@ -143,7 +141,7 @@ export function AnalyzerTab({ situation: initialSituation }: { situation: Villag
         ))}
       </ul>
 
-      {/* Day content: Room grid + Footsteps/Daily memo */}
+      {/* Day content: Room grid + Footsteps */}
       {currentDaySituation && analyzerData.village.roomSize && (
         <div className="flex flex-col gap-[10px] lg:flex-row">
           {/* Room grid */}
@@ -160,14 +158,22 @@ export function AnalyzerTab({ situation: initialSituation }: { situation: Villag
             />
           </div>
 
-          {/* Footstep analysis + Daily memo */}
-          <div className="flex min-w-0 flex-1 flex-col gap-[10px]">
+          {/* Footstep analysis */}
+          <div className="min-w-0 flex-1">
             <AnalyzerFootsteps footsteps={currentDayFootsteps} onChange={onFootstepsChange} />
-            {/* 横並び時は日次メモを部屋割の下端まで伸ばす */}
-            <div className="lg:flex lg:min-h-0 lg:flex-1 lg:flex-col">
+          </div>
+        </div>
+      )}
+
+      {/* Memos: Daily + Whole (lg では 2 カラム) */}
+      <div className="mt-[10px] border-t border-border">
+        <div className="flex flex-col gap-[10px] py-[10px] lg:flex-row">
+          {currentDaySituation && analyzerData.village.roomSize && (
+            <div className="flex min-w-0 flex-1 flex-col">
               <label className="mb-[4px] block text-village-sm font-bold text-gray-300">
                 {dayLabel(activeDay, epilogueDay)} メモ
               </label>
+              {/* 横並び時は全体メモと同じ高さまで伸ばす */}
               <textarea
                 value={currentDailyMemo}
                 onChange={(e) => setDailyMemo(activeDay, e.target.value)}
@@ -176,21 +182,8 @@ export function AnalyzerTab({ situation: initialSituation }: { situation: Villag
                 placeholder="この日のメモ..."
               />
             </div>
-          </div>
-        </div>
-      )}
-
-      {/* Bottom section: Vote + Whole memo */}
-      <div className="mt-[10px] border-t border-border">
-        <div className="flex flex-col lg:flex-row lg:gap-[10px]">
-          {initialSituation.vote != null && (
-            <div className="min-w-0 flex-shrink-0 lg:max-w-[60%]">
-              <VoteTab vote={initialSituation.vote} roomAssignedRows={null} />
-            </div>
           )}
-
-          {/* 横並び時は全体メモを投票欄の下端まで伸ばす。py は VoteTab 内の上下パディングと揃える */}
-          <div className="flex min-w-0 flex-1 flex-col py-[10px]">
+          <div className="flex min-w-0 flex-1 flex-col">
             <label className="mb-[4px] block text-village-sm font-bold text-gray-300">
               全体メモ
             </label>
@@ -198,7 +191,7 @@ export function AnalyzerTab({ situation: initialSituation }: { situation: Villag
               value={wholeMemo}
               onChange={(e) => setWholeMemo(e.target.value)}
               rows={10}
-              className={`${textareaClass} lg:flex-1`}
+              className={textareaClass}
               placeholder="村全体のメモ..."
             />
           </div>

--- a/frontend/app/features/village/components/info/SituationPanel.tsx
+++ b/frontend/app/features/village/components/info/SituationPanel.tsx
@@ -7,15 +7,16 @@ import { useVillageContext } from "~/features/village/VillageContext";
 import { AnalyzerTab } from "~/features/village/components/analyzer/AnalyzerTab";
 import { MemberListTab } from "./MemberListTab";
 import { RoomAssignedTab } from "./RoomAssignedTab";
+import { VoteTab } from "./VoteTab";
 
-type TabKey = "room" | "member" | "analyzer";
+type TabKey = "room" | "member" | "vote" | "analyzer";
 
 const STORAGE_KEY = "village_panel_situation";
 const BOTTOM_FIX_KEY = "village_panel_bottom_fix";
 const TAB_STORAGE_KEY = "village_panel_situation_tab";
 
 /**
- * 状況サマリ。部屋割り当て / 参加者 / 推理補助 をタブで切り替える。
+ * 状況サマリ。部屋割り当て / 参加者 / 投票 / 推理補助 をタブで切り替える。
  * 部屋割り当てタブは部屋が割り当てられた 1 日目以降のみ表示する。
  */
 export function SituationPanel({
@@ -30,6 +31,7 @@ export function SituationPanel({
 }) {
   const village = useVillageContext();
   const hasRoomTab = situation.roomWidth != null && day > 0;
+  const hasVoteTab = situation.vote != null;
   const hasAnalyzerTab = !village.status.isPrologue && !village.status.isCanceled;
 
   const bodyId = useId();
@@ -45,6 +47,7 @@ export function SituationPanel({
   const tabs: { key: TabKey; label: string }[] = [
     ...(hasRoomTab ? [{ key: "room" as const, label: "部屋割り当て" }] : []),
     { key: "member", label: "参加者" },
+    ...(hasVoteTab ? [{ key: "vote" as const, label: "投票" }] : []),
     ...(hasAnalyzerTab ? [{ key: "analyzer" as const, label: "推理補助" }] : []),
   ];
 
@@ -113,7 +116,10 @@ export function SituationPanel({
               />
             )}
             {activeTab === "member" && <MemberListTab />}
-            {activeTab === "analyzer" && <AnalyzerTab situation={situation} />}
+            {activeTab === "vote" && situation.vote != null && (
+              <VoteTab vote={situation.vote} roomAssignedRows={situation.roomAssignedRowList} />
+            )}
+            {activeTab === "analyzer" && <AnalyzerTab />}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 目的

推理補助（analyzer）タブに投票マトリクスを統合した結果（PR #123）、「日別タブ + 部屋割グリッド + 足音 + 日次メモ + 投票マトリクス + 全体メモ」でかなり縦長になっていた。投票を独立タブに戻して縦長を解消する。

## 変更内容

- `SituationPanel`: タブ構成を「部屋割り当て / 参加者 / **投票** / 推理補助」に変更。投票タブは旧独立タブ（コミット 25d6c212 で削除）と同じ条件（`situation.vote != null` = 3 日目以降）・同じ props（`roomAssignedRows` を渡し部屋割り凡例つき）で `VoteTab` を表示
- `AnalyzerTab`: 下部の投票セクションを除去。あわせて PC 幅（lg）のレイアウトを「部屋割グリッド | 足音」「日次メモ | 全体メモ（2 カラム）」の 2 行構成に整理（ユーザー指示）。未使用になった `situation` prop を削除
- モバイル幅は従来どおり縦積み（部屋割 → 足音 → 日次メモ → 全体メモ）

## 動作確認

- 終了村（村 114、投票 2d〜5d あり）で実測:
  - タブが「部屋割り当て / 参加者 / 投票 / 推理補助」で表示され、投票タブで部屋割り凡例 + 投票マトリクスが単独表示される（PC / モバイル 390px スクリーンショット確認）
  - 推理補助タブから投票が消え、PC 幅で「部屋割 | 足音」「日次メモ | 全体メモ」の 2 行 2 カラム表示になる（スクリーンショット確認）
  - 投票タブ選択状態でリロード → localStorage（`village_panel_situation_tab`）から投票タブが復元される
  - 投票データのない日（day/1）では投票タブが表示されず、保存タブがデフォルト（部屋割り当て）にフォールバックする
  - モバイル 390px の横はみ出し検査: 検出された要素は固定フッター（`w-screen`）と広告 iframe のみで、いずれも本 PR の変更対象外の既存要素（投票テーブルははみ出さない）
- `pnpm lint` / `pnpm format:check` / `pnpm build` green
- e2e（`village` / `village-vote` / `village-info` spec）: 12 passed / 0 failed / 0 flaky（最終コードで再実行済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGWv3p2HafNyBKGnDWvS2r