### PR TITLE
fix: エピローグ後の足音の内訳を推理補助タブに表示する

### DIFF
--- a/frontend/app/features/village/components/analyzer/AnalyzerTab.tsx
+++ b/frontend/app/features/village/components/analyzer/AnalyzerTab.tsx
@@ -8,6 +8,7 @@ import {
 import type { DayFootstep } from "~/features/village/analyzer/types";
 import { textareaClass } from "~/components/ui/Input";
 import { useMe } from "~/features/auth/useMe";
+import type { VillageSituationView } from "~/features/village/api";
 import { useVillageContext } from "~/features/village/VillageContext";
 import { useAnalyzerMemos } from "~/features/village/analyzer/useAnalyzerMemos";
 import { dayLabel } from "~/features/village/components/info/dayLabel";
@@ -15,7 +16,15 @@ import { AnalyzerFootsteps } from "./AnalyzerFootsteps";
 import { AnalyzerRoomGrid } from "./AnalyzerRoomGrid";
 import { ParticipantMemoModal } from "./ParticipantMemoModal";
 
-export function AnalyzerTab() {
+export function AnalyzerTab({
+  footstepList,
+  showsFootstepSpoiler,
+}: {
+  /** 日別の足音 (サーバ整形済み。エピローグ以降は誰が何の役職でどの足音を出したかの詳細になる) */
+  footstepList: NonNullable<VillageSituationView["footstepList"]>;
+  /** 足音の詳細 (ネタバレ) を表示してよいか */
+  showsFootstepSpoiler: boolean;
+}) {
   const { me } = useMe();
   const village = useVillageContext();
 
@@ -86,6 +95,9 @@ export function AnalyzerTab() {
   );
 
   const currentDailyMemo = dailyMemos.find((m) => m.day === activeDay)?.memo ?? "";
+
+  // 足音がない日はサーバが空文字を返すため非表示に落とす
+  const currentDayFootstepDetail = footstepList.find((f) => f.day === activeDay)?.footstep || null;
 
   const openMemoParticipant = useMemo(
     () =>
@@ -161,6 +173,13 @@ export function AnalyzerTab() {
           {/* Footstep analysis */}
           <div className="min-w-0 flex-1">
             <AnalyzerFootsteps footsteps={currentDayFootsteps} onChange={onFootstepsChange} />
+            {/* エピローグ前の footstepList は鳴った部屋番号のみで上の分析表と重複するため、詳細が公開されてからのみ表示する */}
+            {showsFootstepSpoiler && currentDayFootstepDetail != null && (
+              <div className="mt-[10px]">
+                <p className="mb-[4px] text-village-sm font-bold text-gray-300">足音の内訳</p>
+                <p className="text-village-sm whitespace-pre-line">{currentDayFootstepDetail}</p>
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/frontend/app/features/village/components/info/SituationPanel.tsx
+++ b/frontend/app/features/village/components/info/SituationPanel.tsx
@@ -119,7 +119,12 @@ export function SituationPanel({
             {activeTab === "vote" && situation.vote != null && (
               <VoteTab vote={situation.vote} roomAssignedRows={situation.roomAssignedRowList} />
             )}
-            {activeTab === "analyzer" && <AnalyzerTab />}
+            {activeTab === "analyzer" && (
+              <AnalyzerTab
+                footstepList={situation.footstepList ?? []}
+                showsFootstepSpoiler={(situation.isViewableSpoilerContent ?? false) && !spoiled}
+              />
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 目的

旧・状況パネルの足音タブはエピローグ以降「誰が何の能力でどの足音を鳴らしたか」のネタバレ情報を表示していたが、足音タブ削除（25d6c212）以降この情報を見る場所が失われていた。backend は今も `GET /api/v1/villages/{id}/situation` の `footstepList` にビューアごとに整形した文字列（エピローグ以降は `[略称][役職名] 出そうとした足音 → 実際の足音` 形式、`FootstepDomainService.convertToSituation`）を返しているが、frontend がどこからも参照していなかった。

配置はユーザー決定済み: 足音タブは復活させず、推理補助タブに表示する。

## 変更内容

- `SituationPanel`: `AnalyzerTab` に `footstepList` と `showsFootstepSpoiler`（`isViewableSpoilerContent && !spoiled`。`RoomAssignedTab` と同じ判定）を渡す
- `AnalyzerTab`: 足音分析表の直下に、選択中の日の「足音の内訳」を表示（改行保持）。エピローグ前の `footstepList` は鳴った部屋番号のみの簡略版で分析表と重複するため、`showsFootstepSpoiler` が true の場合のみ表示。足音がない日はサーバが空文字を返すため非表示

## 動作確認

- エピローグ後（終了村 114・2日目）: 足音分析表の下に「足音の内訳」として `[07当][賢者] 06 → 06`（改行区切りで複数行）が表示される（スクリーンショット確認）
- 発言抽出の「エピローグ前同等の表示にする」（`spl=true`）適用時: 非表示になる
- 進行中の村（村 124・2日目）の生存参加者視点（ダミーログイン）: 非表示。匿名視点の API も `isViewableSpoilerContent=false` + 簡略文字列であることを確認
- 足音のない日（サーバが空文字を返す日）: 非表示
- `pnpm lint` / `pnpm format:check` / `pnpm build` green
- e2e（`village` / `village-info` spec）: passed / failed 0（`.last-run.json` で確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGWv3p2HafNyBKGnDWvS2r